### PR TITLE
feat: implement environment-aware versioning for Sentry tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,81 +159,86 @@ jobs:
           name: build-files
           path: dist/
 
-      - name: 📝 Auto-bump version for Sentry tracking
+      - name: 📝 Set environment-aware version for Sentry tracking
         run: |
-          echo "🔢 Determining version bump type for proper Sentry error attribution..."
+          echo "🔢 Setting version based on deployment environment..."
           
-          # Configure git for automated commits
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          
-          # Analyze commit messages and PR title to determine version bump type
-          RECENT_COMMITS=$(git log --oneline -10 --pretty=format:"%s")
-          PR_TITLE="${{ github.event.head_commit.message }}"
-          
-          echo "Recent commits:"
-          echo "$RECENT_COMMITS"
-          echo ""
-          echo "PR Title: $PR_TITLE"
-          echo ""
-          
-          # Determine version bump type based on commit messages
-          VERSION_TYPE="patch"  # Default to patch
-          
-          # Check for feature indicators (case insensitive)
-          if echo "$RECENT_COMMITS $PR_TITLE" | grep -iE "(feat|feature|add|implement|new)" > /dev/null; then
-            VERSION_TYPE="minor"
-            echo "🚀 Detected FEATURE: Using minor version bump"
-          elif echo "$RECENT_COMMITS $PR_TITLE" | grep -iE "(break|breaking|major)" > /dev/null; then
-            VERSION_TYPE="major"
-            echo "💥 Detected BREAKING CHANGE: Using major version bump"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Preview deployment - use PR-specific version
+            BASE_VERSION=$(node -p "require('./package.json').version")
+            NEW_VERSION="${BASE_VERSION}-pr-${{ github.event.number }}"
+            DEPLOYMENT_TYPE="preview"
+            echo "🔍 Preview deployment detected"
+            echo "Base version: $BASE_VERSION"
+            echo "Preview version: $NEW_VERSION"
           else
-            echo "🐛 Detected BUG FIX/MAINTENANCE: Using patch version bump"
+            # Production deployment (main branch) - bump version properly
+            echo "🚀 Production deployment detected"
+            
+            # Configure git for automated commits (only for production)
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            
+            # Analyze commit messages to determine version bump type
+            RECENT_COMMITS=$(git log --oneline -10 --pretty=format:"%s")
+            PR_TITLE="${{ github.event.head_commit.message }}"
+            
+            echo "Recent commits:"
+            echo "$RECENT_COMMITS"
+            echo ""
+            echo "PR Title: $PR_TITLE"
+            echo ""
+            
+            # Determine version bump type based on commit messages
+            VERSION_TYPE="patch"  # Default to patch
+            
+            # Check for feature indicators (case insensitive)
+            if echo "$RECENT_COMMITS $PR_TITLE" | grep -iE "(feat|feature|add|implement|new)" > /dev/null; then
+              VERSION_TYPE="minor"
+              echo "🚀 Detected FEATURE: Using minor version bump"
+            elif echo "$RECENT_COMMITS $PR_TITLE" | grep -iE "(break|breaking|major)" > /dev/null; then
+              VERSION_TYPE="major"
+              echo "💥 Detected BREAKING CHANGE: Using major version bump"
+            else
+              echo "🐛 Detected BUG FIX/MAINTENANCE: Using patch version bump"
+            fi
+            
+            echo "Version bump type: $VERSION_TYPE"
+            
+            # Bump version based on detected type
+            npm version $VERSION_TYPE --no-git-tag-version
+            NEW_VERSION=$(node -p "require('./package.json').version")
+            DEPLOYMENT_TYPE="production"
+            echo "Production version: $NEW_VERSION"
           fi
           
-          echo "Version bump type: $VERSION_TYPE"
+          # Export version and deployment type for subsequent steps
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "DEPLOYMENT_TYPE=$DEPLOYMENT_TYPE" >> $GITHUB_ENV
+          echo "✅ Version set: $NEW_VERSION (${DEPLOYMENT_TYPE})"
           
