### PR TITLE
fix: force refresh FlexiRecords on every login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vikings-eventmgmt-mobile",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vikings-eventmgmt-mobile",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "dependencies": {
         "@capacitor-community/sqlite": "^7.0.0",
         "@capacitor/cli": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vikings-eventmgmt-mobile",
   "private": true,
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Mobile React version of Vikings Event Management",
   "type": "module",
   "engines": {

--- a/src/shared/services/referenceData/referenceDataService.js
+++ b/src/shared/services/referenceData/referenceDataService.js
@@ -238,7 +238,7 @@ export async function loadFlexiRecordData(sections, token) {
     // Load FlexiRecord lists for all sections
     for (const section of sections) {
       try {
-        const flexiRecords = await getFlexiRecords(section.sectionid, token, 'n', false);
+        const flexiRecords = await getFlexiRecords(section.sectionid, token, 'n', true);
         if (flexiRecords && flexiRecords.items) {
           flexiRecordData.lists.push({
             sectionId: section.sectionid,


### PR DESCRIPTION
## Summary

Fixed FlexiRecords not refreshing on subsequent logins by changing `forceRefresh` parameter from `false` to `true` in `loadFlexiRecordData()`.

## Problem

FlexiRecords were only being loaded fresh from OSM on first-time login. On subsequent logins, cached data was used, preventing updates made in OSM (like camp group assignments) from appearing in the app.

## Root Cause

In `referenceDataService.js` line 241:
```javascript
const flexiRecords = await getFlexiRecords(section.sectionid, token, 'n', false);
//                                                                           ^^^^^ forceRefresh=false
```

This meant FlexiRecord API calls were skipped on subsequent logins, using stale cached data instead.

## Solution

Changed `forceRefresh` to `true` to match the data loading diagram specification:
```javascript
const flexiRecords = await getFlexiRecords(section.sectionid, token, 'n', true);
//                                                                           ^^^^ forceRefresh=true
```

Now FlexiRecords are fetched fresh from OSM on every login, ensuring:
- Camp group assignments stay up-to-date
- Viking Event Mgmt FlexiRecord data reflects OSM changes
- Viking Section Movers FlexiRecord data stays current

## Testing

- ✅ Lint: 0 errors, 14 warnings (existing warnings)
- ⏭️ Tests: Skipped (service logic only)
- ⏭️ Build: Pending

## References

- Data loading flow diagram: `docs/diagrams/02-initial-login-data-load.puml` (Phase 1B, lines 140-159)
- Specification states: `forceRefresh=true` should bypass cache on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)