### PR TITLE
fix: remove OAuth client ID from frontend for security

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -3,9 +3,9 @@
 
 // Required environment variables for basic functionality
 // Skip validation in demo mode to allow public access
+// OAuth client ID removed - now handled server-side for security
 const requiredVars = [
   'VITE_API_URL',
-  'VITE_OAUTH_CLIENT_ID',
 ];
 
 // Helper function to check demo mode safely
@@ -66,7 +66,6 @@ if (apiUrl && !apiUrl.match(/^https?:\/\/.+/)) {
 export const config = {
   // API Configuration
   apiUrl: import.meta.env.VITE_API_URL,
-  oauthClientId: import.meta.env.VITE_OAUTH_CLIENT_ID,
   
   // Optional Configuration
   sentryDsn: import.meta.env.VITE_SENTRY_DSN,
@@ -109,7 +108,7 @@ export const config = {
 if (config.actualEnvironment === 'development') {
   console.log('🔧 Environment Configuration:');
   console.log('   API URL:', config.apiUrl);
-  console.log('   OAuth Client ID:', config.oauthClientId ? '***configured***' : '❌ missing');
+  console.log('   OAuth Client ID:', '***handled by backend***');
   console.log('   Sentry DSN:', config.sentryDsn ? '***configured***' : 'not configured');
   console.log('   Environment:', config.actualEnvironment);
   console.log('   Vite Mode:', config.mode);


### PR DESCRIPTION
- Remove VITE_OAUTH_CLIENT_ID from required environment variables
- Update generateOAuthUrl() to redirect to backend /oauth/login endpoint
- Remove client ID validation and client ID from config export
- OAuth client ID now handled server-side for enhanced security
- Prevents OAuth client credentials from being exposed in frontend JavaScript
- Frontend now delegates OAuth URL construction to backend

🤖 Generated with [Claude Code](https://claude.ai/code)