### PR TITLE
Security: Remove hardcoded Sentry token

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -2,8 +2,8 @@
 org=walton-vikings
 project=viking-event-mgmt
 
-[auth]
-token='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'
+# Auth token now provided via SENTRY_AUTH_TOKEN environment variable
+# See GitHub repository secrets for secure token management
 
 # Optional - specify your Sentry URL if using self-hosted
 # url=https://de.sentry.io


### PR DESCRIPTION
## Summary
Remove hardcoded Sentry authentication token from version control and use secure GitHub secrets environment variable approach.

## Security Issue
The .sentryclirc file contained a hardcoded Sentry auth token, which is a security risk when committed to version control.

## Solution
- Removed hardcoded token from .sentryclirc file
- Using SENTRY_AUTH_TOKEN environment variable from GitHub secrets
- Maintained existing GitHub workflow functionality

## Verification
- GitHub workflow already uses secrets.SENTRY_AUTH_TOKEN
- No functional changes to release process
- Secure token management implemented
- Follows security best practices

## Impact
- Before: Token exposed in version control and public repository
- After: Token securely managed through GitHub repository secrets
- Risk Reduction: Prevents unauthorized access to Sentry organization