### PR TITLE
Fix modal layout: consistent 2-column grid for all sections

### DIFF
--- a/src/components/MemberDetailModal.jsx
+++ b/src/components/MemberDetailModal.jsx
@@ -322,7 +322,7 @@ function MemberDetailModal({ member, isOpen, onClose }) {
                   </Card.Title>
                 </Card.Header>
                 <Card.Body className="space-y-3">
-                  <div className="grid grid-cols-1 gap-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     {Object.entries(groupData).map(([fieldKey, fieldValue]) => (
                       <div key={fieldKey}>
                         <label className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Summary
- Fix layout inconsistency in MemberDetailModal where Basic Information used 2-column grid but contact groups used single column
- Update contact groups to use responsive 2-column layout consistent with Basic Information section
- Reduces modal height and improves space utilization

## Changes Made
- Modified contact groups grid layout from `grid-cols-1` to `grid-cols-1 sm:grid-cols-2`
- Maintains responsive behavior (single column on mobile, 2 columns on desktop)
- No functional changes, only layout optimization

## Test Plan
- ✅ All unit tests pass (26/26)
- ✅ Linting passes with no errors
- ✅ Build succeeds without warnings
- ✅ Manual testing: Modal displays consistently across sections
- ✅ Responsive behavior maintained on mobile and desktop

## Before/After
**Before:** Contact groups displayed in single column making modal unnecessarily tall
**After:** Contact groups display in 2-column layout on desktop, consistent with Basic Information section

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of contact information in the member detail modal for better organization and readability on wider screens, displaying fields in two columns on small devices and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->