### PR TITLE
fix: use section-specific person_type for attendance YP/YL/L grouping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-eventmgmt-mobile",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-eventmgmt-mobile",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "dependencies": {
         "@capacitor-community/sqlite": "^7.0.0",
         "@capacitor/cli": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vikings-eventmgmt-mobile",
   "private": true,
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Mobile React version of Vikings Event Management",
   "type": "module",
   "engines": {

--- a/src/features/events/components/attendance/EventAttendance.jsx
+++ b/src/features/events/components/attendance/EventAttendance.jsx
@@ -147,6 +147,19 @@ function EventAttendance({ events, members: membersProp, onBack }) {
       if (!memberMap.has(key)) {
         const memberData = membersById.get(String(record.scoutid));
 
+        // Get person_type for the specific section
+        let personType = null;
+        if (memberData?.sections && Array.isArray(memberData.sections)) {
+          const sectionMembership = memberData.sections.find(s => s.sectionid === record.sectionid);
+          personType = sectionMembership?.person_type;
+        }
+        if (!personType) {
+          personType = memberData?.person_type;
+        }
+        if (!personType && memberData?.age_years) {
+          personType = memberData.age_years >= 18 ? 'Leaders' : 'Young People';
+        }
+
         memberMap.set(key, {
           scoutid: record.scoutid,
           name: `${record.firstname} ${record.lastname}`,
@@ -164,7 +177,7 @@ function EventAttendance({ events, members: membersProp, onBack }) {
             !isFieldCleared(record.vikingEventData.SignedInBy) &&
             (!record.vikingEventData?.SignedOutBy || isFieldCleared(record.vikingEventData.SignedOutBy)),
           ),
-          person_type: memberData?.person_type,
+          person_type: personType,
           patrol_id: memberData?.patrol_id,
           patrolid: memberData?.patrolid,
         });
@@ -207,6 +220,19 @@ function EventAttendance({ events, members: membersProp, onBack }) {
       if (!memberMap.has(key)) {
         const memberData = membersById.get(String(record.scoutid));
 
+        // Get person_type for the specific section
+        let personType = null;
+        if (memberData?.sections && Array.isArray(memberData.sections)) {
+          const sectionMembership = memberData.sections.find(s => s.sectionid === record.sectionid);
+          personType = sectionMembership?.person_type;
+        }
+        if (!personType) {
+          personType = memberData?.person_type;
+        }
+        if (!personType && memberData?.age_years) {
+          personType = memberData.age_years >= 18 ? 'Leaders' : 'Young People';
+        }
+
         memberMap.set(key, {
           scoutid: record.scoutid,
           name: `${record.firstname} ${record.lastname}`,
@@ -224,7 +250,7 @@ function EventAttendance({ events, members: membersProp, onBack }) {
             !isFieldCleared(record.vikingEventData.SignedInBy) &&
             (!record.vikingEventData?.SignedOutBy || isFieldCleared(record.vikingEventData.SignedOutBy)),
           ),
-          person_type: memberData?.person_type,
+          person_type: personType,
           patrol_id: memberData?.patrol_id,
           patrolid: memberData?.patrolid,
         });
@@ -293,7 +319,23 @@ function EventAttendance({ events, members: membersProp, onBack }) {
       if (!section) return; // Should never happen now
 
       const memberData = membersById.get(String(record.scoutid));
-      const personType = memberData?.person_type;
+
+      // Get person_type for the specific section the person is attending under
+      let personType = null;
+      if (memberData?.sections && Array.isArray(memberData.sections)) {
+        const sectionMembership = memberData.sections.find(s => s.sectionid === record.sectionid);
+        personType = sectionMembership?.person_type;
+      }
+
+      // Fallback to top-level person_type if section-specific not found
+      if (!personType) {
+        personType = memberData?.person_type;
+      }
+
+      // Additional fallback: use age-based logic if still no person_type
+      if (!personType && memberData?.age_years) {
+        personType = memberData.age_years >= 18 ? 'Leaders' : 'Young People';
+      }
 
       let roleType = 'l';
       if (personType === 'Young People') {
@@ -316,7 +358,23 @@ function EventAttendance({ events, members: membersProp, onBack }) {
 
       if (!uniqueScouts.has(uniqueKey)) {
         const memberData = membersById.get(String(record.scoutid));
-        const personType = memberData?.person_type;
+
+        // Get person_type for the specific section the person is attending under
+        let personType = null;
+        if (memberData?.sections && Array.isArray(memberData.sections)) {
+          const sectionMembership = memberData.sections.find(s => s.sectionid === record.sectionid);
+          personType = sectionMembership?.person_type;
+        }
+
+        // Fallback to top-level person_type if section-specific not found
+        if (!personType) {
+          personType = memberData?.person_type;
+        }
+
+        // Additional fallback: use age-based logic if still no person_type
+        if (!personType && memberData?.age_years) {
+          personType = memberData.age_years >= 18 ? 'Leaders' : 'Young People';
+        }
 
         let roleType = 'l';
         if (personType === 'Young People') {


### PR DESCRIPTION
## Summary
Fixes incorrect YP/YL/L categorization in attendance overview by using section-specific person_type data from the member_section table instead of the member's first section.

## Problem
The attendance overview was categorizing members (Young People, Young Leaders, Leaders) based on their first section membership from `member.person_type`, not the specific section they were attending the event under. 

This caused issues especially for shared attendance where:
- Young leaders might attend as leaders in one section
- Leaders might help at cubs/beavers events
- The YP/YL/L counts didn't match the actual attendance section

**Example:**
- Alice is a Young Leader in Scouts (person_type: "Young Leaders")
- Alice attends a Cubs event as a Leader
- ❌ Before: Counted as YL in Cubs
- ✅ After: Counted as L in Cubs (correct)

## Solution
Modified person_type lookup to use the section-specific data from `member.sections` array:

1. **Primary**: Look up person_type from `member.sections` array matching `record.sectionid`
2. **Fallback 1**: Use `member.person_type` if section-specific not found
3. **Fallback 2**: Age-based logic (age >= 18 = Leaders, else Young People)

## Changes

### EventAttendance.jsx
Updated 4 locations where person_type is determined:

**1. summaryStats useMemo** (lines 150-161)
```javascript
// Get person_type for the specific section
let personType = null;
if (memberData?.sections && Array.isArray(memberData.sections)) {
  const sectionMembership = memberData.sections.find(s => s.sectionid === record.sectionid);
  personType = sectionMembership?.person_type;
}
if (!personType) {
  personType = memberData?.person_type;
}
if (!personType && memberData?.age_years) {
  personType = memberData.age_years >= 18 ? 'Leaders' : 'Young People';
}
```

**2. bulkOperationSummaryStats useMemo** (lines 223-234)  
Same logic for bulk operations

**3. simplifiedSummaryStatsForOverview - section counts** (lines 297-312)  
Same logic for overview section counts

**4. simplifiedSummaryStatsForOverview - totals** (lines 336-351)  
Same logic for overview totals

## Testing

**All 361 tests passing ✅**
- Verified YP/YL/L counts per section
- Tested with shared attendance scenarios
- Confirmed fallback logic works

**Quality Checks:**
- Linter: ✅ Passed (0 errors, 14 pre-existing warnings)
- Tests: ✅ All 361 passing
- Build: ✅ Verified

## Impact

**Fixes:**
- ✅ Attendance overview shows correct YP/YL/L counts per section
- ✅ Shared attendance correctly categorizes members by attending section
- ✅ Young leaders attending as leaders are counted correctly
- ✅ Age-based fallback ensures data integrity

**Improves:**
- ✅ Accuracy of attendance reporting
- ✅ Proper utilization of member_section table data
- ✅ Support for multi-section members

**Maintains:**
- ✅ Backward compatibility with fallback logic
- ✅ All existing functionality
- ✅ Performance (O(n) lookup within cached member data)

## Related Work
Part of dual-store refactor benefits - leveraging section-specific data from member_section table introduced in PR #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)