-          # Bump version based on detected type
-          npm version $VERSION_TYPE --no-git-tag-version
-          
-          # Get the new version for commit message
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "New version: $NEW_VERSION"
-          
-          # Commit the version bump with context
-          git add package.json package-lock.json
-          git commit -m "chore: bump $VERSION_TYPE version to v${NEW_VERSION} for deployment
-          
-          Auto-bumped for Sentry error attribution ($VERSION_TYPE version)
-          - Every deployment needs unique version for proper error tracking
-          - Enables verification of bug fixes and attribution of new issues
-          - Version type determined from commit analysis: $VERSION_TYPE
-          
-          🤖 Generated with [Claude Code](https://claude.ai/code)
-          
-          Co-Authored-By: Claude <noreply@anthropic.com>"
-          
-          # Push the version bump back to main
-          git push origin main
-          
-          # Create tag or release based on version type
-          if [ "$VERSION_TYPE" = "patch" ]; then
-            # Patch versions: Just create tag for Sentry tracking
-            git tag "v${NEW_VERSION}"
-            git push origin "v${NEW_VERSION}"
-            echo "✅ Version bumped to v${NEW_VERSION} and tagged (patch)"
+          # Create tags and releases only for production deployments
+          if [ "$DEPLOYMENT_TYPE" = "production" ]; then
+            if [ "$VERSION_TYPE" = "patch" ]; then
+              # Patch versions: Just create tag for Sentry tracking
+              git tag "v${NEW_VERSION}"
+              git push origin "v${NEW_VERSION}"
+              echo "✅ Production version tagged: v${NEW_VERSION} (patch)"
+            else
+              # Minor/Major versions: Create GitHub Release
+              git tag "v${NEW_VERSION}"
+              git push origin "v${NEW_VERSION}"
+              
+              # Create GitHub Release for features/breaking changes  
+              gh release create "v${NEW_VERSION}" \
+                --title "Release v${NEW_VERSION}" \
+                --notes "Auto-generated $VERSION_TYPE release v${NEW_VERSION}. This release was created automatically based on commit analysis. Changes: $VERSION_TYPE version bump based on detected changes. Sentry Tracking: Version v${NEW_VERSION}, Type $VERSION_TYPE. All errors will be attributed to this release. Generated with Claude Code." \
+                --latest
+              
+              echo "✅ Production version released: v${NEW_VERSION} (${VERSION_TYPE})"
+            fi
           else
-            # Minor/Major versions: Create GitHub Release
-            git tag "v${NEW_VERSION}"
-            git push origin "v${NEW_VERSION}"
-            
-            # Create GitHub Release for features/breaking changes  
-            gh release create "v${NEW_VERSION}" \
-              --title "Release v${NEW_VERSION}" \
-              --notes "Auto-generated $VERSION_TYPE release v${NEW_VERSION}. This release was created automatically based on commit analysis. Changes: $VERSION_TYPE version bump based on detected changes. Sentry Tracking: Version v${NEW_VERSION}, Type $VERSION_TYPE. All errors will be attributed to this release. Generated with Claude Code." \
-              --latest
-            
-            echo "✅ Version bumped to v${NEW_VERSION} and GitHub Release created ($VERSION_TYPE)"
+            echo "🔍 Preview deployment - no tags or releases created"
           fi
 
       - name: 📤 Create Sentry release for error tracking
@@ -242,14 +247,15 @@ jobs:
           SENTRY_ORG: walton-vikings
           SENTRY_PROJECT: viking-event-mgmt
         run: |
-          # Get the version that was just bumped
-          VERSION=$(node -p "require('./package.json').version")
-          RELEASE="vikings-eventmgmt-mobile@$VERSION"
+          # Use the environment-aware version set in previous step
+          RELEASE="vikings-eventmgmt-mobile@$NEW_VERSION"
+          ENVIRONMENT="$DEPLOYMENT_TYPE"
           
           echo "📊 Creating Sentry release: $RELEASE"
+          echo "🌍 Environment: $ENVIRONMENT"
           
           if [ -n "$SENTRY_AUTH_TOKEN" ]; then
-            # Create Sentry release
+            # Create Sentry release with environment
             npx @sentry/cli releases new "$RELEASE" || echo "Release may already exist"
             
             # Upload source maps if they exist
@@ -263,7 +269,10 @@ jobs:
             npx @sentry/cli releases set-commits "$RELEASE" --auto
             npx @sentry/cli releases finalize "$RELEASE"
             
-            echo "✅ Sentry release $RELEASE created and finalized"
+            # Mark deployment in the appropriate environment
+            npx @sentry/cli releases deploys "$RELEASE" new -e "$ENVIRONMENT"
+            
+            echo "✅ Sentry release $RELEASE created for $ENVIRONMENT environment"
           else
             echo "⚠️ SENTRY_AUTH_TOKEN not configured, skipping Sentry release"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [unit-tests, build]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Run for PRs targeting main (preview) and pushes to main (production)
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     permissions:
       contents: write
     steps:
@@ -278,6 +279,7 @@ jobs:
           fi
 
       - name: Deploy to production
+        if: env.DEPLOYMENT_TYPE == 'production'
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
         run: |


### PR DESCRIPTION
## Summary
- Implement preview deployment versioning using `BASE_VERSION-pr-NUMBER` format
- Add production deployment with proper semantic version bumping  
- Set appropriate Sentry environments (preview vs production)
- Create tags/releases only for production deployments
- Prevent Sentry version confusion between preview and production

## Problem Solved
Previously, preview deployments from PRs would show future version numbers in production Sentry monitoring (e.g., v1.2.0 preview showing in production dashboard). This made it impossible to distinguish between actual production releases and preview deployments.

## Solution Details
**Preview Deployments (PRs):**
- Version format: `1.1.0-pr-75` (clearly marked as preview)
- Sentry environment: `preview`
- No Git tags or releases created
- Easy to identify in Sentry dashboard

**Production Deployments (main branch):**
- Proper semantic versioning based on commit analysis
- Sentry environment: `production` 
- Git tags and GitHub releases created
- Clear separation from preview versions

## Technical Implementation
- **Environment Detection**: Checks `github.event_name` to distinguish PR vs main branch
- **Version Strategy**: PR-specific versioning vs semantic version bumping
- **Sentry Integration**: Environment-aware release creation with proper source maps
- **Release Management**: Tags and releases only for production

## Test Plan
- [x] YAML syntax validation passes locally
- [x] All unit tests pass (`npm run test:run`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Verify preview deployment shows correct version format in Sentry
- [ ] Verify production deployment creates proper tags and releases
- [ ] Confirm environment separation in Sentry dashboard

## Addresses
- GitHub issue #62 (deployment automation)
- Sentry version confusion between preview and production
- Branch protection compatibility for automated version management

🤖 Generated with [Claude Code](https://claude.ai/code)