### PR TITLE
fix: show all page terms in movers assignment dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-eventmgmt-mobile",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-eventmgmt-mobile",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "dependencies": {
         "@capacitor-community/sqlite": "^7.0.0",
         "@capacitor/cli": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vikings-eventmgmt-mobile",
   "private": true,
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Mobile React version of Vikings Event Management",
   "type": "module",
   "engines": {

--- a/src/features/movements/components/SectionMovementTracker.jsx
+++ b/src/features/movements/components/SectionMovementTracker.jsx
@@ -362,6 +362,7 @@ function SectionMovementTracker({ onBack }) {
                 movers={termData.movers}
                 sectionTypeTotals={termData.sectionTypeTotals}
                 onDataRefresh={refetch}
+                allTerms={futureTerms}
               />
             ))}
           </div>

--- a/src/features/movements/components/TermMovementCard.jsx
+++ b/src/features/movements/components/TermMovementCard.jsx
@@ -8,7 +8,7 @@ import { getToken } from '../../../shared/services/auth/tokenService.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import { useNotification } from '../../../shared/contexts/notifications';
 
-function TermMovementCard({ term, sectionSummaries, sectionsData, movers, sectionTypeTotals, onDataRefresh }) {
+function TermMovementCard({ term, sectionSummaries, sectionsData, movers, sectionTypeTotals, onDataRefresh, allTerms }) {
   
   const [sectionState, setSectionState] = useState({
     assignments: new Map(),
@@ -136,13 +136,14 @@ function TermMovementCard({ term, sectionSummaries, sectionsData, movers, sectio
   }, [sectionSummaries, sectionsData, sectionState.optimisticCounts]);
 
   const availableTerms = useMemo(() => {
-    return [
+    // Use all terms displayed on the page instead of hardcoded list
+    return allTerms || [
       { type: 'Spring', year: term.year },
       { type: 'Summer', year: term.year },
       { type: 'Autumn', year: term.year },
       { type: 'Spring', year: term.year + 1 },
     ];
-  }, [term.year]);
+  }, [allTerms, term.year]);
 
   const handleAssignmentChange = useCallback((memberId, assignment) => {
     setSectionState(prev => {
@@ -483,6 +484,10 @@ TermMovementCard.propTypes = {
   movers: PropTypes.arrayOf(PropTypes.object).isRequired,
   sectionTypeTotals: PropTypes.instanceOf(Map),
   onDataRefresh: PropTypes.func.isRequired,
+  allTerms: PropTypes.arrayOf(PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    year: PropTypes.number.isRequired,
+  })),
 };
 
 export default TermMovementCard;


### PR DESCRIPTION
## Summary
Fixed a bug in the Section Movers page where the term assignment dropdown only showed terms from after a child's age transition date, instead of showing all terms displayed on the page.

## Problem
- Child turns 8 in September 15th → due to move in Spring term  
- Dropdown only showed: Spring, Summer (future terms from age transition)
- Could NOT select: Autumn (even though it was shown on the page)
- Users needed to assign members to earlier terms that were visible

## Solution
- Modified `TermMovementCard.jsx` to accept `allTerms` prop from parent
- Updated `availableTerms` to use actual displayed terms instead of hardcoded list
- Modified `SectionMovementTracker.jsx` to pass `futureTerms` to each card
- Added proper PropTypes validation

## Technical Changes
- **Files Modified**: `TermMovementCard.jsx`, `SectionMovementTracker.jsx`
- **Root Cause**: Hardcoded term list in `availableTerms` useMemo
- **Fix**: Use parent's `futureTerms` array that matches displayed page content

## Testing
- ✅ All 141 tests pass
- ✅ No new lint errors  
- ✅ Production build succeeds
- ✅ Maintains backward compatibility with fallback

## Example Fix
**Before**: Child ages out in Spring → dropdown shows Spring, Summer only  
**After**: Child ages out in Spring → dropdown shows Autumn, Spring, Summer (all page terms)

The assignment dropdown now correctly shows all terms visible on the current page, allowing flexible manual assignment to any displayed term period.