### PR TITLE
fix: correct person_type classification for shared attendance records

### DIFF
--- a/src/shared/services/api/api/events.js
+++ b/src/shared/services/api/api/events.js
@@ -579,7 +579,6 @@ export async function createMemberSectionRecordsForSharedAttendees(sectionId, at
         if (match) {
           const years = parseInt(match[1], 10);
           if (years >= 18) return 'Leaders';
-          if (years >= 14) return 'Young Leaders';
           return 'Young People';
         }
         return null;
@@ -599,7 +598,7 @@ export async function createMemberSectionRecordsForSharedAttendees(sectionId, at
           // 5. Age-based derivation
           const personType = existing?.person_type
             || attendee?.person_type
-            || mapPatrolIdToPersonType(attendee?.patrol_id)
+            || mapPatrolIdToPersonType(attendee?.patrol_id || attendee?.patrolid)
             || derivePersonTypeFromAge(attendee?.age || attendee?.yrs)
             || 'Young People'; // Final fallback
 


### PR DESCRIPTION
## Issue
Shared attendance Explorers (age 14-17) were incorrectly classified as "Young Leaders" instead of "Young People", causing incorrect attendance counts.

## Root Causes
1. **Field name mismatch**: Code checked `attendee.patrol_id` but OSM returns `patrolid` (no underscore)
2. **Incorrect age logic**: Age fallback treated 14-17 year-olds as Young Leaders (logic I incorrectly added in c5e1468)

## Changes
- ✅ Check both `patrol_id` and `patrolid` field name variants in shared attendance
- ✅ Remove incorrect 14-17 → Young Leaders age classification  
- ✅ Age-based fallback now only: ≥18 = Leaders, <18 = Young People

## Why This Fixes It
Ensures patrol-based classification takes priority over age. Only Leaders (18+) get special age-based handling when patrol data is unavailable.

## Testing
- ✅ Lint: 0 errors (14 pre-existing warnings)
- ✅ Tests: 361 passed
- ✅ Build: Success

After deployment, production Explorers section should show correct YP/YL counts matching local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)