### PR TITLE
Add Viking Section Movers FlexiRecord validation with notifications

### DIFF
--- a/src/components/sectionMovements/SectionMovementTracker.jsx
+++ b/src/components/sectionMovements/SectionMovementTracker.jsx
@@ -11,7 +11,7 @@ import { safeGetItem } from '../../utils/storageUtils.js';
 
 function SectionMovementTracker({ onBack }) {
   const [numberOfTerms, setNumberOfTerms] = useState(2);
-  const { members, sections, loading, error, refetch } = useSectionMovements();
+  const { members, sections, loading, error, refetch, flexiRecordState } = useSectionMovements();
   const { notifyError } = useNotification();
   const hasCheckedFlexiRecords = useRef(false);
   
@@ -67,13 +67,13 @@ function SectionMovementTracker({ onBack }) {
     }
   }, [notifyError]);
 
-  // Check for missing FlexiRecords when sections load (only once per session)
+  // Check for missing FlexiRecords when sections load and FlexiRecord discovery completes (only once per session)
   useEffect(() => {
-    if (sections && sections.length > 0 && !hasCheckedFlexiRecords.current) {
+    if (sections && sections.length > 0 && !hasCheckedFlexiRecords.current && flexiRecordState.loading === false) {
       checkForMissingFlexiRecords(sections);
       hasCheckedFlexiRecords.current = true;
     }
-  }, [sections, checkForMissingFlexiRecords]);
+  }, [sections, checkForMissingFlexiRecords, flexiRecordState.loading]);
 
   // Reset the check flag when component unmounts
   useEffect(() => {

--- a/src/components/sectionMovements/SectionMovementTracker.jsx
+++ b/src/components/sectionMovements/SectionMovementTracker.jsx
@@ -35,7 +35,12 @@ function SectionMovementTracker({ onBack }) {
         return; // Skip these sections
       }
 
-      // Check if FlexiRecord list exists in cache for this section
+      // Check if this section is already loaded (has FlexiRecord data)
+      if (flexiRecordState.loadedSections && flexiRecordState.loadedSections.has(sectionId)) {
+        return; // Section has FlexiRecord loaded, treat as present
+      }
+
+      // Fallback: Check if FlexiRecord list exists in cache for this section
       const cacheKey = `viking_flexi_lists_${sectionId}_offline`;
       const flexiRecordsList = safeGetItem(cacheKey, null);
       
@@ -65,7 +70,7 @@ function SectionMovementTracker({ onBack }) {
         `and optional fields: ${optionalFields.join(', ')}.`;
       notifyError(message);
     }
-  }, [notifyError]);
+  }, [notifyError, flexiRecordState.loadedSections]);
 
   // Check for missing FlexiRecords when sections load and FlexiRecord discovery completes (only once per session)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add validation for missing Viking Section Movers FlexiRecords when Section Movers page loads
- Show toast notification with specific section names that need FlexiRecord setup
- Filter out adults and waitinglist sections from validation
- Prevent duplicate notifications using ref-based tracking
- Include required and optional field names in notification message

## Changes
- Enhanced SectionMovementTracker component with FlexiRecord validation
- Added cache-based detection of missing Viking Section Movers FlexiRecords  
- Integrated with existing notification system for user feedback
- One-time check on page load to avoid notification loops

## Test plan
- [x] Build passes without errors
- [x] ESLint passes with no new warnings
- [x] Component loads without breaking existing functionality
- [ ] Test with sections missing Viking Section Movers FlexiRecord
- [ ] Verify notification shows correct section names and field requirements
- [ ] Confirm adults/waitinglist sections are properly filtered out

🤖 Generated with [Claude Code](https://claude.ai/code)