### PR TITLE
feat: enhance movement tracker UI and cascading calculations

### DIFF
--- a/src/features/movements/components/MovementSummaryTable.jsx
+++ b/src/features/movements/components/MovementSummaryTable.jsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { groupSectionsByType } from '../../../shared/utils/sectionMovements/sectionGrouping.js';
+
+function getSectionTypeFromName(sectionName) {
+  if (!sectionName) return null;
+  
+  const normalized = sectionName.toLowerCase();
+  
+  if (normalized.includes('squirrel')) return 'Squirrels';
+  if (normalized.includes('beaver')) return 'Beavers';
+  if (normalized.includes('cub')) return 'Cubs';
+  if (normalized.includes('scout') && !normalized.includes('cub')) return 'Scouts';
+  if (normalized.includes('explorer')) return 'Explorers';
+  
+  return null;
+}
+
+function MovementSummaryTable({ termCalculations, assignments, sectionsData }) {
+  
+  if (!termCalculations || termCalculations.length === 0) {
+    return null;
+  }
+
+  const allSectionTypes = ['Squirrels', 'Beavers', 'Cubs', 'Scouts', 'Explorers'];
+  
+  // Calculate section type totals across all terms to handle cascading
+  const sectionTypeTotals = new Map();
+  
+  // Initialize starting counts for first term
+  termCalculations.forEach((termData, termIndex) => {
+    const groupedSections = groupSectionsByType(termData.sectionSummaries, sectionsData || []);
+    
+    allSectionTypes.forEach(sectionType => {
+      const group = groupedSections.get(sectionType);
+      if (!group) return;
+      
+      let startingCount;
+      if (termIndex === 0) {
+        // First term: use actual current members count
+        startingCount = group.sections.reduce((total, section) => {
+          return total + (section.cumulativeCurrentCount || section.currentMembers.length);
+        }, 0);
+      } else {
+        // Subsequent terms: use planned count from previous term
+        const prevTermKey = `${sectionType}-${termIndex - 1}`;
+        startingCount = sectionTypeTotals.get(prevTermKey)?.plannedCount || 0;
+      }
+      
+      const incomingCount = termData.movers.filter(mover => {
+        const targetSectionType = mover.targetSection?.toLowerCase();
+        return targetSectionType === sectionType.toLowerCase();
+      }).length;
+      
+      const outgoingCount = group.totalOutgoing;
+      const plannedCount = startingCount + incomingCount - outgoingCount;
+      
+      // Store the calculated totals for this term
+      const termKey = `${sectionType}-${termIndex}`;
+      sectionTypeTotals.set(termKey, {
+        startingCount,
+        incomingCount,
+        outgoingCount,
+        plannedCount,
+      });
+    });
+  });
+
+  return (
+    <div className="mb-6">
+      <div className="bg-gray-100 p-3 rounded-t-lg border-b">
+        <h2 className="text-lg font-semibold text-gray-800">
+          Movement Summary by Term
+        </h2>
+      </div>
+      
+      <div className="bg-white rounded-b-lg border border-t-0 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 border-b">
+            <tr>
+              <th className="text-left py-3 px-4 font-medium text-gray-900">
+                Section
+              </th>
+              {termCalculations.map(termData => (
+                <th key={`${termData.term.type}-${termData.term.year}`} className="text-center py-3 px-4 font-medium text-gray-900 min-w-40">
+                  {termData.term.displayName || `${termData.term.type} ${termData.term.year}`}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {allSectionTypes.map(sectionType => {
+              // Check if this section type has any data across terms
+              const hasData = termCalculations.some((termData) => {
+                const groupedSections = groupSectionsByType(termData.sectionSummaries, sectionsData || []);
+                return groupedSections.has(sectionType);
+              });
+              
+              if (!hasData) return null;
+              
+              return (
+                <React.Fragment key={sectionType}>
+                  {/* Section Type Header Row */}
+                  <tr className="border-b bg-blue-50">
+                    <td className="py-3 px-4 font-semibold text-gray-900">
+                      {sectionType}
+                    </td>
+                    {termCalculations.map((termData, termIndex) => {
+                      const termKey = `${sectionType}-${termIndex}`;
+                      const totals = sectionTypeTotals.get(termKey);
+                      
+                      if (!totals) {
+                        return (
+                          <td key={termIndex} className="py-3 px-4 text-center text-gray-500">
+                            -
+                          </td>
+                        );
+                      }
+                      
+                      const { startingCount, incomingCount, outgoingCount, plannedCount } = totals;
+                      
+                      return (
+                        <td key={termIndex} className="py-2 px-4 text-center">
+                          <div className="text-xs flex items-center justify-center space-x-1">
+                            <span className="text-gray-700">Current: {startingCount}</span>
+                            <span className={incomingCount > 0 ? 'text-green-600' : 'text-gray-400'}>↑{incomingCount}</span>
+                            <span className={outgoingCount > 0 ? 'text-orange-600' : 'text-gray-400'}>↓{outgoingCount}</span>
+                            <span className="font-medium text-blue-700">Planned: {plannedCount}</span>
+                          </div>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                  
+                  {/* Individual Section Rows */}
+                  {(() => {
+                    const firstTermGrouped = groupSectionsByType(termCalculations[0]?.sectionSummaries, sectionsData || []);
+                    const firstTermGroup = firstTermGrouped.get(sectionType);
+                    if (!firstTermGroup) return null;
+                    
+                    const rows = [];
+                    
+                    // Add individual section rows
+                    firstTermGroup.sections.forEach(section => {
+                      rows.push(
+                        <tr key={`${section.sectionId}`} className="border-b">
+                          <td className="py-2 px-4 pl-8 text-gray-700">
+                            {section.sectionName}
+                          </td>
+                          {termCalculations.map((termData, termIndex) => {
+                            const sectionSummary = termData.sectionSummaries.get(section.sectionId);
+                              
+                            if (!sectionSummary) {
+                              return (
+                                <td key={termIndex} className="py-2 px-4 text-center text-gray-500">
+                                    -
+                                </td>
+                              );
+                            }
+                              
+                            const currentCount = sectionSummary.cumulativeCurrentCount || sectionSummary.currentMembers.length;
+                            const outgoingCount = sectionSummary.outgoingMovers.length;
+                              
+                            // Get assignments for this specific section from this term's movers
+                            const sectionAssignments = assignments ? termData.movers.filter(mover => {
+                              const assignment = assignments.get(mover.memberId);
+                              return assignment && String(assignment.sectionId) === String(section.sectionId);
+                            }).length : 0;
+                              
+                            const plannedCount = currentCount + sectionAssignments - outgoingCount;
+                              
+                            return (
+                              <td key={termIndex} className="py-2 px-4 text-center">
+                                <div className="text-xs flex items-center justify-center space-x-1">
+                                  <span className="text-gray-600">Current: {currentCount}</span>
+                                  <span className={sectionAssignments > 0 ? 'text-green-500' : 'text-gray-400'}>↑{sectionAssignments}</span>
+                                  <span className={outgoingCount > 0 ? 'text-orange-500' : 'text-gray-400'}>↓{outgoingCount}</span>
+                                  <span className="font-medium text-gray-800">Planned: {plannedCount}</span>
+                                </div>
+                              </td>
+                            );
+                          })}
+                        </tr>,
+                      );
+                    });
+                      
+                    // Add unassigned row for this section type
+                    rows.push(
+                      <tr key={`unassigned-${sectionType}`} className="border-b bg-amber-50">
+                        <td className="py-2 px-4 pl-8 text-amber-800 italic">
+                            Unassigned
+                        </td>
+                        {termCalculations.map((termData, termIndex) => {
+                          // Calculate unassigned movers for this section type
+                          const incomingMovers = termData.movers.filter(mover => {
+                            const targetSectionType = mover.targetSection?.toLowerCase();
+                            return targetSectionType === sectionType.toLowerCase();
+                          });
+                            
+                          // Count how many are assigned to specific sections of this type from this term's movers
+                          const assignedCount = assignments ? incomingMovers.filter(mover => {
+                            const assignment = assignments.get(mover.memberId);
+                            if (!assignment) return false;
+                              
+                            // Check if the assignment is for a section of this type
+                            const assignedSection = sectionsData?.find(s => 
+                              String(s.sectionId || s.sectionid) === String(assignment.sectionId),
+                            );
+                            if (!assignedSection) return false;
+                              
+                            // Get the section type from the assigned section
+                            const assignedSectionName = assignedSection.sectionname || assignedSection.name || '';
+                            const assignedSectionType = getSectionTypeFromName(assignedSectionName);
+                            return assignedSectionType?.toLowerCase() === sectionType.toLowerCase();
+                          }).length : 0;
+                            
+                          const unassignedCount = Math.max(0, incomingMovers.length - assignedCount);
+                            
+                          return (
+                            <td key={termIndex} className="py-2 px-4 text-center">
+                              <div className="text-xs flex items-center justify-center">
+                                {unassignedCount > 0 ? (
+                                  <span className="text-amber-600">↑{unassignedCount} incoming</span>
+                                ) : (
+                                  <span className="text-gray-400">-</span>
+                                )}
+                              </div>
+                            </td>
+                          );
+                        })}
+                      </tr>,
+                    );
+                      
+                    return rows;
+                  })()}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+MovementSummaryTable.propTypes = {
+  termCalculations: PropTypes.arrayOf(PropTypes.object).isRequired,
+  assignments: PropTypes.instanceOf(Map),
+  sectionsData: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default MovementSummaryTable;

--- a/src/features/movements/components/SectionTypeGroup.jsx
+++ b/src/features/movements/components/SectionTypeGroup.jsx
@@ -27,6 +27,7 @@ function SectionTypeGroup({
   availableTerms = [],
   assignments = new Map(),
   currentTerm,
+  sectionTypeTotals,
   onAssignmentChange,
   onTermOverrideChange,
   onSaveAssignments,
@@ -51,26 +52,42 @@ function SectionTypeGroup({
     assignments.has(mover.memberId),
   );
 
+  // Use passed section type totals or fallback to calculation
+  const sectionTotals = sectionTypeTotals?.get(sectionType);
+  const startingCount = sectionTotals?.startingCount || group.sections.reduce((total, section) => {
+    return total + (section.cumulativeCurrentCount || section.currentMembers.length);
+  }, 0);
+  const incomingCount = sectionTotals?.incomingCount || incomingMovers.length;
+  const outgoingCount = sectionTotals?.outgoingCount || group.totalOutgoing;
+  const plannedCount = sectionTotals?.plannedCount || (startingCount + incomingCount - outgoingCount);
 
   return (
     <div className="mb-6">
-      <div className="bg-gray-100 p-3 rounded-t-lg border-b">
+      <div className="bg-white p-3 rounded-t-lg border-b">
         <div className="flex items-center justify-between">
           <div>
             <h3 className="text-lg font-semibold text-gray-800">
               {sectionType}
             </h3>
             <div className="text-sm text-gray-600 mt-1">
-              {incomingMovers.length > 0 && (
-                <span className="mr-4">
-                  ↑ {incomingMovers.length} incoming
-                </span>
-              )}
-              {group.totalOutgoing > 0 && (
+              <div className="flex flex-wrap gap-4">
                 <span>
-                  ↓ {group.totalOutgoing} moving up
+                  Starting: {startingCount}
                 </span>
-              )}
+                {incomingCount > 0 && (
+                  <span>
+                    ↑ {incomingCount} incoming
+                  </span>
+                )}
+                {outgoingCount > 0 && (
+                  <span>
+                    ↓ {outgoingCount} moving up
+                  </span>
+                )}
+                <span className="font-medium">
+                  Planned: {plannedCount}
+                </span>
+              </div>
             </div>
           </div>
           
@@ -98,8 +115,8 @@ function SectionTypeGroup({
       </div>
       
       <div className="bg-white rounded-b-lg border border-t-0 p-4">
-        {/* Section cards grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-4">
+        {/* Section cards grid including the assignment interface card */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 mb-4">
           {group.sections.map(summary => {
             const sectionData = allSections.find(s => s.sectionId === summary.sectionId);
             const incomingCount = sectionData?.incomingCount || 0;
@@ -114,44 +131,44 @@ function SectionTypeGroup({
               />
             );
           })}
-        </div>
-        
-        {/* Assignment interface - separate from grid to allow natural sizing */}
-        {showAssignmentInterface && incomingMovers.length > 0 && (
-          <div className="bg-amber-50 rounded-lg border border-amber-200 p-4 w-fit max-w-4xl">
-            <div className="flex items-center justify-between mb-3">
-              <h4 className="font-medium text-amber-900">
-                Moving to {sectionType}
-              </h4>
-              <div className="text-sm text-amber-700">
-                {incomingMovers.filter(m => assignments.has(m.memberId)).length}/{incomingMovers.length} assigned
+          
+          {/* Assignment interface card - dynamic width to fit content */}
+          {showAssignmentInterface && incomingMovers.length > 0 && (
+            <div className="bg-amber-50 rounded-lg border border-amber-200 p-4 w-fit min-w-[400px]">
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="font-medium text-amber-900">
+                  Moving to {sectionType}
+                </h4>
+                <div className="text-sm text-amber-700">
+                  {incomingMovers.filter(m => assignments.has(m.memberId)).length}/{incomingMovers.length} assigned
+                </div>
+              </div>
+              
+              <div className="space-y-2 max-h-48 overflow-y-auto">
+                {incomingMovers.map(mover => (
+                  <MoverAssignmentRow
+                    key={mover.memberId}
+                    mover={{
+                      ...mover,
+                      assignedSectionId: assignments.get(mover.memberId)?.sectionId || null,
+                      assignedTerm: assignments.get(mover.memberId)?.term || mover.flexiRecordTerm || `${currentTerm?.type}-${currentTerm?.year}`,
+                    }}
+                    availableSections={availableSectionsForType}
+                    availableTerms={availableTerms}
+                    onAssignmentChange={onAssignmentChange}
+                    onTermOverrideChange={onTermOverrideChange}
+                  />
+                ))}
+                
+                {incomingMovers.length === 0 && (
+                  <div className="text-center py-4 text-amber-600">
+                    No movers to {sectionType} this term
+                  </div>
+                )}
               </div>
             </div>
-            
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              {incomingMovers.map(mover => (
-                <MoverAssignmentRow
-                  key={mover.memberId}
-                  mover={{
-                    ...mover,
-                    assignedSectionId: assignments.get(mover.memberId)?.sectionId || null,
-                    assignedTerm: assignments.get(mover.memberId)?.term || mover.flexiRecordTerm || `${currentTerm?.type}-${currentTerm?.year}`,
-                  }}
-                  availableSections={availableSectionsForType}
-                  availableTerms={availableTerms}
-                  onAssignmentChange={onAssignmentChange}
-                  onTermOverrideChange={onTermOverrideChange}
-                />
-              ))}
-              
-              {incomingMovers.length === 0 && (
-                <div className="text-center py-4 text-amber-600">
-                  No movers to {sectionType} this term
-                </div>
-              )}
-            </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Fix cascading calculation bug where manual FlexiRecord assignments weren't carrying forward to next term's starting counts
- Improve UI layout and styling for better user experience with term assignment dropdowns
- Add persistent user preferences system for UI settings

## Key Changes
- **Fixed cascading calculation**: Manual assignments from Spring 2026 now properly become Summer 2026's starting counts
- **Improved assignment card layout**: Yellow "Moving to..." card now dynamically sizes to fit term dropdowns
- **Enhanced card styling**: Term cards have grey headers, section type cards have white headers for better visual hierarchy
- **Removed blue accent**: Cleaned up term card styling by removing blue left border
- **Standardized card styling**: MovementSummaryTable now uses consistent card styling with other components
- **User preferences**: Added localStorage-based system for 'Future Terms to Show' setting that survives logout/clear

## Technical Details
- Modified `SectionMovementTracker.jsx` to include manual assignments in projected count calculations
- Updated `SectionTypeGroup.jsx` to make assignment card dynamically sized (`w-fit min-w-[400px]`)
- Refactored `TermMovementCard.jsx` to use standard grey header styling
- Created new `MovementSummaryTable.jsx` component with proper card structure
- Added user preferences utilities using localStorage with error handling

## Test Results
- ✅ All tests pass (`npm run test:run`)
- ✅ No linting errors (`npm run lint`) 
- ✅ Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.ai/code)