### PR TITLE
fix(ios): post-launch fixes — auth, attendance sync, schema drift + migration framework

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,5 +1,8 @@
 {
   "appId": "com.vikingscouts.vikingscoutsmanager",
   "appName": "Vikings Event Mgmt",
-  "webDir": "dist"
+  "webDir": "dist",
+  "ios": {
+    "webContentsDebuggingEnabled": true
+  }
 }

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -1,0 +1,225 @@
+# Data Flows: API → IndexedDB & SQLite
+
+How OSM API responses flow into the two storage backends — IndexedDB on web, SQLite on native iOS — and where the two diverge. Each section is a Mermaid diagram so it renders inline on GitHub and most Markdown viewers.
+
+The point of this document is to make alignment (or misalignment) between the two backends visible at a glance. The "Alignment status" table at the end lists the concrete gaps that still need closing.
+
+---
+
+## 1. Top-level overview
+
+Every save goes through `databaseService` which branches per platform. IndexedDB is used both as the web fallback and (separately) for a couple of utility caches on iOS — but the main data is split as shown.
+
+```mermaid
+flowchart TB
+  subgraph API["OSM API (via backend)"]
+    A1[get_user_roles<br/>+ startup_data]
+    A2[get_events]
+    A3[get_event_attendance]
+    A4[get_event_attendance<br/>shared sections]
+    A5[get_members]
+    A6[get_terms]
+    A7[get_flexi_records]
+    A8[get_flexi_structure]
+    A9[get_flexi_data]
+  end
+
+  subgraph DS["DatabaseService (single facade, branches per platform)"]
+    SS[saveSections]
+    SE[saveEvents]
+    SA[saveAttendance]
+    SSA[saveSharedAttendance]
+    SM[saveMembers]
+    ST[saveTerms]
+    SFL[saveFlexiLists]
+    SFS[saveFlexiStructure]
+    SFD[saveFlexiData]
+  end
+
+  A1 --> SS
+  A2 --> SE
+  A3 --> SA
+  A4 --> SSA
+  A5 --> SM
+  A6 --> ST
+  A7 --> SFL
+  A8 --> SFS
+  A9 --> SFD
+
+  DS -->|"!isNative or no db"| WEB[(IndexedDB<br/>vikings_db)]
+  DS -->|"isNative iOS"| NATIVE[(SQLite<br/>vikings_db)]
+```
+
+---
+
+## 2. Sections
+
+```mermaid
+flowchart TB
+  API["OSM API → auth.js getUserRoles()<br/>raw items: { sectionid, sectionname, section, isDefault, permissions }"]
+  API --> Map["Map response (auth.js:198):<br/>sectiontype = item.section ?? item.sectionname<br/>+ enriched fields preserved"]
+  Map --> Save["databaseService.saveSections(sections)"]
+  Save --> Validate["safeParseArray(SectionSchema)<br/>✓ runs on BOTH paths"]
+  Validate --> Branch{"isNative<br/>&& this.db?"}
+
+  Branch -->|"web"| IDBOp["IndexedDBService.bulkReplaceSections<br/>store.clear() + store.put({...section, updated_at})"]
+  IDBOp --> IDBStore["⚙️ IndexedDB store: sections<br/>keyPath: sectionid<br/>persists ALL fields incl.<br/>section, isDefault, permissions"]
+
+  Branch -->|"iOS"| SQL["_runInTransaction:<br/>1. DELETE FROM sections<br/>2. INSERT OR REPLACE INTO sections (3 cols)"]
+  SQL --> SQLTable["⚙️ SQLite table: sections<br/>PK: sectionid<br/>cols: sectionid, sectionname, sectiontype<br/>extra fields DROPPED"]
+
+  IDBStore -.->|"alignment gap"| MISMATCH["⚠️ Web keeps `section` field<br/>SQLite drops it<br/>(was the SectionsList toLowerCase crash)"]
+  SQLTable -.-> MISMATCH
+```
+
+---
+
+## 3. Events
+
+```mermaid
+flowchart TB
+  API["OSM API → events.js getEvents()<br/>response.items per section"]
+  API --> Save["databaseService.saveEvents(sectionId, events)"]
+  Save --> Branch{"isNative<br/>&& this.db?"}
+
+  Branch -->|"web"| WebVal["safeParseArray(EventSchema)<br/>⚠️ runs on web ONLY"]
+  WebVal --> IDBOp["IndexedDBService.bulkReplaceEventsForSection<br/>cursor delete by sectionid + put each event"]
+  IDBOp --> IDBStore["⚙️ IndexedDB store: events<br/>keyPath: eventid, indexed by sectionid<br/>persists full event object incl. extras"]
+
+  Branch -->|"iOS"| SQLNoVal["⚠️ NO validation on this path"]
+  SQLNoVal --> SQL["_runInTransaction:<br/>1. DELETE FROM events WHERE sectionid=?<br/>2. INSERT INTO events (11 cols)"]
+  SQL --> SQLTable["⚙️ SQLite table: events<br/>PK: eventid, FK→sections.sectionid<br/>cols: eventid, sectionid, termid, name, date,<br/>startdate(_g), enddate(_g), location, notes"]
+
+  WebVal -.->|"alignment gap"| GAP1["⚠️ saveEvents validates only on web.<br/>iOS gets raw API shape into SQLite.<br/>Plain INSERT (no OR REPLACE) — UNIQUE risk."]
+  SQLNoVal -.-> GAP1
+```
+
+---
+
+## 4. Attendance (regular + shared)
+
+```mermaid
+flowchart TB
+  subgraph getEventAttendance["getEventAttendance() — regular"]
+    APIa["OSM API: ?sectionid&termid&eventid<br/>response.items"]
+    APIa --> SaveA1["databaseService.saveAttendance(eventId, rawItems)<br/>⚠️ first call with RAW items missing eventid/sectionid"]
+    APIa --> Map["syncEventAttendance maps to coreRecords:<br/>{scoutid, eventid, sectionid, attending, patrol, notes}"]
+    Map --> SaveA2["databaseService.saveAttendance(eventId, coreRecords)<br/>second call — properly shaped"]
+  end
+
+  subgraph getSharedEventAttendance["getSharedEventAttendance() — shared sections"]
+    APIs["OSM API: shared event endpoint"]
+    APIs --> MapS["Map to coreSharedRecords with isSharedSection=true"]
+    MapS --> SaveS["databaseService.saveSharedAttendance(eventId, records)"]
+  end
+
+  SaveA1 --> ValA["safeParseArray(AttendanceSchema)<br/>+ unknown-key check"]
+  SaveA2 --> ValA
+  SaveS --> ValSh["safeParseArray(AttendanceSchema)<br/>+ unknown-key check"]
+
+  ValA --> BranchA{"isNative?"}
+  ValSh --> BranchS{"isNative?"}
+
+  BranchA -->|"web"| IDBA["IndexedDBService.bulkReplaceAttendanceForEvent<br/>cursor delete by eventid (excl. shared) + put"]
+  BranchS -->|"web"| IDBS["IndexedDBService share path<br/>cursor delete WHERE isSharedSection=1 + put"]
+  IDBA --> IDBStore["⚙️ IndexedDB store: attendance<br/>keyPath: [eventid, scoutid]<br/>indexed by eventid, scoutid, sectionid"]
+  IDBS --> IDBStore
+
+  BranchA -->|"iOS"| SQLA["_runInTransaction:<br/>1. DELETE FROM attendance WHERE eventid=?<br/>2. INSERT OR REPLACE INTO attendance"]
+  BranchS -->|"iOS"| SQLS["_runInTransaction:<br/>1. DELETE WHERE eventid=? AND isSharedSection=1<br/>2. INSERT OR REPLACE INTO attendance (isSharedSection=1)"]
+  SQLA --> SQLTable["⚙️ SQLite table: attendance<br/>PK: (eventid, scoutid)<br/>cols: eventid, scoutid, sectionid, attending,<br/>patrol, notes, isSharedSection<br/>(sectionid + isSharedSection added in migration 002)"]
+  SQLS --> SQLTable
+```
+
+---
+
+## 5. Members — biggest asymmetry
+
+The two backends store members in structurally different ways. IndexedDB normalises into a dual-store (one row per scout in `core_members`, plus one row per (scout, section) in `member_section`). SQLite collapses everything onto a single `members` row keyed by scoutid, with the multi-section information JSON-encoded in the `sections` column. Both `getMembers()` paths reassemble the same shape on read.
+
+```mermaid
+flowchart TB
+  API["OSM API → members.js<br/>response includes core info + section membership(s)<br/>+ contact_groups + custom_data + sectionMemberships[]"]
+  API --> Save["databaseService.saveMembers(sectionIds, members)"]
+  Save --> Branch{"isNative<br/>&& this.db?"}
+
+  Branch -->|"web"| Split["Split each member into:<br/>• coreMember (identity, JSON blobs)<br/>• one sectionMember per role/section"]
+  Split --> IDBCore["IndexedDBService.bulkUpsertCoreMembers"]
+  Split --> IDBSec["IndexedDBService.bulkUpsertMemberSections"]
+  IDBCore --> CoreStore["⚙️ IndexedDB: core_members<br/>keyPath: scoutid<br/>identity + JSON blobs<br/>(contact_groups, custom_data, flattened_fields)"]
+  IDBSec --> SecStore["⚙️ IndexedDB: member_section<br/>keyPath: [scoutid, sectionid]<br/>per-section role: sectionname,<br/>person_type, patrol, dates"]
+
+  Branch -->|"iOS"| Loop["For each member: REPLACE INTO members<br/>(wrapped in _runInTransaction)"]
+  Loop --> SQLTable["⚙️ SQLite: members (single table)<br/>PK: scoutid (one row per scout, NOT per (scout, section))<br/>JSON-encoded: sections, contact_groups,<br/>custom_data, flattened_fields, read_only<br/>section info collapsed into top-level columns"]
+
+  CoreStore -.->|"alignment gap (by design)"| GAP["⚠️ IndexedDB normalises to dual-store<br/>(scout can have N sections cleanly).<br/>SQLite collapses to one row per scout<br/>+ JSON-encoded `sections` array.<br/>Read paths in getMembers() reassemble<br/>shape on both sides."]
+  SecStore -.-> GAP
+  SQLTable -.-> GAP
+```
+
+---
+
+## 6. Terms, Flexi (homogeneous patterns)
+
+These follow the same DELETE+INSERT-in-transaction shape as the others. Drawn together since they share structure.
+
+```mermaid
+flowchart TB
+  subgraph Terms[" "]
+    TA[OSM API: terms]
+    TA --> TSave[saveTerms]
+    TSave --> TBranch{native?}
+    TBranch -->|web| TVal[validate + bulkReplaceTermsForSection]
+    TBranch -->|iOS| TSQL[no validation; DELETE + INSERT in transaction]
+    TVal --> TIDB[("IndexedDB: terms<br/>keyPath: termid")]
+    TSQL --> TSQLite[("SQLite: terms<br/>PK: termid")]
+  end
+
+  subgraph FlexiLists[" "]
+    FA[OSM API: flexi list]
+    FA --> FSave[saveFlexiLists]
+    FSave --> FVal[validate at top]
+    FVal --> FBranch{native?}
+    FBranch -->|web| FIDB1[bulkReplaceFlexiListsForSection]
+    FBranch -->|iOS| FSQL1[DELETE + INSERT OR REPLACE in transaction]
+    FIDB1 --> FStore[("IndexedDB: flexi_lists")]
+    FSQL1 --> FSQLite[("SQLite: flexi_lists")]
+  end
+
+  subgraph FlexiData[" "]
+    FDA[OSM API: flexi data]
+    FDA --> FDSave[saveFlexiData]
+    FDSave --> FDVal[validate at top]
+    FDVal --> FDBranch{native?}
+    FDBranch -->|web| FDIDB[bulkReplace via index cursor]
+    FDBranch -->|iOS| FDSQL[DELETE + INSERT in transaction]
+    FDIDB --> FDStore[("IndexedDB: flexi_data")]
+    FDSQL --> FDSQLite[("SQLite: flexi_data<br/>PK: extraid+sectionid+termid+scoutid")]
+  end
+```
+
+---
+
+## Alignment status (at a glance)
+
+| Entity | Validation | Upsert semantics | Field shape | Status |
+|---|---|---|---|---|
+| sections | ✅ both paths | ✅ both upsert | ⚠️ web keeps `section`, SQLite drops it | UI fixed by reading `sectiontype` |
+| events | ⚠️ web only | ⚠️ SQLite uses plain `INSERT` (no OR REPLACE) | ✅ same fields | **Two gaps still** |
+| attendance | ✅ both paths | ✅ both upsert (after recent fix) | ✅ aligned (since migration 002) | OK |
+| shared attendance | ✅ both paths | ✅ both upsert (after recent fix) | ✅ aligned | OK |
+| members | ❌ neither path validates | ✅ both upsert | ⚠️ structurally different (dual-store vs single table + JSON) | **By design** — read paths reassemble |
+| terms | ⚠️ web only | ⚠️ SQLite uses plain `INSERT` | ✅ same fields | Same gap as events |
+| flexi_lists | ✅ both paths | ✅ both upsert | ✅ aligned | OK |
+| flexi_data | ✅ both paths | ⚠️ SQLite uses plain `INSERT` | ✅ aligned | Upsert gap |
+| flexi_structure | ✅ both paths | ✅ INSERT OR REPLACE single row | ✅ aligned | OK |
+
+### Concrete follow-ups
+
+1. **Switch to `INSERT OR REPLACE`** in `saveEvents`, `saveTerms`, `saveFlexiData` SQLite paths. Same UNIQUE-constraint trap as the attendance/sections bug.
+2. **Lift validation above the `isNative` branch** in `saveEvents` and `saveTerms` (so iOS gets validated too — matches the pattern `saveAttendance` already uses).
+3. **Strengthen the schema-parity test** (Layer 2) to flag plain `INSERT INTO` (vs `INSERT OR REPLACE INTO`) on tables that are bulk-rewritten via DELETE+INSERT — would catch (1) at static-analysis time.
+
+---
+
+_Last updated: 2026-04-28. Maintainer note: when adding a new save path, add a node to the relevant diagram and a row to the alignment table — keeps both backends visible to reviewers._

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -12,6 +12,8 @@
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
         "autoprefixer": "^10.4.21",
