### PR TITLE
fix: pass Error objects to logger so Sentry receives stack traces

### DIFF
--- a/src/features/admin/components/DataClearPage.jsx
+++ b/src/features/admin/components/DataClearPage.jsx
@@ -26,7 +26,7 @@ function DataClearPage() {
           stores: Object.values(IndexedDBService.STORES),
         }, LOG_CATEGORIES.APP);
       } catch (dbError) {
-        logger.error('Failed to clear IndexedDB', { error: dbError.message }, LOG_CATEGORIES.ERROR);
+        logger.error('Failed to clear IndexedDB', { error: dbError }, LOG_CATEGORIES.ERROR);
         throw dbError; // Re-throw to handle in outer catch
       }
 
@@ -72,7 +72,7 @@ function DataClearPage() {
       }, 2000);
 
     } catch (error) {
-      logger.error('Failed to clear application data', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Failed to clear application data', { error: error }, LOG_CATEGORIES.ERROR);
       setIsClearing(false);
     }
   };

--- a/src/features/auth/hooks/useAuth.jsx
+++ b/src/features/auth/hooks/useAuth.jsx
@@ -84,7 +84,7 @@ function useAuthLogic() {
         return 'no_data';
       }
     } catch (error) {
-      logger.warn('Error determining auth state', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.warn('Error determining auth state', { error: error }, LOG_CATEGORIES.ERROR);
       return isAuth ? 'authenticated' : 'no_data';
     }
   }, []);
@@ -478,7 +478,7 @@ function useAuthLogic() {
       setAuthState(newAuthState);
       
     } catch (error) {
-      logger.error('Error checking authentication', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Error checking authentication', { error: error }, LOG_CATEGORIES.ERROR);
       setIsAuthenticated(false);
       setUser(null);
       setAuthState('no_data'); // Fallback to no_data state on error

--- a/src/features/auth/services/auth.js
+++ b/src/features/auth/services/auth.js
@@ -572,7 +572,7 @@ export async function fetchUserInfoFromAPI() {
       return fallbackUserInfo;
     }
   } catch (error) {
-    logger.error('Failed to fetch user info from API', { error: error.message }, LOG_CATEGORIES.AUTH);
+    logger.error('Failed to fetch user info from API', { error: error }, LOG_CATEGORIES.AUTH);
     throw error;
   }
 }

--- a/src/features/events/components/EventDashboard.jsx
+++ b/src/features/events/components/EventDashboard.jsx
@@ -310,7 +310,7 @@ function EventDashboard({ onNavigateToMembers, onNavigateToAttendance }) {
     try {
       await loadInitialDataInBackground();
     } catch (error) {
-      logger.error('Manual refresh failed', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Manual refresh failed', { error: error }, LOG_CATEGORIES.ERROR);
       // Don't affect UI on error - just log it
     }
   };

--- a/src/features/events/components/EventsLayout.jsx
+++ b/src/features/events/components/EventsLayout.jsx
@@ -40,7 +40,7 @@ function EventsLayoutContent() {
         await loadInitialReferenceData(token);
       }
     } catch (error) {
-      logger.error('Manual refresh failed', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Manual refresh failed', { error: error }, LOG_CATEGORIES.ERROR);
       notifyError('Refresh failed. Please try again.');
     } finally {
       setIsRefreshing(false);

--- a/src/features/events/components/EventsOverview.jsx
+++ b/src/features/events/components/EventsOverview.jsx
@@ -50,7 +50,7 @@ function EventsOverview({ onNavigateToAttendance: _onNavigateToAttendance }) {
           setEventCards([]);
         }
       } catch (err) {
-        logger.error('Failed to build event cards for overview', { error: err.message }, LOG_CATEGORIES.ERROR);
+        logger.error('Failed to build event cards for overview', { error: err }, LOG_CATEGORIES.ERROR);
         setError(err.message);
         setEventCards([]);
       } finally {

--- a/src/features/events/components/EventsRegister.jsx
+++ b/src/features/events/components/EventsRegister.jsx
@@ -64,7 +64,7 @@ function EventsRegister() {
           }
         }
       } catch (err) {
-        logger.error('Failed to load events data for register', { error: err.message }, LOG_CATEGORIES.ERROR);
+        logger.error('Failed to load events data for register', { error: err }, LOG_CATEGORIES.ERROR);
         setError(err.message);
       } finally {
         setLoading(false);

--- a/src/features/events/services/flexiRecordService.js
+++ b/src/features/events/services/flexiRecordService.js
@@ -159,7 +159,7 @@ export async function getFlexiRecordsList(sectionId, token, forceRefresh = false
         return cached;
       }
     } catch (cacheError) {
-      logger.error('Cache fallback failed', { error: cacheError.message });
+      logger.error('Cache fallback failed', { error: cacheError });
     }
 
     throw error;
