### PR TITLE
fix: add missing SQLite terms table and remove stale store constant

### DIFF
--- a/src/shared/services/storage/__tests__/indexedDBStoreCreation.test.js
+++ b/src/shared/services/storage/__tests__/indexedDBStoreCreation.test.js
@@ -141,8 +141,8 @@ describe.skip('IndexedDB Store Creation and Upgrade Logic - Disabled for CI/CD',
         'flexi_data',
         'events',
         'attendance',
-        'shared_attendance',
-        'members',
+        'core_members',
+        'member_section',
       ];
 
       expectedStores.forEach(storeName => {
@@ -186,8 +186,9 @@ describe.skip('IndexedDB Store Creation and Upgrade Logic - Disabled for CI/CD',
         FLEXI_DATA: 'flexi_data',
         EVENTS: 'events',
         ATTENDANCE: 'attendance',
-        SHARED_ATTENDANCE: 'shared_attendance',
-        MEMBERS: 'members',
+        CORE_MEMBERS: 'core_members',
+        MEMBER_SECTION: 'member_section',
+        SHARED_EVENT_METADATA: 'shared_event_metadata',
       };
 
       Object.entries(expectedStores).forEach(([constant, value]) => {

--- a/src/shared/services/storage/database.js
+++ b/src/shared/services/storage/database.js
@@ -334,6 +334,7 @@ class DatabaseService {
     await this.db.execute(createEventDashboardTable);
     await this.db.execute(createSyncMetadataTable);
 
+    await this.db.execute(SQLITE_SCHEMAS.terms);
     await this.db.execute(SQLITE_SCHEMAS.flexi_lists);
     await this.db.execute(SQLITE_SCHEMAS.flexi_structure);
     await this.db.execute(SQLITE_SCHEMAS.flexi_data);

--- a/src/shared/services/storage/indexedDBService.js
+++ b/src/shared/services/storage/indexedDBService.js
@@ -17,7 +17,6 @@ const STORES = {
   FLEXI_DATA: 'flexi_data',
   EVENTS: 'events',
   ATTENDANCE: 'attendance',
-  SHARED_ATTENDANCE: 'shared_attendance',
   CORE_MEMBERS: 'core_members',
   MEMBER_SECTION: 'member_section',
   SHARED_EVENT_METADATA: 'shared_event_metadata',
@@ -102,8 +101,8 @@ function getDB() {
           attendanceStore.createIndex('eventId', 'eventId', { unique: false });
         }
 
-        if (!db.objectStoreNames.contains(STORES.SHARED_ATTENDANCE)) {
-          const sharedAttendanceStore = db.createObjectStore(STORES.SHARED_ATTENDANCE, { keyPath: 'key' });
+        if (!db.objectStoreNames.contains('shared_attendance')) {
+          const sharedAttendanceStore = db.createObjectStore('shared_attendance', { keyPath: 'key' });
           sharedAttendanceStore.createIndex('eventId', 'eventId', { unique: false });
         }
 
@@ -153,8 +152,8 @@ function getDB() {
           attendanceStoreV6.createIndex('scoutid', 'scoutid', { unique: false });
           attendanceStoreV6.createIndex('sectionid', 'sectionid', { unique: false });
 
-          if (db.objectStoreNames.contains(STORES.SHARED_ATTENDANCE)) {
-            db.deleteObjectStore(STORES.SHARED_ATTENDANCE);
+          if (db.objectStoreNames.contains('shared_attendance')) {
+            db.deleteObjectStore('shared_attendance');
           }
           db.createObjectStore(STORES.SHARED_EVENT_METADATA, { keyPath: 'eventid' });
 


### PR DESCRIPTION
## Summary
- **Add missing SQLite terms table** — `SQLITE_SCHEMAS.terms` was defined but never executed in `createTables()`, meaning native Capacitor deployment would crash on any terms operation with "no such table: terms"
- **Remove stale `SHARED_ATTENDANCE` store constant** — the IndexedDB store was deleted in the v6 upgrade but the constant remained in `STORES`, causing failed `clear()` calls and Sentry noise on every logout
- **Update test assertions** — `indexedDBStoreCreation.test.js` had stale store names (`members`, `SHARED_ATTENDANCE`)

## Found during
Milestone v1.0 audit (`/gsd:audit-milestone`) — integration checker identified the SQLite gap and stale constant.

## Test plan
- [x] `npm run lint` passes (0 errors, 13 pre-existing warnings)
- [x] `npm run test:run` passes (393 passed, 13 skipped)
- [ ] Verify native Capacitor build creates terms table on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)