+        "better-sqlite3": "^12.9.0",
         "cypress": "^14.5.0",
         "documentation": "^14.0.3",
         "eslint": "^9.29.0",
@@ -4367,6 +4368,21 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -4384,6 +4400,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -7398,6 +7424,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
     "autoprefixer": "^10.4.21",
+    "better-sqlite3": "^12.9.0",
     "cypress": "^14.5.0",
     "documentation": "^14.0.3",
     "eslint": "^9.29.0",

--- a/src/features/auth/hooks/useAuth.jsx
+++ b/src/features/auth/hooks/useAuth.jsx
@@ -117,8 +117,8 @@ function useAuthLogic() {
       authService.setToken(accessToken);
       tokenStored = true;
       broadcastAuthSync();
-      sessionStorage.removeItem('token_expired');
-      sessionStorage.removeItem('token_invalid');
+      localStorage.removeItem('token_expired');
+      localStorage.removeItem('token_invalid');
       setHasHandledExpiredToken(false);
       localStorage.removeItem('token_expiration_choice');
       if (tokenType) {
@@ -143,7 +143,7 @@ function useAuthLogic() {
         }, LOG_CATEGORIES.AUTH);
       }
 
-      sessionStorage.setItem('token_expires_at', expirationTime.toString());
+      localStorage.setItem('token_expires_at', expirationTime.toString());
 
       if (source === 'url') {
         try {
@@ -411,7 +411,7 @@ function useAuthLogic() {
 
       // Check if token exists (including expired tokens stored in sessionStorage)
       const hasValidToken = authService.isAuthenticated();
-      const hasStoredToken = !!sessionStorage.getItem('access_token'); // Check for any stored token
+      const hasStoredToken = !!localStorage.getItem('access_token'); // Check for any stored token
       const tokenExpired = isTokenExpired();
       
 
@@ -642,7 +642,7 @@ function useAuthLogic() {
 
   // Helper function to check cached data and show expiration dialog
   const checkAndShowExpirationDialog = useCallback(async () => {
-    const hasStoredToken = !!sessionStorage.getItem('access_token');
+    const hasStoredToken = !!localStorage.getItem('access_token');
     const tokenExpired = isTokenExpired();
     const hasStoredChoice = localStorage.getItem('token_expiration_choice');
     
@@ -680,7 +680,7 @@ function useAuthLogic() {
 
   // Periodic token expiration monitoring
   useEffect(() => {
-    if (!sessionStorage.getItem('access_token')) {
+    if (!localStorage.getItem('access_token')) {
       return; // No token to monitor
     }
 
@@ -729,7 +729,7 @@ function useAuthLogic() {
     
     try {
       // Update auth state to reflect token expiration and offline mode
-      const hadToken = !!sessionStorage.getItem('access_token');
+      const hadToken = !!localStorage.getItem('access_token');
       const newAuthState = await determineAuthState(hadToken);
       setAuthState(newAuthState);
       setIsOfflineMode(true);

--- a/src/features/auth/services/auth.js
+++ b/src/features/auth/services/auth.js
@@ -60,7 +60,7 @@ import { IndexedDBService } from '../../../shared/services/storage/indexedDBServ
  * // Token expiration check
  * const checkAuth = () => {
  *   const token = getToken();
- *   if (!token && sessionStorage.getItem('token_expired') === 'true') {
+ *   if (!token && localStorage.getItem('token_expired') === 'true') {
  *     notifyWarning('Session expired. Please log in again.');
  *     handleTokenExpiration();
  *   }
@@ -75,12 +75,12 @@ export function getToken() {
   }
   
   // Don't return a token if it's been marked as expired
-  const tokenExpired = sessionStorage.getItem('token_expired') === 'true';
+  const tokenExpired = localStorage.getItem('token_expired') === 'true';
   if (tokenExpired) {
     return null;
   }
   
-  return sessionStorage.getItem('access_token');
+  return localStorage.getItem('access_token');
 }
 
 /**
@@ -125,7 +125,7 @@ export function getToken() {
  * @since 2.3.7
  */
 export function setToken(token) {
-  sessionStorage.setItem('access_token', token);
+  localStorage.setItem('access_token', token);
   
   // Reset auth error state when new token is set
   authHandler.reset();
@@ -182,10 +182,10 @@ export function setToken(token) {
  * @since 2.3.7
  */
 export function clearToken() {
-  sessionStorage.removeItem('access_token');
-  sessionStorage.removeItem('token_invalid');
-  sessionStorage.removeItem('token_expired');
-  sessionStorage.removeItem('token_expires_at');
+  localStorage.removeItem('access_token');
+  localStorage.removeItem('token_invalid');
+  localStorage.removeItem('token_expired');
+  localStorage.removeItem('token_expires_at');
   
   // Reset auth handler state when token is cleared
   authHandler.reset();
@@ -263,7 +263,7 @@ export function isAuthenticated() {
   }
   
   // Check if we've previously determined this token is invalid
-  const tokenInvalid = sessionStorage.getItem('token_invalid');
+  const tokenInvalid = localStorage.getItem('token_invalid');
   if (tokenInvalid === 'true') {
     // Token was marked as invalid, but don't clear it immediately
     // Let the auth flow decide when to clear it
@@ -287,7 +287,7 @@ export function isAuthenticated() {
  * // API response validation
  * const handleApiResponse = (response) => {
  *   if (!isTokenValid(response)) {
- *     sessionStorage.setItem('token_invalid', 'true');
+ *     localStorage.setItem('token_invalid', 'true');
  *     notifyError('Session expired. Please log in again.');
  *     handleTokenExpiration();
  *     return;
@@ -330,7 +330,7 @@ export function handleTokenExpiration() {
   // DON'T clear offline cached data when token expires
   // The offline data should remain available for offline access
   // Only clear session-specific data
-  sessionStorage.removeItem('token_invalid');
+  localStorage.removeItem('token_invalid');
     
   // Instead of reloading, we'll let React handle the state change
   // The useAuth hook will detect the token removal and update accordingly
@@ -510,7 +510,7 @@ export async function fetchUserInfoFromAPI() {
   try {
     // Direct sessionStorage access intentional - this function fetches user info 
     // regardless of token expiration status (for API calls vs general auth checks)
-    const token = sessionStorage.getItem('access_token');
+    const token = localStorage.getItem('access_token');
     if (!token) {
       throw new Error('No authentication token available');
     }
@@ -606,8 +606,8 @@ export async function validateToken() {
     // Real validation happens when actual API calls are made
     
     // Clear any invalid token flag since we're assuming the token is good
-    sessionStorage.removeItem('token_invalid');
-    sessionStorage.removeItem('token_expired');
+    localStorage.removeItem('token_invalid');
+    localStorage.removeItem('token_expired');
     
     return true;
         
@@ -672,9 +672,9 @@ export async function handleApiAuthError(error) {
     
     if (hasCachedData) {
       logger.info('API auth failed but cached data available - enabling offline mode', {}, LOG_CATEGORIES.AUTH);
-      sessionStorage.setItem('token_expired', 'true');
+      localStorage.setItem('token_expired', 'true');
       // Prevent stale/negative countdown while offline
-      sessionStorage.removeItem('token_expires_at');
+      localStorage.removeItem('token_expires_at');
       return { offline: true, shouldReload: true };
     } else {
       logger.info('API auth failed with no cached data - full logout required', {}, LOG_CATEGORIES.AUTH);
@@ -688,7 +688,7 @@ export async function handleApiAuthError(error) {
 
 // Guard function to check if write operations are allowed
 export function checkWritePermission() {
-  if (sessionStorage.getItem('token_expired') === 'true') {
+  if (localStorage.getItem('token_expired') === 'true') {
     throw new Error('Write operations are not allowed while in offline mode with expired token');
   }
 }

--- a/src/features/sections/components/SectionsList.jsx
+++ b/src/features/sections/components/SectionsList.jsx
@@ -349,7 +349,7 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
                 .slice()
                 .sort((a, b) => {
                   const getSectionOrder = (sectionType) => {
-                    const type = sectionType.toLowerCase();
+                    const type = (sectionType ?? '').toLowerCase();
                     if (type.includes('earlyyears')) return 1;
                     if (type.includes('beavers')) return 2;
                     if (type.includes('cubs')) return 3;
@@ -359,7 +359,7 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
                     return 7;
                   };
                   const getDayOrder = (sectionName) => {
-                    const name = sectionName.toLowerCase();
+                    const name = (sectionName ?? '').toLowerCase();
                     if (name.includes('monday')) return 1;
                     if (name.includes('tuesday')) return 2;
                     if (name.includes('wednesday')) return 3;
@@ -369,8 +369,8 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
                     if (name.includes('sunday')) return 7;
                     return 8;
                   };
-                  const ao = getSectionOrder(a.section);
-                  const bo = getSectionOrder(b.section);
+                  const ao = getSectionOrder(a.sectiontype);
+                  const bo = getSectionOrder(b.sectiontype);
                   return ao !== bo ? ao - bo : getDayOrder(a.sectionname) - getDayOrder(b.sectionname);
                 })
                 .map((section) => {

--- a/src/shared/components/TokenCountdown.jsx
+++ b/src/shared/components/TokenCountdown.jsx
@@ -13,7 +13,7 @@ function TokenCountdown({ authState, className = '', compact = false }) {
     }
 
     const updateCountdown = () => {
-      const expiresAt = sessionStorage.getItem('token_expires_at');
+      const expiresAt = localStorage.getItem('token_expires_at');
       if (!expiresAt) {
         setTimeRemaining(null);
         setDisplayText('');

--- a/src/shared/services/api/api/events.js
+++ b/src/shared/services/api/api/events.js
@@ -14,6 +14,7 @@ import { authHandler } from '../../auth/authHandler.js';
 import databaseService from '../../storage/database.js';
 import IndexedDBService from '../../storage/indexedDBService.js';
 import logger, { LOG_CATEGORIES } from '../../utils/logger.js';
+import { sentryUtils } from '../../utils/sentry.js';
 
 /**
  * Retrieves events for a specific section and term
@@ -419,7 +420,13 @@ export async function getSharedEventAttendance(eventId, sectionId, token) {
 
       logger.debug('Saved shared attendance to normalized store', { eventId, sectionId }, LOG_CATEGORIES.API);
     } catch (cacheError) {
-      logger.warn('Failed to save shared attendance to normalized store', { error: cacheError }, LOG_CATEGORIES.API);
+      logger.warn(`Failed to save shared attendance to normalized store (eventId=${eventId}): ${cacheError?.message || cacheError}`, { error: cacheError?.message, stack: cacheError?.stack }, LOG_CATEGORIES.API);
+      if (cacheError instanceof Error) {
+        sentryUtils.captureException(cacheError, {
+          tags: { operation: 'save_shared_attendance' },
+          contexts: { event: { id: String(eventId), sectionId: String(sectionId) } },
+        });
+      }
     }
 
     return data;

--- a/src/shared/services/auth/tokenService.js
+++ b/src/shared/services/auth/tokenService.js
@@ -12,16 +12,16 @@ export function getToken() {
     return 'demo-mode-token';
   }
   
-  const tokenExpired = sessionStorage.getItem('token_expired') === 'true';
+  const tokenExpired = localStorage.getItem('token_expired') === 'true';
   if (tokenExpired) {
     return null;
   }
   
-  return sessionStorage.getItem('access_token');
+  return localStorage.getItem('access_token');
 }
 
 export function setToken(token) {
-  sessionStorage.setItem('access_token', token);
+  localStorage.setItem('access_token', token);
   
   // Reset auth error state when new token is set
   authHandler.reset();
@@ -41,10 +41,10 @@ export function setToken(token) {
 }
 
 export function clearToken() {
-  sessionStorage.removeItem('access_token');
-  sessionStorage.removeItem('token_invalid');
-  sessionStorage.removeItem('token_expired');
-  sessionStorage.removeItem('token_expires_at');
+  localStorage.removeItem('access_token');
+  localStorage.removeItem('token_invalid');
+  localStorage.removeItem('token_expired');
+  localStorage.removeItem('token_expires_at');
   
   // Reset auth handler state when token is cleared
   authHandler.reset();
@@ -61,10 +61,10 @@ export function clearToken() {
 }
 
 export function isTokenExpired() {
-  const expiresAt = sessionStorage.getItem('token_expires_at');
+  const expiresAt = localStorage.getItem('token_expires_at');
   if (!expiresAt) {
     // No expiration time stored - fall back to existing token_expired flag
-    return sessionStorage.getItem('token_expired') === 'true';
+    return localStorage.getItem('token_expired') === 'true';
   }
   
   const expirationTime = parseInt(expiresAt, 10);
@@ -73,11 +73,11 @@ export function isTokenExpired() {
   if (!Number.isFinite(expirationTime)) {
     logger.warn('Corrupt token expiration time detected in API validation', {
       corruptValue: expiresAt,
-      tokenExpiredFlag: sessionStorage.getItem('token_expired'),
+      tokenExpiredFlag: localStorage.getItem('token_expired'),
     }, LOG_CATEGORIES.AUTH);
     
     // Treat corrupt expiration as expired for safety and consistency
-    sessionStorage.setItem('token_expired', 'true');
+    localStorage.setItem('token_expired', 'true');
     return true;
   }
   
@@ -85,24 +85,24 @@ export function isTokenExpired() {
   const isExpired = now >= expirationTime;
   
   // If expired, set the token_expired flag for consistency with existing code
-  if (isExpired && sessionStorage.getItem('token_expired') !== 'true') {
+  if (isExpired && localStorage.getItem('token_expired') !== 'true') {
     logger.info('Token expiration detected during API validation', {
       now,
       expirationTime,
       expired: true,
     }, LOG_CATEGORIES.AUTH);
-    sessionStorage.setItem('token_expired', 'true');
+    localStorage.setItem('token_expired', 'true');
   }
   
   return isExpired;
 }
 
 export function markTokenAsExpired() {
-  sessionStorage.setItem('token_expired', 'true');
+  localStorage.setItem('token_expired', 'true');
 }
 
 export function markTokenAsValid() {
-  sessionStorage.removeItem('token_expired');
+  localStorage.removeItem('token_expired');
 }
 
 export function generateOAuthUrl(storeCurrentPath = false) {
@@ -131,7 +131,7 @@ export function generateOAuthUrl(storeCurrentPath = false) {
 }
 
 export function checkWritePermission() {
-  if (sessionStorage.getItem('token_expired') === 'true') {
+  if (localStorage.getItem('token_expired') === 'true') {
     throw new Error('Write operations are not allowed while in offline mode with expired token');
   }
 }
@@ -155,7 +155,7 @@ export async function validateToken() {
     logger.info('Token found - assuming valid until API calls prove otherwise', {}, LOG_CATEGORIES.AUTH);
     
     // Clear any invalid token flag since we're assuming the token is good
-    sessionStorage.removeItem('token_invalid');
+    localStorage.removeItem('token_invalid');
     return true;
   } catch (error) {
     logger.error('Token validation failed', { 

--- a/src/shared/services/data/eventDataLoader.js
+++ b/src/shared/services/data/eventDataLoader.js
@@ -2,6 +2,7 @@ import { getEventAttendance, getSharedEventAttendance, createMemberSectionRecord
 import { getToken } from '../auth/tokenService.js';
 import databaseService from '../storage/database.js';
 import logger, { LOG_CATEGORIES } from '../utils/logger.js';
+import { sentryUtils } from '../utils/sentry.js';
 import { getScoutFriendlyMessage } from '../../utils/scoutErrorHandler.js';
 
 class EventDataLoader {
@@ -117,11 +118,19 @@ class EventDataLoader {
             eventName: event.name,
             error: result.reason?.message || 'Unknown error',
           });
-          logger.warn('Failed to sync attendance for event', {
+          const reasonMsg = result.reason?.message || String(result.reason);
+          logger.warn(`Failed to sync attendance for event "${event.name}" (id=${event.eventid}): ${reasonMsg}`, {
             eventName: event.name,
             eventId: event.eventid,
             error: result.reason?.message,
+            stack: result.reason?.stack,
           }, LOG_CATEGORIES.DATA_SERVICE);
+          if (result.reason instanceof Error) {
+            sentryUtils.captureException(result.reason, {
+              tags: { operation: 'sync_event_attendance' },
+              contexts: { event: { id: String(event.eventid), name: event.name, sectionid: event.sectionid } },
+            });
+          }
         }
       });
 

--- a/src/shared/services/storage/__tests__/databaseService.sqlite.test.js
+++ b/src/shared/services/storage/__tests__/databaseService.sqlite.test.js
@@ -1,0 +1,274 @@
+/**
+ * SQLite (iOS code path) integration tests for DatabaseService.
+ *
+ * Backs the @capacitor-community/sqlite plugin with better-sqlite3 in-memory
+ * so we can exercise the real SQL the app runs on iOS. Catches schema drift,
+ * INSERT-vs-UPSERT mistakes, and write/read round-trip regressions without
+ * needing a device.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+
+let activeDb = null;
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => 'ios',
+  },
+}));
+
+vi.mock('@capacitor-community/sqlite', () => {
+  const makeConnection = () => ({
+    open: async () => {},
+    close: async () => {},
+    execute: async (sql) => {
+      activeDb.exec(sql);
+      return { changes: { changes: 0 } };
+    },
+    run: async (sql, values = []) => {
+      const safeValues = (values || []).map(v => v === undefined ? null : v);
+      const stmt = activeDb.prepare(sql);
+      const info = stmt.run(...safeValues);
+      return { changes: { changes: info.changes, lastId: Number(info.lastInsertRowid) } };
+    },
+    query: async (sql, values = []) => {
+      const safeValues = (values || []).map(v => v === undefined ? null : v);
+      const stmt = activeDb.prepare(sql);
+      const rows = stmt.all(...safeValues);
+      return { values: rows };
+    },
+  });
+
+  function SQLiteConnection() {
+    return {
+      checkConnectionsConsistency: async () => ({ result: true }),
+      isConnection: async () => ({ result: false }),
+      retrieveConnection: async () => makeConnection(),
+      createConnection: async () => makeConnection(),
+    };
+  }
+
+  return {
+    CapacitorSQLite: {},
+    SQLiteConnection,
+  };
+});
+
+async function loadFreshDatabaseService() {
+  vi.resetModules();
+  const mod = await import('../database.js');
+  return mod.default;
+}
+
+describe('DatabaseService — SQLite (iOS code path)', () => {
+  beforeEach(() => {
+    activeDb = new Database(':memory:');
+    // Match @capacitor-community/sqlite production default — foreign keys
+    // are NOT enforced. better-sqlite3 enables them by default; turn off so
+    // tests reflect real iOS behaviour.
+    activeDb.pragma('foreign_keys = OFF');
+  });
+
+  afterEach(() => {
+    if (activeDb) {
+      activeDb.close();
+      activeDb = null;
+    }
+  });
+
+  describe('Fresh install schema', () => {
+    it('creates all expected tables', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      const tables = activeDb
+        .prepare('SELECT name FROM sqlite_master WHERE type=\'table\' ORDER BY name')
+        .all()
+        .map(t => t.name);
+
+      for (const required of ['sections', 'events', 'attendance', 'members', 'sync_status']) {
+        expect(tables).toContain(required);
+      }
+    });
+
+    it('attendance table has every column the code references', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      const cols = new Set(
+        activeDb.prepare('PRAGMA table_info(attendance)').all().map(c => c.name),
+      );
+
+      for (const required of [
+        'eventid', 'scoutid', 'sectionid', 'attending',
+        'patrol', 'notes', 'isSharedSection',
+      ]) {
+        expect(cols.has(required)).toBe(true);
+      }
+    });
+  });
+
+  describe('Schema drift regression (production bug 2026-04-28)', () => {
+    /**
+     * Reproduces the exact failure mode from production:
+     * - User installed an older build that created `attendance` without
+     *   `sectionid` and `isSharedSection` columns.
+     * - Newer build's INSERT references both columns.
+     * - `CREATE TABLE IF NOT EXISTS` does NOT alter existing tables, so the
+     *   columns stayed missing → all attendance writes failed silently with
+     *   "table attendance has no column named sectionid".
+     */
+    function preCreateOldAttendanceTable() {
+      activeDb.exec(`
+        CREATE TABLE attendance (
+          eventid TEXT NOT NULL,
+          scoutid INTEGER NOT NULL,
+          attending TEXT,
+          patrol TEXT,
+          notes TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY (eventid, scoutid)
+        );
+      `);
+    }
+
+    it('detects and adds missing sectionid + isSharedSection columns on init', async () => {
+      preCreateOldAttendanceTable();
+
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      const cols = new Set(
+        activeDb.prepare('PRAGMA table_info(attendance)').all().map(c => c.name),
+      );
+      expect(cols.has('sectionid')).toBe(true);
+      expect(cols.has('isSharedSection')).toBe(true);
+    });
+
+    it('saveAttendance succeeds against a pre-existing old-schema table after migration', async () => {
+      preCreateOldAttendanceTable();
+
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      const records = [
+        { scoutid: 1, eventid: '100', sectionid: 5, attending: 'Yes', patrol: 'Eagle', notes: null },
+        { scoutid: 2, eventid: '100', sectionid: 5, attending: 'No', patrol: 'Hawk', notes: null },
+      ];
+
+      await expect(databaseService.saveAttendance('100', records)).resolves.toBeUndefined();
+
+      const stored = activeDb.prepare('SELECT * FROM attendance ORDER BY scoutid').all();
+      expect(stored.length).toBe(2);
+      expect(stored[0].sectionid).toBe(5);
+      expect(stored[0].isSharedSection).toBe(0);
+    });
+
+    it('saveSharedAttendance survives DELETE WHERE isSharedSection = 1 against migrated old table', async () => {
+      preCreateOldAttendanceTable();
+
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      // Calling without throwing is the assertion — the production failure
+      // was "no such column: isSharedSection" on the DELETE filter.
+      const records = [
+        { scoutid: 99, eventid: '100', sectionid: 7, attending: 'Yes', patrol: null, notes: null, isSharedSection: true },
+      ];
+      await expect(databaseService.saveSharedAttendance('100', records)).resolves.toBeUndefined();
+
+      const stored = activeDb.prepare('SELECT * FROM attendance').all();
+      expect(stored.length).toBe(1);
+      expect(stored[0].isSharedSection).toBe(1);
+    });
+  });
+
+  describe('Save + read round-trip', () => {
+    it('saveAttendance + getAttendance preserves core fields', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      const records = [
+        { scoutid: 1, eventid: '100', sectionid: 5, attending: 'Yes', patrol: 'Eagle', notes: 'late' },
+        { scoutid: 2, eventid: '100', sectionid: 5, attending: 'No', patrol: 'Hawk', notes: null },
+      ];
+
+      await databaseService.saveAttendance('100', records);
+      const got = await databaseService.getAttendance('100');
+
+      expect(got.length).toBe(2);
+      expect(got.find(r => r.scoutid === 1)?.attending).toBe('Yes');
+      expect(got.find(r => r.scoutid === 1)?.notes).toBe('late');
+      expect(got.find(r => r.scoutid === 2)?.attending).toBe('No');
+    });
+
+    it('saveSections + getSections round-trips correctly', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      await databaseService.saveSections([
+        { sectionid: 1, sectionname: 'Beavers Mon', sectiontype: 'beavers' },
+        { sectionid: 2, sectionname: 'Cubs Tue', sectiontype: 'cubs' },
+      ]);
+
+      const got = await databaseService.getSections();
+      expect(got.length).toBe(2);
+      expect(got.map(s => s.sectionname).sort()).toEqual(['Beavers Mon', 'Cubs Tue']);
+    });
+
+    it('saveEvents + getEvents scopes to sectionId', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      await databaseService.saveEvents(5, [
+        { eventid: '100', name: 'Camp', startdate: '2026-05-01', termid: 't1' },
+        { eventid: '101', name: 'Hike', startdate: '2026-05-08', termid: 't1' },
+      ]);
+      await databaseService.saveEvents(7, [
+        { eventid: '200', name: 'Other section camp', startdate: '2026-06-01', termid: 't1' },
+      ]);
+
+      const sec5 = await databaseService.getEvents(5);
+      const sec7 = await databaseService.getEvents(7);
+
+      expect(sec5.length).toBe(2);
+      expect(sec7.length).toBe(1);
+      expect(sec7[0].name).toBe('Other section camp');
+    });
+  });
+
+  describe('Duplicate input handling (INSERT OR REPLACE / UPSERT)', () => {
+    it('saveSections survives duplicate sectionid in input array', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      // Plain INSERT would throw UNIQUE constraint on second row; INSERT OR
+      // REPLACE matches IndexedDB put() upsert semantics.
+      await expect(databaseService.saveSections([
+        { sectionid: 1, sectionname: 'First', sectiontype: 'beavers' },
+        { sectionid: 1, sectionname: 'Duplicate', sectiontype: 'beavers' },
+      ])).resolves.toBeUndefined();
+
+      const stored = activeDb.prepare('SELECT * FROM sections').all();
+      expect(stored.length).toBe(1);
+      expect(stored[0].sectionname).toBe('Duplicate');
+    });
+
+    it('saveAttendance survives duplicate (eventid, scoutid) in input array', async () => {
+      const databaseService = await loadFreshDatabaseService();
+      await databaseService.initialize();
+
+      await expect(databaseService.saveAttendance('100', [
+        { scoutid: 1, eventid: '100', sectionid: 5, attending: 'Yes', patrol: 'Eagle' },
+        { scoutid: 1, eventid: '100', sectionid: 5, attending: 'No', patrol: 'Eagle' },
+      ])).resolves.toBeUndefined();
+
+      const stored = activeDb.prepare('SELECT * FROM attendance').all();
+      expect(stored.length).toBe(1);
+      expect(stored[0].attending).toBe('No');
+    });
+  });
+});

--- a/src/shared/services/storage/__tests__/migrationRunner.test.js
+++ b/src/shared/services/storage/__tests__/migrationRunner.test.js
@@ -1,0 +1,179 @@
+/**
+ * Migration runner tests.
+ *
+ * Backs the runner with better-sqlite3 in-memory and verifies idempotency,
+ * version-tracking persistence, ordering, and uniqueness validation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../migrationRunner.js';
+import { MIGRATIONS } from '../migrations/index.js';
+
+let activeDb = null;
+
+function makeAdapter(db) {
+  return {
+    execute: async (sql) => {
+      db.exec(sql);
+      return { changes: { changes: 0 } };
+    },
+    run: async (sql, values = []) => {
+      const safe = (values || []).map(v => v === undefined ? null : v);
+      const info = db.prepare(sql).run(...safe);
+      return { changes: { changes: info.changes, lastId: Number(info.lastInsertRowid) } };
+    },
+    query: async (sql, values = []) => {
+      const safe = (values || []).map(v => v === undefined ? null : v);
+      const rows = db.prepare(sql).all(...safe);
+      return { values: rows };
+    },
+  };
+}
+
+describe('migrationRunner', () => {
+  let adapter;
+
+  beforeEach(() => {
+    activeDb = new Database(':memory:');
+    activeDb.pragma('foreign_keys = OFF');
+    adapter = makeAdapter(activeDb);
+  });
+
+  afterEach(() => {
+    if (activeDb) {
+      activeDb.close();
+      activeDb = null;
+    }
+  });
+
+  describe('Production migrations applied to a fresh DB', () => {
+    it('applies all migrations in order and records versions', async () => {
+      const result = await runMigrations(adapter, MIGRATIONS);
+
+      const expectedVersions = MIGRATIONS.map(m => m.version).sort((a, b) => a - b);
+      expect(result.applied).toEqual(expectedVersions);
+      expect(result.skipped).toEqual([]);
+
+      const recorded = activeDb
+        .prepare('SELECT version FROM schema_migrations ORDER BY version')
+        .all()
+        .map(r => r.version);
+      expect(recorded).toEqual(expectedVersions);
+    });
+
+    it('produces all expected core tables', async () => {
+      await runMigrations(adapter, MIGRATIONS);
+      const tables = new Set(
+        activeDb.prepare('SELECT name FROM sqlite_master WHERE type=\'table\'')
+          .all()
+          .map(t => t.name),
+      );
+      for (const required of [
+        'sections', 'events', 'attendance', 'members', 'sync_status',
+        'event_dashboard', 'sync_metadata', 'terms', 'flexi_lists',
+        'flexi_structure', 'flexi_data', 'shared_event_metadata',
+        'schema_migrations',
+      ]) {
+        expect(tables.has(required)).toBe(true);
+      }
+    });
+
+    it('attendance table includes sectionid + isSharedSection on a fresh DB', async () => {
+      await runMigrations(adapter, MIGRATIONS);
+      const cols = new Set(
+        activeDb.prepare('PRAGMA table_info(attendance)').all().map(c => c.name),
+      );
+      expect(cols.has('sectionid')).toBe(true);
+      expect(cols.has('isSharedSection')).toBe(true);
+    });
+  });
+
+  describe('Idempotency', () => {
+    it('running twice applies pending migrations on the first call and skips all on the second', async () => {
+      const first = await runMigrations(adapter, MIGRATIONS);
+      const second = await runMigrations(adapter, MIGRATIONS);
+
+      expect(first.applied.length).toBe(MIGRATIONS.length);
+      expect(second.applied).toEqual([]);
+      expect(second.skipped).toEqual(MIGRATIONS.map(m => m.version).sort((a, b) => a - b));
+    });
+  });
+
+  describe('Pre-existing legacy schema (no schema_migrations table)', () => {
+    it('treats an old DB as version 0 and applies every migration', async () => {
+      // Simulate an old build that created attendance without the newer
+      // columns, no schema_migrations table tracked.
+      activeDb.exec(`
+        CREATE TABLE attendance (
+          eventid TEXT NOT NULL,
+          scoutid INTEGER NOT NULL,
+          attending TEXT,
+          patrol TEXT,
+          notes TEXT,
+          PRIMARY KEY (eventid, scoutid)
+        );
+      `);
+
+      const result = await runMigrations(adapter, MIGRATIONS);
+      expect(result.applied).toEqual(MIGRATIONS.map(m => m.version).sort((a, b) => a - b));
+
+      const cols = new Set(
+        activeDb.prepare('PRAGMA table_info(attendance)').all().map(c => c.name),
+      );
+      expect(cols.has('sectionid')).toBe(true);
+      expect(cols.has('isSharedSection')).toBe(true);
+    });
+  });
+
+  describe('Ordering and registration validation', () => {
+    it('applies migrations in version order even if registered out of order', async () => {
+      const calls = [];
+      const out = [
+        { version: 3, name: 'third', up: async () => { calls.push(3); } },
+        { version: 1, name: 'first', up: async () => { calls.push(1); } },
+        { version: 2, name: 'second', up: async () => { calls.push(2); } },
+      ];
+      await runMigrations(adapter, out);
+      expect(calls).toEqual([1, 2, 3]);
+    });
+
+    it('rejects duplicate versions', async () => {
+      const dup = [
+        { version: 1, name: 'a', up: async () => {} },
+        { version: 1, name: 'b', up: async () => {} },
+      ];
+      await expect(runMigrations(adapter, dup)).rejects.toThrow(/Duplicate migration version/);
+    });
+
+    it('rejects non-positive or non-integer versions', async () => {
+      await expect(runMigrations(adapter, [{ version: 0, name: 'zero', up: async () => {} }]))
+        .rejects.toThrow(/invalid version/);
+      await expect(runMigrations(adapter, [{ version: 1.5, name: 'frac', up: async () => {} }]))
+        .rejects.toThrow(/invalid version/);
+    });
+  });
+
+  describe('Partial application', () => {
+    it('applies only pending versions when some are already recorded', async () => {
+      // Pretend version 1 has already been applied previously.
+      adapter.execute(`
+        CREATE TABLE schema_migrations (
+          version INTEGER PRIMARY KEY, name TEXT NOT NULL,
+          applied_at DATETIME DEFAULT CURRENT_TIMESTAMP);
+      `);
+      activeDb.prepare('INSERT INTO schema_migrations (version, name) VALUES (?, ?)').run(1, 'manual_seed');
+
+      const calls = [];
+      const migrations = [
+        { version: 1, name: 'one', up: async () => { calls.push(1); } },
+        { version: 2, name: 'two', up: async () => { calls.push(2); } },
+      ];
+
+      const result = await runMigrations(adapter, migrations);
+      expect(calls).toEqual([2]);
+      expect(result.applied).toEqual([2]);
+      expect(result.skipped).toEqual([1]);
+    });
+  });
+});

--- a/src/shared/services/storage/__tests__/schemaParity.test.js
+++ b/src/shared/services/storage/__tests__/schemaParity.test.js
@@ -1,0 +1,259 @@
+/**
+ * Static schema parity check.
+ *
+ * Parses every CREATE TABLE definition (in database.js and sqliteSchema.js)
+ * and the migration registry, then asserts every column referenced by an
+ * INSERT/REPLACE/DELETE/UPDATE in those same files exists in the table's
+ * declared column set.
+ *
+ * Catches the inverse of today's bug: code referencing a column that the
+ * schema (after migrations) never declares. Pure static analysis — no DB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * The schema is now defined by versioned migration files. Operations (INSERT,
+ * DELETE, UPDATE, SELECT) live in database.js. Both must agree.
+ *
+ * sqliteSchema.js is intentionally NOT included — it's superseded by the
+ * migrations folder and kept only as legacy.
+ */
+const MIGRATIONS_DIR = path.resolve(__dirname, '../migrations');
+const migrationFiles = readdirSync(MIGRATIONS_DIR)
+  .filter(f => f.endsWith('.js') && f !== 'index.js')
+  .map(f => path.join(MIGRATIONS_DIR, f));
+
+const SOURCES = [
+  path.resolve(__dirname, '../database.js'),
+  ...migrationFiles,
+];
+
+const combinedSource = SOURCES.map(p => readFileSync(p, 'utf-8')).join('\n\n');
+
+function splitTopLevelCommas(s) {
+  const parts = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of s) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+}
+
+function stripSqlComments(s) {
+  // Remove SQL line comments (-- to end of line) and block comments (/* ... */).
+  return s
+    .replace(/--[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function parseCreateTableColumns(columnsBlock) {
+  const TABLE_LEVEL_KEYWORDS = ['PRIMARY', 'FOREIGN', 'UNIQUE', 'CHECK', 'CONSTRAINT'];
+  const columns = [];
+  // Strip comments first — inline ones like `col TEXT, -- with, commas` will
+  // otherwise split mid-comment and produce phantom column names.
+  const cleaned = stripSqlComments(columnsBlock);
+  for (const part of splitTopLevelCommas(cleaned)) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const firstWord = trimmed.split(/\s+/, 1)[0].replace(/^[`"']|[`"']$/g, '').toUpperCase();
+    if (TABLE_LEVEL_KEYWORDS.includes(firstWord)) continue;
+    const nameMatch = trimmed.match(/^[`"']?(\w+)[`"']?/);
+    if (nameMatch) columns.push(nameMatch[1]);
+  }
+  return columns;
+}
+
+function extractCreateTables(text) {
+  const tables = {};
+  const regex = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(([\s\S]*?)\)\s*[;`]/gi;
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    const name = m[1];
+    const cols = parseCreateTableColumns(m[2]);
+    if (!tables[name]) tables[name] = new Set();
+    for (const c of cols) tables[name].add(c);
+  }
+  return tables;
+}
+
+function extractAlterAddColumns(text) {
+  const adds = [];
+  const regex = /ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)/gi;
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    adds.push({ table: m[1], column: m[2] });
+  }
+  return adds;
+}
+
+/**
+ * Reads applySchemaMigrations()'s requiredColumns registry. The registry is
+ * the source of truth for what columns must exist after migration; if a
+ * column is referenced by an INSERT but listed only there (not in any
+ * CREATE TABLE), the runtime will still ALTER it in.
+ */
+function extractMigrationRegistry(text) {
+  const adds = [];
+  const blockMatch = text.match(/requiredColumns\s*=\s*\{([\s\S]*?)\n\s*\};/);
+  if (!blockMatch) return adds;
+  const block = blockMatch[1];
+  const tableRegex = /(\w+)\s*:\s*\{([\s\S]*?)\}/g;
+  let tm;
+  while ((tm = tableRegex.exec(block)) !== null) {
+    const table = tm[1];
+    const colsBlock = tm[2];
+    const colMatches = colsBlock.matchAll(/(\w+)\s*:\s*['"`]/g);
+    for (const cm of colMatches) {
+      adds.push({ table, column: cm[1] });
+    }
+  }
+  return adds;
+}
+
+function buildSchemaIndex(text) {
+  const schemas = extractCreateTables(text);
+  for (const m of extractAlterAddColumns(text)) {
+    if (!schemas[m.table]) schemas[m.table] = new Set();
+    schemas[m.table].add(m.column);
+  }
+  for (const m of extractMigrationRegistry(text)) {
+    if (!schemas[m.table]) schemas[m.table] = new Set();
+    schemas[m.table].add(m.column);
+  }
+  return schemas;
+}
+
+function extractInserts(text) {
+  const inserts = [];
+  const regex = /(?:INSERT\s+OR\s+REPLACE\s+INTO|INSERT\s+INTO|REPLACE\s+INTO)\s+(\w+)\s*\(([^)]+)\)/gi;
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    const table = m[1];
+    const cols = m[2]
+      .split(',')
+      .map(c => c.trim().replace(/^[`"']|[`"']$/g, ''))
+      .filter(c => c && /^\w+$/.test(c));
+    inserts.push({ table, columns: cols });
+  }
+  return inserts;
+}
+
+function extractDeleteWhereColumns(text) {
+  const deletes = [];
+  // Capture WHERE clause until a SQL terminator we can recognise inside template strings.
+  const regex = /DELETE\s+FROM\s+(\w+)(?:\s+WHERE\s+([^`'"]+?)(?=`|'|"|;|$))?/gi;
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    const table = m[1];
+    const whereClause = (m[2] || '').trim();
+    if (!whereClause) {
+      deletes.push({ table, columns: [] });
+      continue;
+    }
+    const cols = [...whereClause.matchAll(/\b(\w+)\s*(?:=|<|>|!=|<>|IS|IN|LIKE)/gi)]
+      .map(mm => mm[1])
+      .filter(c => !['AND', 'OR', 'NOT', 'IS', 'IN', 'LIKE'].includes(c.toUpperCase()));
+    deletes.push({ table, columns: cols });
+  }
+  return deletes;
+}
+
+function extractUpdateSetColumns(text) {
+  const updates = [];
+  const regex = /UPDATE\s+(\w+)\s+SET\s+([\s\S]*?)(?:WHERE|`|'|"|;)/gi;
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    const table = m[1];
+    const setClause = m[2];
+    const cols = [...setClause.matchAll(/\b(\w+)\s*=/g)].map(mm => mm[1]);
+    updates.push({ table, columns: cols });
+  }
+  return updates;
+}
+
+describe('SQLite schema parity (static)', () => {
+  const schemas = buildSchemaIndex(combinedSource);
+
+  it('discovers a non-empty schema for the core tables', () => {
+    for (const t of ['sections', 'events', 'attendance', 'members', 'sync_status']) {
+      expect(schemas[t]).toBeDefined();
+      expect(schemas[t].size).toBeGreaterThan(0);
+    }
+  });
+
+  it('every column listed in an INSERT exists in the target table', () => {
+    const violations = [];
+    for (const { table, columns } of extractInserts(combinedSource)) {
+      const declared = schemas[table];
+      if (!declared) {
+        violations.push(`INSERT into unknown table "${table}"`);
+        continue;
+      }
+      for (const col of columns) {
+        if (!declared.has(col)) {
+          violations.push(
+            `INSERT INTO ${table} references column "${col}" not declared in schema. ` +
+            `Declared columns: [${[...declared].sort().join(', ')}]`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('every column referenced in a DELETE WHERE clause exists in the target table', () => {
+    const violations = [];
+    for (const { table, columns } of extractDeleteWhereColumns(combinedSource)) {
+      const declared = schemas[table];
+      if (!declared) {
+        violations.push(`DELETE from unknown table "${table}"`);
+        continue;
+      }
+      for (const col of columns) {
+        if (!declared.has(col)) {
+          violations.push(
+            `DELETE FROM ${table} references column "${col}" not declared in schema. ` +
+            `Declared columns: [${[...declared].sort().join(', ')}]`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('every column referenced in an UPDATE SET clause exists in the target table', () => {
+    const violations = [];
+    for (const { table, columns } of extractUpdateSetColumns(combinedSource)) {
+      const declared = schemas[table];
+      if (!declared) {
+        violations.push(`UPDATE on unknown table "${table}"`);
+        continue;
+      }
+      for (const col of columns) {
+        if (!declared.has(col)) {
+          violations.push(
+            `UPDATE ${table} SET references column "${col}" not declared in schema. ` +
+            `Declared columns: [${[...declared].sort().join(', ')}]`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/shared/services/storage/database.js
+++ b/src/shared/services/storage/database.js
@@ -22,7 +22,8 @@
 import { CapacitorSQLite, SQLiteConnection } from '@capacitor-community/sqlite';
 import { Capacitor } from '@capacitor/core';
 import IndexedDBService from './indexedDBService.js';
-import { SQLITE_SCHEMAS, SQLITE_INDEXES } from './schemas/sqliteSchema.js';
+import { runMigrations } from './migrationRunner.js';
+import { MIGRATIONS } from './migrations/index.js';
 import { SectionSchema, EventSchema, AttendanceSchema, SharedEventMetadataSchema, TermSchema, FlexiListSchema, FlexiStructureSchema, FlexiDataSchema, safeParseArray } from './schemas/validation.js';
 import { CurrentActiveTermsService } from './currentActiveTermsService.js';
 import { sentryUtils } from '../utils/sentry.js';
@@ -180,7 +181,7 @@ class DatabaseService {
       }
       
       await this.db.open();
-      await this.createTables();
+      await runMigrations(this.db, MIGRATIONS);
       this.isInitialized = true;
       logger.info('Database initialized successfully', {}, LOG_CATEGORIES.DATABASE);
     } catch (error) {
@@ -202,189 +203,6 @@ class DatabaseService {
       });
       this.isInitialized = true;
       this.isNative = false;
-    }
-  }
-
-  /**
-   * Creates database schema with all required tables
-   * 
-   * Establishes the complete database structure including sections, events,
-   * attendance, members, and sync tracking tables. Uses proper foreign key
-   * relationships and indexes for optimal performance. Only executed on
-   * native platforms with SQLite support.
-   * 
-   * Tables created:
-   * - sections: Scout sections (Beavers, Cubs, Scouts, etc.)
-   * - events: Section events with date ranges and locations
-   * - attendance: Event attendance records for individual scouts
-   * - members: Comprehensive scout member information
-   * - sync_status: Data synchronization tracking
-   * - event_dashboard: Aggregated event summary data
-   * - sync_metadata: Additional synchronization metadata
-   * 
-   * @async
-   * @private
-   * @returns {Promise<void>} Resolves when all tables are created
-   * @throws {Error} If table creation fails
-   * 
-   * @example
-   * // Called automatically during initialize()
-   * await this.createTables();
-   */
-  async createTables() {
-    const createSectionsTable = `
-      CREATE TABLE IF NOT EXISTS sections (
-        sectionid INTEGER PRIMARY KEY,
-        sectionname TEXT NOT NULL,
-        sectiontype TEXT,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-      );
-    `;
-
-    const createEventsTable = `
-      CREATE TABLE IF NOT EXISTS events (
-        eventid TEXT PRIMARY KEY,
-        sectionid INTEGER,
-        termid TEXT,
-        name TEXT NOT NULL,
-        date TEXT,
-        startdate TEXT,
-        startdate_g TEXT,
-        enddate TEXT,
-        enddate_g TEXT,
-        location TEXT,
-        notes TEXT,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (sectionid) REFERENCES sections (sectionid)
-      );
-    `;
-
-    const createAttendanceTable = `
-      CREATE TABLE IF NOT EXISTS attendance (
-        eventid TEXT NOT NULL,
-        scoutid INTEGER NOT NULL,
-        sectionid INTEGER,
-        attending TEXT,
-        patrol TEXT,
-        notes TEXT,
-        isSharedSection INTEGER DEFAULT 0,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        PRIMARY KEY (eventid, scoutid),
-        FOREIGN KEY (eventid) REFERENCES events (eventid)
-      );
-    `;
-
-    const createMembersTable = `
-      CREATE TABLE IF NOT EXISTS members (
-        scoutid INTEGER PRIMARY KEY,
-        -- Basic info
-        firstname TEXT,
-        lastname TEXT,
-        date_of_birth TEXT,
-        age TEXT,
-        age_years INTEGER,
-        age_months INTEGER,
-        
-        -- Section info
-        sectionid INTEGER,
-        sectionname TEXT,
-        section TEXT,
-        sections TEXT, -- JSON array of all sections this member belongs to
-        patrol TEXT,
-        patrol_id INTEGER,
-        person_type TEXT, -- Young People, Young Leaders, Leaders
-        
-        -- Membership dates
-        started TEXT,
-        joined TEXT,
-        end_date TEXT,
-        active BOOLEAN,
-        
-        -- Photo info
-        photo_guid TEXT,
-        has_photo BOOLEAN,
-        pic BOOLEAN,
-        
-        -- Role info
-        patrol_role_level INTEGER,
-        patrol_role_level_label TEXT,
-        
-        -- Contact info (basic)
-        email TEXT,
-        
-        -- Complex data stored as JSON
-        contact_groups TEXT, -- JSON blob of all contact groups
-        custom_data TEXT,    -- JSON blob of raw custom_data from OSM
-        flattened_fields TEXT, -- JSON blob of all flattened custom fields
-        
-        -- Metadata
-        read_only TEXT, -- JSON array
-        filter_string TEXT,
-        
-        -- Versioning and sync tracking
-        version INTEGER DEFAULT 1,
-        local_version INTEGER DEFAULT 1,
-        last_sync_version INTEGER DEFAULT 0,
-        is_locally_modified BOOLEAN DEFAULT 0,
-        last_synced_at DATETIME,
-        conflict_resolution_needed BOOLEAN DEFAULT 0,
-
-        -- Timestamps
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-      );
-    `;
-
-    const createSyncStatusTable = `
-      CREATE TABLE IF NOT EXISTS sync_status (
-        table_name TEXT PRIMARY KEY,
-        last_sync DATETIME,
-        needs_sync INTEGER DEFAULT 0
-      );
-    `;
-
-    const createEventDashboardTable = `
-      CREATE TABLE IF NOT EXISTS event_dashboard (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        event_id TEXT NOT NULL,
-        event_name TEXT NOT NULL,
-        section_id INTEGER NOT NULL,
-        section_name TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        attendance_summary TEXT,
-        last_updated DATETIME DEFAULT CURRENT_TIMESTAMP,
-        UNIQUE(event_id, section_id)
-      );
-    `;
-
-    const createSyncMetadataTable = `
-      CREATE TABLE IF NOT EXISTS sync_metadata (
-        key TEXT PRIMARY KEY,
-        value TEXT,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-      );
-    `;
-
-    await this.db.execute(createSectionsTable);
-    await this.db.execute(createEventsTable);
-    await this.db.execute(createAttendanceTable);
-    await this.db.execute(createMembersTable);
-    await this.db.execute(createSyncStatusTable);
-    await this.db.execute(createEventDashboardTable);
-    await this.db.execute(createSyncMetadataTable);
-
-    await this.db.execute(SQLITE_SCHEMAS.terms);
-    await this.db.execute(SQLITE_SCHEMAS.flexi_lists);
-    await this.db.execute(SQLITE_SCHEMAS.flexi_structure);
-    await this.db.execute(SQLITE_SCHEMAS.flexi_data);
-    await this.db.execute(SQLITE_SCHEMAS.shared_event_metadata);
-
-    for (const indexSql of SQLITE_INDEXES) {
-      await this.db.execute(indexSql);
     }
   }
 
@@ -435,7 +253,7 @@ class DatabaseService {
 
       for (const section of sections) {
         const insert = `
-          INSERT INTO sections (sectionid, sectionname, sectiontype)
+          INSERT OR REPLACE INTO sections (sectionid, sectionname, sectiontype)
           VALUES (?, ?, ?)
         `;
         await this.db.run(insert, [section.sectionid, section.sectionname, section.sectiontype], false);
@@ -692,10 +510,15 @@ class DatabaseService {
 
     const { data: validRecords, errors } = safeParseArray(AttendanceSchema, attendanceData);
     if (errors.length > 0) {
-      logger.warn('Attendance validation errors during save', {
+      const firstIssue = errors[0]?.issues?.[0];
+      const issuePath = (firstIssue?.path || []).join('.');
+      const sampleRecord = errors[0] ? attendanceData?.[errors[0].index] : null;
+      logger.warn(`Attendance validation: ${errors.length}/${attendanceData?.length} rejected — first issue "${firstIssue?.message}" at [${issuePath}] received=${JSON.stringify(firstIssue?.received ?? sampleRecord?.[firstIssue?.path?.[0]])}`, {
         errorCount: errors.length,
         totalCount: attendanceData?.length,
-        errors: errors.slice(0, 5),
+        firstIssue,
+        sampleRecord,
+        errors: errors.slice(0, 3),
       }, LOG_CATEGORIES.DATABASE);
     }
 
@@ -720,7 +543,7 @@ class DatabaseService {
 
       for (const record of validRecords) {
         const insert = `
-          INSERT INTO attendance (eventid, scoutid, sectionid, attending, patrol, notes, isSharedSection)
+          INSERT OR REPLACE INTO attendance (eventid, scoutid, sectionid, attending, patrol, notes, isSharedSection)
           VALUES (?, ?, ?, ?, ?, ?, ?)
         `;
         await this.db.run(insert, [
@@ -780,10 +603,15 @@ class DatabaseService {
 
     const { data: validRecords, errors } = safeParseArray(AttendanceSchema, markedData);
     if (errors.length > 0) {
-      logger.warn('Shared attendance validation errors during save', {
+      const firstIssue = errors[0]?.issues?.[0];
+      const issuePath = (firstIssue?.path || []).join('.');
+      const sampleRecord = errors[0] ? markedData?.[errors[0].index] : null;
+      logger.warn(`Shared attendance validation: ${errors.length}/${markedData?.length} rejected — first issue "${firstIssue?.message}" at [${issuePath}] received=${JSON.stringify(firstIssue?.received ?? sampleRecord?.[firstIssue?.path?.[0]])}`, {
         errorCount: errors.length,
         totalCount: attendanceData?.length,
-        errors: errors.slice(0, 5),
+        firstIssue,
+        sampleRecord,
+        errors: errors.slice(0, 3),
       }, LOG_CATEGORIES.DATABASE);
     }
 
@@ -825,7 +653,7 @@ class DatabaseService {
 
       for (const record of validRecords) {
         const insert = `
-          INSERT INTO attendance (eventid, scoutid, sectionid, attending, patrol, notes, isSharedSection)
+          INSERT OR REPLACE INTO attendance (eventid, scoutid, sectionid, attending, patrol, notes, isSharedSection)
           VALUES (?, ?, ?, ?, ?, ?, ?)
         `;
         await this.db.run(insert, [
@@ -1163,65 +991,67 @@ class DatabaseService {
       return;
     }
 
-    for (const member of members) {
-      const knownFields = new Set([
-        'scoutid', 'member_id', 'firstname', 'lastname', 'date_of_birth', 'age', 'age_years', 'age_months',
-        'sectionid', 'sectionname', 'section', 'sections', 'patrol', 'patrol_id', 'person_type',
-        'started', 'joined', 'end_date', 'active', 'photo_guid', 'has_photo', 'pic',
-        'patrol_role_level', 'patrol_role_level_label', 'email', 'contact_groups', 'custom_data',
-        'read_only', 'filter_string', '_filterString',
-      ]);
+    await this._runInTransaction(async () => {
+      for (const member of members) {
+        const knownFields = new Set([
+          'scoutid', 'member_id', 'firstname', 'lastname', 'date_of_birth', 'age', 'age_years', 'age_months',
+          'sectionid', 'sectionname', 'section', 'sections', 'patrol', 'patrol_id', 'person_type',
+          'started', 'joined', 'end_date', 'active', 'photo_guid', 'has_photo', 'pic',
+          'patrol_role_level', 'patrol_role_level_label', 'email', 'contact_groups', 'custom_data',
+          'read_only', 'filter_string', '_filterString',
+        ]);
 
-      const flattenedFields = {};
-      Object.keys(member).forEach(key => {
-        if (!knownFields.has(key)) {
-          flattenedFields[key] = member[key];
-        }
-      });
+        const flattenedFields = {};
+        Object.keys(member).forEach(key => {
+          if (!knownFields.has(key)) {
+            flattenedFields[key] = member[key];
+          }
+        });
 
-      const insert = `
-        REPLACE INTO members (
-          scoutid, firstname, lastname, date_of_birth, age, age_years, age_months,
-          sectionid, sectionname, section, sections, patrol, patrol_id, person_type,
-          started, joined, end_date, active, photo_guid, has_photo, pic,
-          patrol_role_level, patrol_role_level_label, email,
-          contact_groups, custom_data, flattened_fields, read_only, filter_string
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `;
+        const insert = `
+          REPLACE INTO members (
+            scoutid, firstname, lastname, date_of_birth, age, age_years, age_months,
+            sectionid, sectionname, section, sections, patrol, patrol_id, person_type,
+            started, joined, end_date, active, photo_guid, has_photo, pic,
+            patrol_role_level, patrol_role_level_label, email,
+            contact_groups, custom_data, flattened_fields, read_only, filter_string
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `;
 
-      await this.db.run(insert, [
-        member.scoutid || member.member_id,
-        member.firstname,
-        member.lastname,
-        member.date_of_birth,
-        member.age,
-        member.age_years,
-        member.age_months,
-        member.sectionid,
-        member.sectionname,
-        member.section,
-        JSON.stringify(member.sections || [], false),
-        member.patrol,
-        member.patrol_id,
-        member.person_type,
-        member.started,
-        member.joined,
-        member.end_date,
-        member.active,
-        member.photo_guid,
-        member.has_photo,
-        member.pic,
-        member.patrol_role_level,
-        member.patrol_role_level_label,
-        member.email,
-        JSON.stringify(member.contact_groups || {}),
-        JSON.stringify(member.custom_data || {}),
-        JSON.stringify(flattenedFields),
-        JSON.stringify(member.read_only || []),
-        member._filterString || member.filter_string,
-      ]);
-    }
+        await this.db.run(insert, [
+          member.scoutid || member.member_id,
+          member.firstname,
+          member.lastname,
+          member.date_of_birth,
+          member.age,
+          member.age_years,
+          member.age_months,
+          member.sectionid,
+          member.sectionname,
+          member.section,
+          JSON.stringify(member.sections || [], false),
+          member.patrol,
+          member.patrol_id,
+          member.person_type,
+          member.started,
+          member.joined,
+          member.end_date,
+          member.active,
+          member.photo_guid,
+          member.has_photo,
+          member.pic,
+          member.patrol_role_level,
+          member.patrol_role_level_label,
+          member.email,
+          JSON.stringify(member.contact_groups || {}),
+          JSON.stringify(member.custom_data || {}),
+          JSON.stringify(flattenedFields),
+          JSON.stringify(member.read_only || []),
+          member._filterString || member.filter_string,
+        ], false);
+      }
+    });
 
     await this.updateSyncStatus('members');
   }
@@ -1873,11 +1703,11 @@ class DatabaseService {
     }
 
     await this._runInTransaction(async () => {
-      await this.db.run('DELETE FROM flexi_lists WHERE sectionid = ?', [Number(sectionId)]);
+      await this.db.run('DELETE FROM flexi_lists WHERE sectionid = ?', [Number(sectionId)], false);
 
       for (const item of valid) {
         const insert = 'INSERT OR REPLACE INTO flexi_lists (sectionid, extraid, name) VALUES (?, ?, ?)';
-        await this.db.run(insert, [Number(item.sectionid), String(item.extraid), item.name]);
+        await this.db.run(insert, [Number(item.sectionid), String(item.extraid), item.name], false);
       }
     });
   }
@@ -2049,7 +1879,7 @@ class DatabaseService {
     }
 
     await this._runInTransaction(async () => {
-      await this.db.run('DELETE FROM flexi_data WHERE extraid = ? AND sectionid = ? AND termid = ?', [String(recordId), Number(sectionId), String(termId)]);
+      await this.db.run('DELETE FROM flexi_data WHERE extraid = ? AND sectionid = ? AND termid = ?', [String(recordId), Number(sectionId), String(termId)], false);
 
       for (const row of valid) {
         const { scoutid, firstname, lastname, ...rest } = row;
@@ -2062,7 +1892,7 @@ class DatabaseService {
           firstname || null,
           lastname || null,
           JSON.stringify(rest),
-        ]);
+        ], false);
       }
     });
   }

--- a/src/shared/services/storage/migrationRunner.js
+++ b/src/shared/services/storage/migrationRunner.js
@@ -1,0 +1,69 @@
+/**
+ * SQLite schema migration runner.
+ *
+ * Tracks applied migrations in a `schema_migrations` table and applies any
+ * pending ones in version order. Idempotent — safe to call on every startup.
+ *
+ * Each migration must export an object with shape:
+ *   { version: number, name: string, up: async (db) => Promise<void> }
+ */
+
+import logger, { LOG_CATEGORIES } from '../utils/logger.js';
+
+const SCHEMA_MIGRATIONS_DDL = `
+  CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+/**
+ * Apply pending migrations in version order. Skips already-applied versions.
+ *
+ * @param {Object} db - Capacitor SQLite connection (must support execute, run, query)
+ * @param {Array<{version:number,name:string,up:Function}>} migrations
+ * @returns {Promise<{applied:number[], skipped:number[]}>}
+ */
+export async function runMigrations(db, migrations) {
+  await db.execute(SCHEMA_MIGRATIONS_DDL);
+
+  const result = await db.query('SELECT version FROM schema_migrations');
+  const applied = new Set((result.values || []).map(row => row.version));
+
+  const ordered = [...migrations].sort((a, b) => a.version - b.version);
+  validateUniqueVersions(ordered);
+
+  const appliedNow = [];
+  const skipped = [];
+
+  for (const migration of ordered) {
+    if (applied.has(migration.version)) {
+      skipped.push(migration.version);
+      continue;
+    }
+    logger.info(`Applying migration ${migration.version}: ${migration.name}`, {}, LOG_CATEGORIES.DATABASE);
+    await migration.up(db);
+    await db.run(
+      'INSERT INTO schema_migrations (version, name) VALUES (?, ?)',
+      [migration.version, migration.name],
+      false,
+    );
+    appliedNow.push(migration.version);
+  }
+
+  return { applied: appliedNow, skipped };
+}
+
+function validateUniqueVersions(migrations) {
+  const seen = new Set();
+  for (const m of migrations) {
+    if (typeof m.version !== 'number' || !Number.isInteger(m.version) || m.version <= 0) {
+      throw new Error(`Migration "${m.name}" has invalid version: ${m.version}`);
+    }
+    if (seen.has(m.version)) {
+      throw new Error(`Duplicate migration version ${m.version} (name: "${m.name}")`);
+    }
+    seen.add(m.version);
+  }
+}

--- a/src/shared/services/storage/migrations/001-initial-schema.js
+++ b/src/shared/services/storage/migrations/001-initial-schema.js
@@ -1,0 +1,221 @@
+/**
+ * Migration 001 — initial schema snapshot.
+ *
+ * IMMUTABLE: Once shipped, this migration must never be edited. To change
+ * the schema, write a new migration with a higher version number.
+ *
+ * Captures the full schema as of the introduction of the migration system.
+ * Devices upgrading from a pre-migration build will already have these
+ * tables (CREATE TABLE IF NOT EXISTS is a no-op); new installs get them
+ * created here.
+ */
+
+const SECTIONS = `
+  CREATE TABLE IF NOT EXISTS sections (
+    sectionid INTEGER PRIMARY KEY,
+    sectionname TEXT NOT NULL,
+    sectiontype TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+const EVENTS = `
+  CREATE TABLE IF NOT EXISTS events (
+    eventid TEXT PRIMARY KEY,
+    sectionid INTEGER,
+    termid TEXT,
+    name TEXT NOT NULL,
+    date TEXT,
+    startdate TEXT,
+    startdate_g TEXT,
+    enddate TEXT,
+    enddate_g TEXT,
+    location TEXT,
+    notes TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sectionid) REFERENCES sections (sectionid)
+  );
+`;
+
+const ATTENDANCE = `
+  CREATE TABLE IF NOT EXISTS attendance (
+    eventid TEXT NOT NULL,
+    scoutid INTEGER NOT NULL,
+    sectionid INTEGER,
+    attending TEXT,
+    patrol TEXT,
+    notes TEXT,
+    isSharedSection INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (eventid, scoutid),
+    FOREIGN KEY (eventid) REFERENCES events (eventid)
+  );
+`;
+
+const MEMBERS = `
+  CREATE TABLE IF NOT EXISTS members (
+    scoutid INTEGER PRIMARY KEY,
+    firstname TEXT,
+    lastname TEXT,
+    date_of_birth TEXT,
+    age TEXT,
+    age_years INTEGER,
+    age_months INTEGER,
+    sectionid INTEGER,
+    sectionname TEXT,
+    section TEXT,
+    sections TEXT,
+    patrol TEXT,
+    patrol_id INTEGER,
+    person_type TEXT,
+    started TEXT,
+    joined TEXT,
+    end_date TEXT,
+    active BOOLEAN,
+    photo_guid TEXT,
+    has_photo BOOLEAN,
+    pic BOOLEAN,
+    patrol_role_level INTEGER,
+    patrol_role_level_label TEXT,
+    email TEXT,
+    contact_groups TEXT,
+    custom_data TEXT,
+    flattened_fields TEXT,
+    read_only TEXT,
+    filter_string TEXT,
+    version INTEGER DEFAULT 1,
+    local_version INTEGER DEFAULT 1,
+    last_sync_version INTEGER DEFAULT 0,
+    is_locally_modified BOOLEAN DEFAULT 0,
+    last_synced_at DATETIME,
+    conflict_resolution_needed BOOLEAN DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+const SYNC_STATUS = `
+  CREATE TABLE IF NOT EXISTS sync_status (
+    table_name TEXT PRIMARY KEY,
+    last_sync DATETIME,
+    needs_sync INTEGER DEFAULT 0
+  );
+`;
+
+const EVENT_DASHBOARD = `
+  CREATE TABLE IF NOT EXISTS event_dashboard (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL,
+    event_name TEXT NOT NULL,
+    section_id INTEGER NOT NULL,
+    section_name TEXT NOT NULL,
+    start_date TEXT NOT NULL,
+    end_date TEXT,
+    attendance_summary TEXT,
+    last_updated DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(event_id, section_id)
+  );
+`;
+
+const SYNC_METADATA = `
+  CREATE TABLE IF NOT EXISTS sync_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+const TERMS = `
+  CREATE TABLE IF NOT EXISTS terms (
+    termid TEXT PRIMARY KEY,
+    sectionid INTEGER,
+    name TEXT NOT NULL,
+    startdate TEXT,
+    enddate TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+const FLEXI_LISTS = `
+  CREATE TABLE IF NOT EXISTS flexi_lists (
+    extraid TEXT NOT NULL,
+    sectionid INTEGER NOT NULL,
+    name TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (extraid, sectionid)
+  );
+`;
+
+const FLEXI_STRUCTURE = `
+  CREATE TABLE IF NOT EXISTS flexi_structure (
+    extraid TEXT PRIMARY KEY,
+    name TEXT,
+    config TEXT,
+    structure TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+const FLEXI_DATA = `
+  CREATE TABLE IF NOT EXISTS flexi_data (
+    extraid TEXT NOT NULL,
+    sectionid INTEGER NOT NULL,
+    termid TEXT NOT NULL,
+    scoutid TEXT NOT NULL,
+    firstname TEXT,
+    lastname TEXT,
+    data TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (extraid, sectionid, termid, scoutid)
+  );
+`;
+
+const SHARED_EVENT_METADATA = `
+  CREATE TABLE IF NOT EXISTS shared_event_metadata (
+    eventid TEXT PRIMARY KEY,
+    is_shared_event INTEGER DEFAULT 1,
+    owner_section_id INTEGER,
+    sections TEXT,
+    updated_at INTEGER
+  );
+`;
+
+const INDEXES = [
+  'CREATE INDEX IF NOT EXISTS idx_events_sectionid ON events(sectionid)',
+  'CREATE INDEX IF NOT EXISTS idx_events_termid ON events(termid)',
+  'CREATE INDEX IF NOT EXISTS idx_events_startdate ON events(startdate)',
+  'CREATE INDEX IF NOT EXISTS idx_attendance_eventid ON attendance(eventid)',
+  'CREATE INDEX IF NOT EXISTS idx_attendance_scoutid ON attendance(scoutid)',
+  'CREATE INDEX IF NOT EXISTS idx_sections_sectiontype ON sections(sectiontype)',
+  'CREATE INDEX IF NOT EXISTS idx_terms_sectionid ON terms(sectionid)',
+  'CREATE INDEX IF NOT EXISTS idx_terms_startdate ON terms(startdate)',
+];
+
+export default {
+  version: 1,
+  name: 'initial_schema',
+  up: async (db) => {
+    await db.execute(SECTIONS);
+    await db.execute(EVENTS);
+    await db.execute(ATTENDANCE);
+    await db.execute(MEMBERS);
+    await db.execute(SYNC_STATUS);
+    await db.execute(EVENT_DASHBOARD);
+    await db.execute(SYNC_METADATA);
+    await db.execute(TERMS);
+    await db.execute(FLEXI_LISTS);
+    await db.execute(FLEXI_STRUCTURE);
+    await db.execute(FLEXI_DATA);
+    await db.execute(SHARED_EVENT_METADATA);
+    for (const indexSql of INDEXES) {
+      await db.execute(indexSql);
+    }
+  },
+};

--- a/src/shared/services/storage/migrations/002-add-attendance-columns.js
+++ b/src/shared/services/storage/migrations/002-add-attendance-columns.js
@@ -1,0 +1,35 @@
+/**
+ * Migration 002 — backfill attendance.sectionid and attendance.isSharedSection.
+ *
+ * IMMUTABLE: Once shipped, never edit. To make further changes, add a new
+ * migration with a higher version number.
+ *
+ * Background: Earlier builds shipped a `attendance` CREATE TABLE statement
+ * that lacked `sectionid` and `isSharedSection` columns. Those columns were
+ * later added to the CREATE TABLE in code, but `CREATE TABLE IF NOT EXISTS`
+ * does not modify pre-existing tables — so devices upgrading from an older
+ * build retained the old schema and every INSERT/DELETE referencing the new
+ * columns failed with `no such column`.
+ *
+ * Idempotent: checks PRAGMA table_info first so it's safe to re-run AND safe
+ * for fresh installs where migration 001 already creates the columns.
+ */
+
+async function getColumnSet(db, tableName) {
+  const info = await db.query(`PRAGMA table_info(${tableName})`);
+  return new Set((info.values || []).map(row => row.name));
+}
+
+export default {
+  version: 2,
+  name: 'add_attendance_sectionid_and_isSharedSection',
+  up: async (db) => {
+    const columns = await getColumnSet(db, 'attendance');
+    if (!columns.has('sectionid')) {
+      await db.execute('ALTER TABLE attendance ADD COLUMN sectionid INTEGER');
+    }
+    if (!columns.has('isSharedSection')) {
+      await db.execute('ALTER TABLE attendance ADD COLUMN isSharedSection INTEGER DEFAULT 0');
+    }
+  },
+};

--- a/src/shared/services/storage/migrations/index.js
+++ b/src/shared/services/storage/migrations/index.js
@@ -1,0 +1,16 @@
+/**
+ * Registry of database migrations, applied in version order on init.
+ *
+ * Add new migrations here as new files. Each migration must have a unique,
+ * monotonically increasing `version` and a stable `name`. Migrations are
+ * frozen once shipped — never edit a previously-released migration; create
+ * a new one instead.
+ */
+
+import migration001 from './001-initial-schema.js';
+import migration002 from './002-add-attendance-columns.js';
+
+export const MIGRATIONS = [
+  migration001,
+  migration002,
+];

--- a/src/shared/services/utils/sentry.js
+++ b/src/shared/services/utils/sentry.js
@@ -5,7 +5,7 @@ import { config } from '../../../config/env.js';
 
 // Environment configuration - Use robust detection from config
 const environment = config.actualEnvironment;
-const release = packageJson.version;
+const release = import.meta.env.VITE_APP_VERSION || packageJson.version;
 const sentryDsn = config.sentryDsn;
 
 // Initialize Sentry


### PR DESCRIPTION
## Summary

Bundled follow-up fixes after the initial iOS TestFlight rollout uncovered a chain of runtime issues, plus testing infrastructure to catch this class of bug in the future.

## Runtime fixes

### Auth token persistence (sessionStorage → localStorage)
WKWebView reclaims `sessionStorage` when iOS backgrounds the app, so users were being signed out. Migrated 4 token-related keys (`access_token`, `token_expired`, `token_expires_at`, `token_invalid`) to `localStorage` across `tokenService.js`, `useAuth.jsx`, `auth.js`, and `TokenCountdown.jsx`. `osm_blocked` and OAuth return-paths intentionally left on `sessionStorage`.

> **Note**: anyone with a token already cached on this build will be signed out once on first launch of the new build. After that, tokens persist across launches and backgrounding.

### SQLite UPSERT semantics
Several save paths were using plain `INSERT INTO` and silently rolling back transactions whenever the API returned duplicate `(eventid, scoutid)` or `sectionid` values. Switched to `INSERT OR REPLACE INTO` to match IndexedDB's `put()` upsert behaviour:
- `saveAttendance` (was wiping attendance on duplicate scout entries)
- `saveSharedAttendance` (same)
- `saveSections` (was throwing UNIQUE constraint on `/movers`)

### Concurrent-write transaction handling
- `saveMembers` native path was making un-queued `db.run()` calls that raced against any `_runInTransaction` writer, throwing "cannot start a transaction within a transaction". Now wrapped in `_runInTransaction` with `transaction:false` flags.
- `saveFlexiLists` / `saveFlexiData` were missing the `transaction:false` flag inside `_runInTransaction`. Added.

### Schema drift on attendance table
`CREATE TABLE IF NOT EXISTS attendance` doesn't update an existing table, so devices upgrading from an older build retained an `attendance` schema lacking `sectionid` and `isSharedSection` columns. Every INSERT/DELETE referencing those columns failed with `no such column`. Now resolved by the migration framework (below).

### SectionsList null-safety
`a.section` is never set on iOS SQLite-loaded section records (only set on web's IndexedDB-loaded ones). Switched the sort callback to use `a.sectiontype` (the canonical schema field both backends honour) and added `?? ''` null guards.

## Diagnostics

- **Sentry release tag** now reads `VITE_APP_VERSION` so it matches the UI version. Was diverging from `package.json` (the source for `sentry.js` previously), making it impossible to tell which build was reporting in Sentry.
- **WebView inspector** enabled via `webContentsDebuggingEnabled: true` in `capacitor.config.json`. ⚠️ Must be turned off before App Store submission — anyone with the IPA could otherwise inspect the JS bundle.
- **Validation warnings** in `saveAttendance` / `saveSharedAttendance` now inline the first `ZodError` issue path + received value into the message string itself, so the cause is visible in console without object expansion (which Sentry's log capture strips).
- **`captureException`** added to `eventDataLoader.syncEventAttendance` and `events.js` shared-attendance catch — silent warnings now surface as proper Sentry error events with stack traces.

## Migration framework (replaces ad-hoc `applySchemaMigrations`)

- `src/shared/services/storage/migrations/` — numbered migration files (`001-initial-schema.js`, `002-add-attendance-columns.js`). Each is **immutable** once shipped — schema changes go in new migrations, never edits to existing ones.
- `src/shared/services/storage/migrationRunner.js` — applies pending migrations in version order, tracks applied versions in a `schema_migrations` table. Idempotent; safe across upgrades from any prior schema version (including pre-migration-system devices).
- `database.js` `initialize()` now calls `runMigrations()`. `createTables()` and `applySchemaMigrations()` removed.

## Test infrastructure (+23 tests, total 416 passing)

| File | Tests | Purpose |
|---|---|---|
| `databaseService.sqlite.test.js` | 10 | Exercises the iOS code path against `better-sqlite3` in-memory. Includes the regression test for today's schema-drift bug. |
| `migrationRunner.test.js` | 9 | Version tracking, idempotency, ordering, validation, partial application. |
| `schemaParity.test.js` | 4 | Static check that every column referenced in INSERT/DELETE/UPDATE exists in some CREATE TABLE or migration. Catches the inverse bug class. |

`better-sqlite3` added as devDependency for the integration tests (test-only, not bundled).

## Test plan

- [ ] Lint clean: `npm run lint` (0 errors, 15 pre-existing warnings)
- [ ] All tests pass: `npm run test:run` (416 passing, 13 skipped)
- [ ] Production build succeeds: `npm run build`
- [ ] Native sync succeeds: `npx cap sync ios`
- [ ] On-device verification:
  - [ ] Sign in, see sections + events
  - [ ] Open `/events` — attendees populate per event
  - [ ] Open `/young-leaders` — no "No authentication token available" error
  - [ ] Open `/movers` — no UNIQUE constraint error
  - [ ] Background the app for 60s+, foreground — still signed in, data still loads
  - [ ] Sentry release tag shows `vikings-eventmgmt-mobile@2.12.5` (matches UI footer)

## Pre-merge cleanup needed

- [ ] **Turn off `webContentsDebuggingEnabled` before App Store release** (TestFlight only)
- [ ] Consider whether to keep verbose validation-error inline messages or pare back to just `captureException` (chatty in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)