@@ -244,7 +244,7 @@ export async function getFlexiRecordStructure(flexirecordId, sectionId, termId, 
         return cached;
       }
     } catch (cacheError) {
-      logger.error('Cache fallback failed', { error: cacheError.message });
+      logger.error('Cache fallback failed', { error: cacheError });
     }
 
     throw error;
@@ -330,7 +330,7 @@ export async function getFlexiRecordData(flexirecordId, sectionId, termId, token
         return cached;
       }
     } catch (cacheError) {
-      logger.error('Cache fallback failed', { error: cacheError.message });
+      logger.error('Cache fallback failed', { error: cacheError });
     }
 
     throw error;

--- a/src/features/movements/components/AssignmentInterface.jsx
+++ b/src/features/movements/components/AssignmentInterface.jsx
@@ -126,7 +126,7 @@ function AssignmentInterface({
 
   useEffect(() => {
     loadDraftFromStorage().catch(error => {
-      logger.error('Failed to load draft from storage', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Failed to load draft from storage', { error: error }, LOG_CATEGORIES.ERROR);
     });
   }, [loadDraftFromStorage]);
 

--- a/src/features/young-leaders/components/YoungLeadersPage.jsx
+++ b/src/features/young-leaders/components/YoungLeadersPage.jsx
@@ -117,7 +117,7 @@ function YoungLeadersPage() {
           try {
             allTerms = await getTerms(token);
           } catch (err) {
-            logger.error('Error loading terms, will use fallback', { error: err.message }, LOG_CATEGORIES.ERROR);
+            logger.error('Error loading terms, will use fallback', { error: err }, LOG_CATEGORIES.ERROR);
           }
         }
 
@@ -136,7 +136,7 @@ function YoungLeadersPage() {
               allTerms = termsBySection;
             }
           } catch (err) {
-            logger.warn('Failed to load offline terms from normalized store', { error: err.message }, LOG_CATEGORIES.APP);
+            logger.warn('Failed to load offline terms from normalized store', { error: err }, LOG_CATEGORIES.APP);
           }
         }
 

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -54,7 +54,7 @@ function AppContent() {
       }
     } catch (error) {
       const { default: logger, LOG_CATEGORIES } = await import('../shared/services/utils/logger.js');
-      logger.error('Refresh failed', { error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Refresh failed', { error: error }, LOG_CATEGORIES.ERROR);
     }
   };
 

--- a/src/shared/hooks/useSignInOut.js
+++ b/src/shared/hooks/useSignInOut.js
@@ -195,7 +195,7 @@ export function useSignInOut(events, onDataRefresh, notificationHandlers = {}) {
         try {
           fieldMapping = parseFlexiStructure(structure);
         } catch (parseError) {
-          logger.error('Failed to parse FlexiRecord structure with parseFlexiStructure()', { error: parseError.message }, LOG_CATEGORIES.ERROR);
+          logger.error('Failed to parse FlexiRecord structure with parseFlexiStructure()', { error: parseError }, LOG_CATEGORIES.ERROR);
 
           // Fallback: try to access pre-parsed data (though this usually doesn't exist)
           if (structure?.vikingFlexiRecord?.fieldMapping) {

--- a/src/shared/services/api/api/auth.js
+++ b/src/shared/services/api/api/auth.js
@@ -248,7 +248,7 @@ export async function getUserRoles(token) {
               logger.warn('No cached sections available for fallback');
             }
           } catch (dbError) {
-            logger.error('Database fallback also failed', { error: dbError.message });
+            logger.error('Database fallback also failed', { error: dbError });
             span.setAttribute('fallback.successful', false);
           }
         }
@@ -330,7 +330,7 @@ export async function getStartupData(token) {
     return startupData;
         
   } catch (error) {
-    logger.error('Error fetching startup data', { error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching startup data', { error: error }, LOG_CATEGORIES.API);
     
     // Don't fall back to cache for authentication errors - these need to be handled by auth system
     if (error.status === 401 || error.status === 403) {

--- a/src/shared/services/api/api/base.js
+++ b/src/shared/services/api/api/base.js
@@ -356,7 +356,7 @@ export async function testBackendConnection() {
     
     return result;
   } catch (error) {
-    logger.error('Backend connection test error', { error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Backend connection test error', { error: error }, LOG_CATEGORIES.API);
     return { status: 'error', error: error.message };
   }
 }

--- a/src/shared/services/api/api/events.js
+++ b/src/shared/services/api/api/events.js
@@ -93,7 +93,7 @@ export async function getEvents(sectionId, termId, token) {
     return eventsWithTermId;
 
   } catch (error) {
-    logger.error('Error fetching events', { sectionId, termId, error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching events', { sectionId, termId, error: error }, LOG_CATEGORIES.API);
         
     // If online request fails, try local database as fallback
     const isOnlineNow = await checkNetworkStatus();
@@ -183,7 +183,7 @@ export async function getEventAttendance(sectionId, eventId, termId, token) {
     return attendance;
 
   } catch (error) {
-    logger.error('Error fetching event attendance', { eventId, error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching event attendance', { eventId, error: error }, LOG_CATEGORIES.API);
         
     // If online request fails, try local database as fallback
     const isOnlineNow = await checkNetworkStatus();
@@ -419,7 +419,7 @@ export async function getSharedEventAttendance(eventId, sectionId, token) {
 
       logger.debug('Saved shared attendance to normalized store', { eventId, sectionId }, LOG_CATEGORIES.API);
     } catch (cacheError) {
-      logger.warn('Failed to save shared attendance to normalized store', { error: cacheError.message }, LOG_CATEGORIES.API);
+      logger.warn('Failed to save shared attendance to normalized store', { error: cacheError }, LOG_CATEGORIES.API);
     }
 
     return data;

--- a/src/shared/services/api/api/flexiRecords.js
+++ b/src/shared/services/api/api/flexiRecords.js
@@ -93,7 +93,7 @@ export async function getFlexiRecords(sectionId, token, archived = 'n', forceRef
     return flexiData;
 
   } catch (error) {
-    logger.error('Error fetching flexi records', { error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching flexi records', { error: error }, LOG_CATEGORIES.API);
 
     const isOnline = await checkNetworkStatus();
     if (isOnline) {
@@ -155,7 +155,7 @@ export async function getSingleFlexiRecord(flexirecordid, sectionid, termid, tok
     return data || { identifier: null, items: [] };
 
   } catch (error) {
-    logger.error('Error fetching single flexi record', { error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching single flexi record', { error: error }, LOG_CATEGORIES.API);
     throw error;
   }
 }
@@ -243,7 +243,7 @@ export async function getFlexiStructure(extraid, sectionid, termid, token, force
     return structureData;
 
   } catch (error) {
-    logger.error('Error fetching flexi structure', { error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching flexi structure', { error: error }, LOG_CATEGORIES.API);
 
     const isOnline = await checkNetworkStatus();
     if (isOnline) {
@@ -323,7 +323,7 @@ export async function updateFlexiRecord(sectionid, scoutid, flexirecordid, colum
     return data || null;
 
   } catch (error) {
-    logger.error('Error updating flexi record', { error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error updating flexi record', { error: error }, LOG_CATEGORIES.API);
     throw error;
   }
 }

--- a/src/shared/services/api/api/members.js
+++ b/src/shared/services/api/api/members.js
@@ -154,7 +154,7 @@ export async function getMembersGrid(sectionId, termId, token) {
     return [];
 
   } catch (error) {
-    logger.error('Error fetching members grid', { sectionId, error: error.message }, LOG_CATEGORIES.API);
+    logger.error('Error fetching members grid', { sectionId, error: error }, LOG_CATEGORIES.API);
     
     // If online request fails, try local database as fallback
     const isOnline = await checkNetworkStatus();
@@ -365,7 +365,7 @@ export async function getListOfMembers(sections, token, forceRefresh = false) {
       });
       
     } catch (sectionError) {
-      logger.warn('Failed to fetch members for section', { sectionId: section.sectionid, error: sectionError.message }, LOG_CATEGORIES.API);
+      logger.warn('Failed to fetch members for section', { sectionId: section.sectionid, error: sectionError }, LOG_CATEGORIES.API);
       // Continue with other sections
     }
   }

--- a/src/shared/services/api/api/terms.js
+++ b/src/shared/services/api/api/terms.js
@@ -280,7 +280,7 @@ export async function fetchMostRecentTermId(sectionId, token) {
 
       return termId;
     } catch (error) {
-      logger.error('Error fetching most recent term ID', { sectionId, error: error.message }, LOG_CATEGORIES.ERROR);
+      logger.error('Error fetching most recent term ID', { sectionId, error: error }, LOG_CATEGORIES.ERROR);
       throw error;
     }
   });

--- a/src/shared/services/referenceData/referenceDataService.js
+++ b/src/shared/services/referenceData/referenceDataService.js
@@ -66,7 +66,7 @@ export async function loadInitialReferenceData(token) {
       isWarning: true,
     });
     errors.push({ type: 'terms', message, originalError: error.message });
-    logger.warn('Terms data loading failed', { error: error.message }, LOG_CATEGORIES.AUTH);
+    logger.warn('Terms data loading failed', { error: error }, LOG_CATEGORIES.AUTH);
   }
 
   // Load user roles
@@ -83,7 +83,7 @@ export async function loadInitialReferenceData(token) {
       isWarning: true,
     });
     errors.push({ type: 'userRoles', message, originalError: error.message });
-    logger.warn('User roles loading failed', { error: error.message }, LOG_CATEGORIES.AUTH);
+    logger.warn('User roles loading failed', { error: error }, LOG_CATEGORIES.AUTH);
   }
 
   // Load startup data
@@ -124,7 +124,7 @@ export async function loadInitialReferenceData(token) {
       isWarning: true,
     });
     errors.push({ type: 'startupData', message, originalError: error.message });
-    logger.warn('Startup data loading failed', { error: error.message }, LOG_CATEGORIES.AUTH);
+    logger.warn('Startup data loading failed', { error: error }, LOG_CATEGORIES.AUTH);
   }
 
   // Load members data
@@ -146,7 +146,7 @@ export async function loadInitialReferenceData(token) {
       isWarning: true,
     });
     errors.push({ type: 'members', message, originalError: error.message });
-    logger.warn('Members data loading failed', { error: error.message }, LOG_CATEGORIES.AUTH);
+    logger.warn('Members data loading failed', { error: error }, LOG_CATEGORIES.AUTH);
   }
 
   const hasErrors = errors.length > 0;


### PR DESCRIPTION
## Summary

The project's `logger` calls `Sentry.captureException(context.error)` (`src/shared/services/utils/logger.js:198–229`). When a site passes `{ error: error.message }` (a **string**) instead of `{ error }` (the Error), Sentry:

- Loses all stack traces — `error.stack` doesn't exist on a string
- Groups every exception as a single **"Non-Error exception captured"** issue, hiding distinct bugs behind one bucket

Discovered while reviewing #177 (the audit-fixes PR). That PR fixed the 7 sites it introduced. **This PR sweeps the rest of the codebase** — 34 pre-existing sites across 19 files.

## Change

For each site, replace `error: <var>.message` → `error: <var>`. Variable name is preserved per-site (`error`, `err`, `dbError`, `cacheError`, `sectionError`, `parseError`).

```js
// Before
logger.error('Error fetching events', { sectionId, termId, error: error.message }, LOG_CATEGORIES.API);

// After
logger.error('Error fetching events', { sectionId, termId, error }, LOG_CATEGORIES.API);
```

## Sites by area

| Area | Files | Sites |
|---|---|---|
| API clients | `flexiRecords.js`, `members.js`, `events.js`, `terms.js`, `base.js`, `auth.js` (api) | 13 |
| Reference data | `referenceDataService.js` | 4 |
| Auth | `useAuth.jsx`, `auth.js` (services), `useSignInOut.js` | 4 |
| Route guard | `AppRouter.jsx` | 1 |
| Feature components | `EventDashboard`, `EventsLayout`, `EventsOverview`, `EventsRegister`, `AssignmentInterface`, `YoungLeadersPage`, `DataClearPage` | 9 |
| Misc | `flexiRecordService.js` (cache fallbacks) | 3 |
| **Total** | **19 files** | **34 sites** |

## Method

Each site was identified by the silent-failure-hunter agent, filtering out non-logger usages (API request payloads, returned values, React state updates, test fixtures). Substitutions applied via line-targeted `sed` to avoid touching same-pattern false positives in the same files.

## Test plan

- [ ] CI passes (lint + tests + build).
- [ ] After merge, watch Sentry's "Issues" page for any errors that have a real stack trace pointing to one of the touched files (rather than into Sentry's wrapper).
- [ ] Spot-check that the "Non-Error exception captured" group stops growing.

## Verification

```
npm run lint     → 0 errors (13 pre-existing warnings unchanged)
npm run test:run → 393 passed, 13 skipped
npm run build    → ok
```

19 files changed, +34 / −34 (one-character delta per site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)