### PR TITLE
fix(events): correct attendance counts for shared cross-section events

### DIFF
--- a/src/features/events/components/EventDashboard.jsx
+++ b/src/features/events/components/EventDashboard.jsx
@@ -23,6 +23,7 @@ import {
 } from '../../../shared/utils/eventDashboardHelpers.js';
 import { notifyError, notifySuccess, notifyInfo } from '../../../shared/utils/notifications.js';
 import { formatLastRefresh } from '../../../shared/utils/timeFormatting.js';
+import { dedupAttendanceForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
 
 function EventDashboard({ onNavigateToMembers, onNavigateToAttendance }) {
   const { lastSyncTime } = useAuth(); // Get shared lastSyncTime from auth context
@@ -465,10 +466,18 @@ function EventDashboard({ onNavigateToMembers, onNavigateToAttendance }) {
     // Convert groups to cards with attendance data
     const cards = [];
     for (const [eventName, events] of eventGroups) {
-      // Enrich events with attendance data without mutating originals
+      const allGroupRecords = events.flatMap((event) => attendanceMap.get(event.eventid) || []);
+      const dedupedRecords = dedupAttendanceForEventGroup(events, allGroupRecords);
+      const dedupedByEventId = new Map();
+      for (const record of dedupedRecords) {
+        const list = dedupedByEventId.get(String(record.eventid)) || [];
+        list.push(record);
+        dedupedByEventId.set(String(record.eventid), list);
+      }
+
       const eventsWithAttendance = events.map((event) => ({
         ...event,
-        attendanceData: attendanceMap.get(event.eventid) || [],
+        attendanceData: dedupedByEventId.get(String(event.eventid)) || [],
       }));
 
       const card = buildEventCard(eventName, eventsWithAttendance);

--- a/src/features/events/components/EventDashboard.jsx
+++ b/src/features/events/components/EventDashboard.jsx
@@ -23,7 +23,7 @@ import {
 } from '../../../shared/utils/eventDashboardHelpers.js';
 import { notifyError, notifySuccess, notifyInfo } from '../../../shared/utils/notifications.js';
 import { formatLastRefresh } from '../../../shared/utils/timeFormatting.js';
-import { dedupAttendanceForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
+import { dedupAttendanceMapForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
 
 function EventDashboard({ onNavigateToMembers, onNavigateToAttendance }) {
   const { lastSyncTime } = useAuth(); // Get shared lastSyncTime from auth context
@@ -466,15 +466,7 @@ function EventDashboard({ onNavigateToMembers, onNavigateToAttendance }) {
     // Convert groups to cards with attendance data
     const cards = [];
     for (const [eventName, events] of eventGroups) {
-      const allGroupRecords = events.flatMap((event) => attendanceMap.get(event.eventid) || []);
-      const dedupedRecords = dedupAttendanceForEventGroup(events, allGroupRecords);
-      const dedupedByEventId = new Map();
-      for (const record of dedupedRecords) {
-        const list = dedupedByEventId.get(String(record.eventid)) || [];
-        list.push(record);
-        dedupedByEventId.set(String(record.eventid), list);
-      }
-
+      const dedupedByEventId = dedupAttendanceMapForEventGroup(events, attendanceMap);
       const eventsWithAttendance = events.map((event) => ({
         ...event,
         attendanceData: dedupedByEventId.get(String(event.eventid)) || [],

--- a/src/features/events/components/EventsOverview.jsx
+++ b/src/features/events/components/EventsOverview.jsx
@@ -12,6 +12,7 @@ import {
   filterEventsByDateRange,
   expandSharedEvents,
 } from '../../../shared/utils/eventDashboardHelpers.js';
+import { dedupAttendanceForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
 import { useAuth } from '../../auth/hooks/useAuth.jsx';
 
 function EventsOverview({ onNavigateToAttendance: _onNavigateToAttendance }) {
@@ -118,10 +119,18 @@ function EventsOverview({ onNavigateToAttendance: _onNavigateToAttendance }) {
     // Convert groups to cards with attendance data
     const cards = [];
     for (const [eventName, events] of eventGroups) {
-      // Enrich events with attendance data without mutating originals
+      const allGroupRecords = events.flatMap((event) => attendanceMap.get(event.eventid) || []);
+      const dedupedRecords = dedupAttendanceForEventGroup(events, allGroupRecords);
+      const dedupedByEventId = new Map();
+      for (const record of dedupedRecords) {
+        const list = dedupedByEventId.get(String(record.eventid)) || [];
+        list.push(record);
+        dedupedByEventId.set(String(record.eventid), list);
+      }
+
       const eventsWithAttendance = events.map((event) => ({
         ...event,
-        attendanceData: attendanceMap.get(event.eventid) || [],
+        attendanceData: dedupedByEventId.get(String(event.eventid)) || [],
       }));
 
       const card = buildEventCard(eventName, eventsWithAttendance);

--- a/src/features/events/components/EventsOverview.jsx
+++ b/src/features/events/components/EventsOverview.jsx
@@ -12,7 +12,7 @@ import {
   filterEventsByDateRange,
   expandSharedEvents,
 } from '../../../shared/utils/eventDashboardHelpers.js';
-import { dedupAttendanceForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
+import { dedupAttendanceMapForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
 import { useAuth } from '../../auth/hooks/useAuth.jsx';
 
 function EventsOverview({ onNavigateToAttendance: _onNavigateToAttendance }) {
@@ -119,15 +119,7 @@ function EventsOverview({ onNavigateToAttendance: _onNavigateToAttendance }) {
     // Convert groups to cards with attendance data
     const cards = [];
     for (const [eventName, events] of eventGroups) {
-      const allGroupRecords = events.flatMap((event) => attendanceMap.get(event.eventid) || []);
-      const dedupedRecords = dedupAttendanceForEventGroup(events, allGroupRecords);
-      const dedupedByEventId = new Map();
-      for (const record of dedupedRecords) {
-        const list = dedupedByEventId.get(String(record.eventid)) || [];
-        list.push(record);
-        dedupedByEventId.set(String(record.eventid), list);
-      }
-
+      const dedupedByEventId = dedupAttendanceMapForEventGroup(events, attendanceMap);
       const eventsWithAttendance = events.map((event) => ({
         ...event,
         attendanceData: dedupedByEventId.get(String(event.eventid)) || [],

--- a/src/features/events/components/attendance/DetailedTab.jsx
+++ b/src/features/events/components/attendance/DetailedTab.jsx
@@ -8,7 +8,7 @@ import { resolveSectionName } from '../../../../shared/utils/memberUtils.js';
 function DetailedTab({ attendees, members, onMemberClick, showContacts = false }) {
   const [_selectedMember, _setSelectedMember] = useState(null);
   const [_showMemberModal, _setShowMemberModal] = useState(false);
-  const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' });
+  const [sortConfig, setSortConfig] = useState({ key: 'age', direction: 'desc' });
 
   // Get all unique consent fields from all members for dynamic table rendering
   // Must be before early return to satisfy Rules of Hooks

--- a/src/features/events/hooks/useAttendanceData.js
+++ b/src/features/events/hooks/useAttendanceData.js
@@ -3,6 +3,7 @@ import { getVikingEventDataForEvents } from '../services/flexiRecordService.js';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import { loadAllAttendanceFromDatabase } from '../../../shared/utils/attendanceHelpers_new.js';
+import { dedupAttendanceForEventGroup } from '../../../shared/utils/sharedEventAttendance.js';
 import databaseService from '../../../shared/services/storage/database.js';
 
 /**
@@ -48,38 +49,7 @@ export function useAttendanceData(events, members = [], refreshTrigger = 0) {
           eventIds: Array.from(eventIds),
         }, LOG_CATEGORIES.COMPONENT);
 
-        const regularAttendance = relevantAttendance.filter(r => !r.isSharedSection);
-        const finalAttendance = [...regularAttendance];
-
-        const regularSectionIds = new Set(regularAttendance.map(r => String(r.sectionid)));
-
-        for (const event of events) {
-          try {
-            const eventAttendance = await databaseService.getAttendance(event.eventid);
-            const sharedRecords = (eventAttendance || []).filter(r => r.isSharedSection === true);
-
-            if (sharedRecords.length > 0) {
-              const inaccessibleSectionRecords = sharedRecords
-                .filter(attendee => !regularSectionIds.has(String(attendee.sectionid)))
-                .map(attendee => ({
-                  ...attendee,
-                  eventid: event.eventid,
-                  sectionid: Number(attendee.sectionid),
-                  scoutid: Number(attendee.scoutid),
-                  firstname: attendee.firstname || attendee.first_name,
-                  lastname: attendee.lastname || attendee.last_name,
-                  _isSharedSection: true,
-                }));
-
-              finalAttendance.push(...inaccessibleSectionRecords);
-            }
-          } catch (sharedError) {
-            logger.debug('No shared attendance found for event', {
-              eventId: event.eventid,
-              error: sharedError.message,
-            }, LOG_CATEGORIES.COMPONENT);
-          }
-        }
+        const finalAttendance = dedupAttendanceForEventGroup(events, relevantAttendance);
 
         const uniqueSectionIds = [...new Set(finalAttendance.map(r => Number(r.sectionid)))];
         const allMembers = await databaseService.getMembers(uniqueSectionIds);

--- a/src/shared/utils/__tests__/attendanceHelpers_new.test.js
+++ b/src/shared/utils/__tests__/attendanceHelpers_new.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/storage/database.js', () => ({
+  default: {
+    getSections: vi.fn(),
+    getEvents: vi.fn(),
+    getAttendance: vi.fn(),
+    getEventById: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/utils/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  LOG_CATEGORIES: { DATA_SERVICE: 'data_service' },
+}));
+
+import databaseService from '../../services/storage/database.js';
+import { loadAllAttendanceFromDatabase } from '../attendanceHelpers_new.js';
+
+const MONDAY = 63813;
+const THURSDAY = 75317;
+
+describe('loadAllAttendanceFromDatabase — sectionname enrichment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the record\'s actual section name (not the event-owner\'s) for cross-section attendees', async () => {
+    // The bug this guards against: a Monday-owned event holds attendance rows
+    // for both Monday Squirrels (the owner section) and Thursday Squirrels
+    // (cross-section invitees via the OSM shared-event mechanism). Before the
+    // fix, all rows were stamped with the event owner's section name, putting
+    // Thursday people under "Monday Squirrels" on the dashboard.
+    databaseService.getSections.mockResolvedValue([
+      { sectionid: MONDAY, sectionname: 'Monday Squirrels' },
+      { sectionid: THURSDAY, sectionname: 'Thursday Squirrels' },
+    ]);
+    databaseService.getEvents.mockImplementation(async (sid) => {
+      if (sid === MONDAY) return [{ eventid: '1727576', name: 'Pirate Camp', startdate: '05/09/2026', sectionname: 'Monday Squirrels' }];
+      if (sid === THURSDAY) return [];
+      return [];
+    });
+    databaseService.getAttendance.mockResolvedValue([
+      { eventid: '1727576', scoutid: 1, sectionid: MONDAY,   attending: 'No',  isSharedSection: false },
+      { eventid: '1727576', scoutid: 2, sectionid: THURSDAY, attending: 'Yes', isSharedSection: true },
+    ]);
+
+    const result = await loadAllAttendanceFromDatabase();
+
+    const monday = result.find(r => r.scoutid === 1);
+    const thursdayCrossInvitee = result.find(r => r.scoutid === 2);
+    expect(monday.sectionname).toBe('Monday Squirrels');
+    expect(thursdayCrossInvitee.sectionname).toBe('Thursday Squirrels');
+  });
+
+  it('falls back to event.sectionname when the record\'s sectionid isn\'t in the sections store', async () => {
+    // Stale data: a record references a section that no longer exists in cache.
+    // We fall back to the event-owner's section name rather than null so the
+    // record still has a usable label.
+    databaseService.getSections.mockResolvedValue([
+      { sectionid: MONDAY, sectionname: 'Monday Squirrels' },
+    ]);
+    databaseService.getEvents.mockImplementation(async (sid) => {
+      if (sid === MONDAY) return [{ eventid: '1727576', name: 'Pirate Camp', startdate: '05/09/2026', sectionname: 'Monday Squirrels' }];
+      return [];
+    });
+    databaseService.getAttendance.mockResolvedValue([
+      { eventid: '1727576', scoutid: 3, sectionid: 999999, attending: 'Yes', isSharedSection: true },
+    ]);
+
+    const result = await loadAllAttendanceFromDatabase();
+    expect(result[0].sectionname).toBe('Monday Squirrels');
+  });
+
+  it('falls back to null when neither the sections store nor the event provides a name', async () => {
+    // Section exists in the store (so getEvents is iterated) but its sectionid
+    // doesn't match the record's, AND the event row has no sectionname either.
+    databaseService.getSections.mockResolvedValue([
+      { sectionid: MONDAY, sectionname: 'Monday Squirrels' },
+    ]);
+    databaseService.getEvents.mockImplementation(async () => [
+      { eventid: '1727576', name: 'Pirate Camp', startdate: '05/09/2026', sectionname: undefined },
+    ]);
+    databaseService.getAttendance.mockResolvedValue([
+      { eventid: '1727576', scoutid: 4, sectionid: 999999, attending: 'Yes' },
+    ]);
+
+    const result = await loadAllAttendanceFromDatabase();
+    expect(result[0].sectionname).toBeNull();
+  });
+
+  it('always uses the record sectionid for the lookup, even when the record happens to be on its own-section event', async () => {
+    // Sanity check: the sections-store join also handles the common (non-shared)
+    // case correctly — Monday person on Monday's event still labelled Monday.
+    databaseService.getSections.mockResolvedValue([
+      { sectionid: MONDAY, sectionname: 'Monday Squirrels' },
+    ]);
+    databaseService.getEvents.mockImplementation(async () => [
+      { eventid: '1727576', name: 'Pirate Camp', startdate: '05/09/2026', sectionname: 'Monday Squirrels' },
+    ]);
+    databaseService.getAttendance.mockResolvedValue([
+      { eventid: '1727576', scoutid: 5, sectionid: MONDAY, attending: 'Yes' },
+    ]);
+
+    const result = await loadAllAttendanceFromDatabase();
+    expect(result[0].sectionname).toBe('Monday Squirrels');
+  });
+});

--- a/src/shared/utils/__tests__/sharedEventAttendance.test.js
+++ b/src/shared/utils/__tests__/sharedEventAttendance.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { dedupAttendanceForEventGroup } from '../sharedEventAttendance.js';
+
+const MONDAY = 63813;
+const THURSDAY = 75317;
+const WEDNESDAY = 99999;
+
+const mondayEvent = { eventid: '1727576', sectionid: MONDAY, name: 'Pirate Camp' };
+const thursdayEvent = { eventid: '1727583', sectionid: THURSDAY, name: 'Pirate Camp' };
+
+describe('dedupAttendanceForEventGroup', () => {
+  describe('shared event with full access (Pirate Camp scenario)', () => {
+    const events = [mondayEvent, thursdayEvent];
+
+    it('keeps own-section regular records', () => {
+      const records = [
+        { eventid: '1727576', scoutid: 1, sectionid: MONDAY, attending: 'No', isSharedSection: false },
+        { eventid: '1727583', scoutid: 2, sectionid: THURSDAY, attending: 'Yes', isSharedSection: false },
+      ];
+      expect(dedupAttendanceForEventGroup(events, records)).toHaveLength(2);
+    });
+
+    it('keeps own-section shared records (Yes responses come back via shared API)', () => {
+      const records = [
+        { eventid: '1727576', scoutid: 10, sectionid: MONDAY, attending: 'Yes', isSharedSection: true },
+      ];
+      expect(dedupAttendanceForEventGroup(events, records)).toEqual(records);
+    });
+
+    it('drops cross-section shared records when the user has access to the persons own-section event', () => {
+      const records = [
+        { eventid: '1727576', scoutid: 20, sectionid: THURSDAY, attending: 'Yes', isSharedSection: true },
+        { eventid: '1727583', scoutid: 20, sectionid: THURSDAY, attending: 'Yes', isSharedSection: false },
+      ];
+      const result = dedupAttendanceForEventGroup(events, records);
+      expect(result).toHaveLength(1);
+      expect(result[0].eventid).toBe('1727583');
+      expect(result[0].isSharedSection).toBe(false);
+    });
+
+    it('reproduces the Pirate Camp counts (8 Monday Yes + 12 Thursday Yes from each section)', () => {
+      const mondayNo = Array.from({ length: 12 }, (_, i) => ({
+        eventid: '1727576', scoutid: 1000 + i, sectionid: MONDAY, attending: 'No', isSharedSection: false,
+      }));
+      const mondayYesShared = Array.from({ length: 8 }, (_, i) => ({
+        eventid: '1727576', scoutid: 2000 + i, sectionid: MONDAY, attending: 'Yes', isSharedSection: true,
+      }));
+      const thursdayCrossInMondayEvent = Array.from({ length: 12 }, (_, i) => ({
+        eventid: '1727576', scoutid: 3000 + i, sectionid: THURSDAY, attending: 'Yes', isSharedSection: true,
+      }));
+      const thursdayOwnEvent = [
+        ...Array.from({ length: 12 }, (_, i) => ({
+          eventid: '1727583', scoutid: 3000 + i, sectionid: THURSDAY, attending: 'Yes', isSharedSection: false,
+        })),
+        ...Array.from({ length: 9 }, (_, i) => ({
+          eventid: '1727583', scoutid: 4000 + i, sectionid: THURSDAY, attending: 'No', isSharedSection: false,
+        })),
+      ];
+
+      const all = [...mondayNo, ...mondayYesShared, ...thursdayCrossInMondayEvent, ...thursdayOwnEvent];
+      const result = dedupAttendanceForEventGroup(events, all);
+
+      const counts = (sid) => ({
+        yes: result.filter(r => r.sectionid === sid && r.attending === 'Yes').length,
+        no: result.filter(r => r.sectionid === sid && r.attending === 'No').length,
+      });
+
+      expect(counts(MONDAY)).toEqual({ yes: 8, no: 12 });
+      expect(counts(THURSDAY)).toEqual({ yes: 12, no: 9 });
+    });
+  });
+
+  describe('shared event with partial access (fallback)', () => {
+    it('keeps shared cross-section records when the user has no event for that section', () => {
+      const events = [mondayEvent];
+      const records = [
+        { eventid: '1727576', scoutid: 30, sectionid: MONDAY, attending: 'No', isSharedSection: false },
+        { eventid: '1727576', scoutid: 31, sectionid: THURSDAY, attending: 'Yes', isSharedSection: true },
+        { eventid: '1727576', scoutid: 32, sectionid: WEDNESDAY, attending: 'Yes', isSharedSection: true },
+      ];
+      const result = dedupAttendanceForEventGroup(events, records);
+      expect(result).toHaveLength(3);
+      expect(result.map(r => r.scoutid).sort()).toEqual([30, 31, 32]);
+    });
+  });
+
+  describe('non-shared events (no-op)', () => {
+    it('returns all records unchanged when each records sectionid matches its events owner', () => {
+      const events = [mondayEvent];
+      const records = [
+        { eventid: '1727576', scoutid: 40, sectionid: MONDAY, attending: 'Yes', isSharedSection: false },
+        { eventid: '1727576', scoutid: 41, sectionid: MONDAY, attending: 'No', isSharedSection: false },
+      ];
+      expect(dedupAttendanceForEventGroup(events, records)).toEqual(records);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns records unchanged when events array is empty', () => {
+      const records = [{ eventid: '1', scoutid: 50, sectionid: MONDAY, attending: 'Yes' }];
+      expect(dedupAttendanceForEventGroup([], records)).toEqual(records);
+    });
+
+    it('returns empty array when records is empty', () => {
+      expect(dedupAttendanceForEventGroup([mondayEvent], [])).toEqual([]);
+    });
+
+    it('handles null/undefined inputs without throwing', () => {
+      expect(dedupAttendanceForEventGroup(null, null)).toEqual([]);
+      expect(dedupAttendanceForEventGroup(undefined, undefined)).toEqual([]);
+      expect(dedupAttendanceForEventGroup([mondayEvent], null)).toEqual([]);
+    });
+
+    it('coerces string sectionids to numbers when matching', () => {
+      const events = [{ eventid: '1', sectionid: '63813' }];
+      const records = [
+        { eventid: '1', scoutid: 60, sectionid: 63813, attending: 'Yes', isSharedSection: false },
+      ];
+      expect(dedupAttendanceForEventGroup(events, records)).toHaveLength(1);
+    });
+  });
+});

--- a/src/shared/utils/__tests__/sharedEventAttendance.test.js
+++ b/src/shared/utils/__tests__/sharedEventAttendance.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { dedupAttendanceForEventGroup } from '../sharedEventAttendance.js';
+import {
+  dedupAttendanceForEventGroup,
+  dedupAttendanceMapForEventGroup,
+} from '../sharedEventAttendance.js';
 
 const MONDAY = 63813;
 const THURSDAY = 75317;
@@ -27,7 +30,7 @@ describe('dedupAttendanceForEventGroup', () => {
       expect(dedupAttendanceForEventGroup(events, records)).toEqual(records);
     });
 
-    it('drops cross-section shared records when the user has access to the persons own-section event', () => {
+    it('drops cross-section shared records when the user has access to the person\'s own-section event', () => {
       const records = [
         { eventid: '1727576', scoutid: 20, sectionid: THURSDAY, attending: 'Yes', isSharedSection: true },
         { eventid: '1727583', scoutid: 20, sectionid: THURSDAY, attending: 'Yes', isSharedSection: false },
@@ -35,10 +38,46 @@ describe('dedupAttendanceForEventGroup', () => {
       const result = dedupAttendanceForEventGroup(events, records);
       expect(result).toHaveLength(1);
       expect(result[0].eventid).toBe('1727583');
-      expect(result[0].isSharedSection).toBe(false);
     });
 
-    it('reproduces the Pirate Camp counts (8 Monday Yes + 12 Thursday Yes from each section)', () => {
+    it('does not inspect isSharedSection — drops a regular row on the wrong event the same as a shared row', () => {
+      const records = [
+        { eventid: '1727576', scoutid: 21, sectionid: THURSDAY, attending: 'Yes', isSharedSection: false },
+        { eventid: '1727583', scoutid: 21, sectionid: THURSDAY, attending: 'Yes', isSharedSection: false },
+      ];
+      const result = dedupAttendanceForEventGroup(events, records);
+      expect(result).toHaveLength(1);
+      expect(result[0].eventid).toBe('1727583');
+    });
+
+    it('keeps both records when a scout has different sectionids across events (eventDataLoader.js:185 data shape)', () => {
+      // Real-world data: scoutid 2216198 in IndexedDB has sectionid=Monday in
+      // Monday's event (shared sync corrected it) and sectionid=Thursday in
+      // Thursday's event (regular sync forced event.sectionid). Both records
+      // pass `personSid === ownerSid` for their own event.
+      const records = [
+        { eventid: '1727576', scoutid: 2216198, sectionid: MONDAY,   attending: 'Yes', isSharedSection: true },
+        { eventid: '1727583', scoutid: 2216198, sectionid: THURSDAY, attending: 'No',  isSharedSection: false },
+      ];
+      const result = dedupAttendanceForEventGroup(events, records);
+      expect(result).toHaveLength(2);
+    });
+
+    it('drops the wrong-event record when a scout has the same sectionid on both events with different statuses', () => {
+      // Same scout, same own-section, but the API returned them on both events
+      // with different statuses. Their own-section event wins; the other is
+      // dropped because the user has access to the scout's section directly.
+      const records = [
+        { eventid: '1727576', scoutid: 22, sectionid: MONDAY, attending: 'Yes', isSharedSection: true },
+        { eventid: '1727583', scoutid: 22, sectionid: MONDAY, attending: 'No',  isSharedSection: true },
+      ];
+      const result = dedupAttendanceForEventGroup(events, records);
+      expect(result).toHaveLength(1);
+      expect(result[0].eventid).toBe('1727576');
+      expect(result[0].attending).toBe('Yes');
+    });
+
+    it('reproduces the Pirate Camp counts after deduping cross-section duplicates', () => {
       const mondayNo = Array.from({ length: 12 }, (_, i) => ({
         eventid: '1727576', scoutid: 1000 + i, sectionid: MONDAY, attending: 'No', isSharedSection: false,
       }));
@@ -85,7 +124,7 @@ describe('dedupAttendanceForEventGroup', () => {
   });
 
   describe('non-shared events (no-op)', () => {
-    it('returns all records unchanged when each records sectionid matches its events owner', () => {
+    it('returns all records unchanged when each record\'s sectionid matches its event\'s owner', () => {
       const events = [mondayEvent];
       const records = [
         { eventid: '1727576', scoutid: 40, sectionid: MONDAY, attending: 'Yes', isSharedSection: false },
@@ -118,5 +157,52 @@ describe('dedupAttendanceForEventGroup', () => {
       ];
       expect(dedupAttendanceForEventGroup(events, records)).toHaveLength(1);
     });
+  });
+});
+
+describe('dedupAttendanceMapForEventGroup', () => {
+  it('regroups deduped records by eventid for downstream EventCard rendering', () => {
+    const events = [mondayEvent, thursdayEvent];
+    const attendanceByEventId = new Map([
+      [mondayEvent.eventid, [
+        { eventid: mondayEvent.eventid, scoutid: 100, sectionid: MONDAY, attending: 'No' },
+        { eventid: mondayEvent.eventid, scoutid: 101, sectionid: THURSDAY, attending: 'Yes' },
+      ]],
+      [thursdayEvent.eventid, [
+        { eventid: thursdayEvent.eventid, scoutid: 101, sectionid: THURSDAY, attending: 'Yes' },
+      ]],
+    ]);
+
+    const result = dedupAttendanceMapForEventGroup(events, attendanceByEventId);
+
+    expect(result.get(mondayEvent.eventid)).toHaveLength(1);
+    expect(result.get(mondayEvent.eventid)[0].scoutid).toBe(100);
+    expect(result.get(thursdayEvent.eventid)).toHaveLength(1);
+    expect(result.get(thursdayEvent.eventid)[0].scoutid).toBe(101);
+  });
+
+  it('returns map keyed by String(eventid) so callers can do .get(String(event.eventid))', () => {
+    const events = [{ eventid: 1727576, sectionid: MONDAY }];
+    const attendanceByEventId = new Map([
+      [1727576, [{ eventid: 1727576, scoutid: 110, sectionid: MONDAY, attending: 'Yes' }]],
+    ]);
+
+    const result = dedupAttendanceMapForEventGroup(events, attendanceByEventId);
+    expect(result.get('1727576')).toHaveLength(1);
+    expect(result.get(1727576)).toBeUndefined();
+  });
+
+  it('returns empty map when attendance map is missing entries for events in the group', () => {
+    const events = [mondayEvent, thursdayEvent];
+    const attendanceByEventId = new Map();
+
+    const result = dedupAttendanceMapForEventGroup(events, attendanceByEventId);
+    expect(result.size).toBe(0);
+  });
+
+  it('handles null/undefined inputs without throwing', () => {
+    expect(dedupAttendanceMapForEventGroup(null, null).size).toBe(0);
+    expect(dedupAttendanceMapForEventGroup(undefined, undefined).size).toBe(0);
+    expect(dedupAttendanceMapForEventGroup([mondayEvent], undefined).size).toBe(0);
   });
 });

--- a/src/shared/utils/attendanceHelpers_new.js
+++ b/src/shared/utils/attendanceHelpers_new.js
@@ -4,7 +4,18 @@ import logger, { LOG_CATEGORIES } from '../services/utils/logger.js';
 /**
  * Loads all attendance from the normalized IndexedDB store with read-time enrichment.
  * Raw attendance records contain only core fields (scoutid, eventid, sectionid, attending, patrol, notes).
- * Enrichment fields (eventname, eventdate, sectionname) are joined at read time from the events store.
+ *
+ * Enrichment fields are joined at read time:
+ *   - eventname, eventdate from the events store (keyed by record.eventid)
+ *   - sectionname from the sections store (keyed by record.sectionid), with
+ *     event.sectionname as a fallback when the record's sectionid isn't in the
+ *     sections cache.
+ *
+ * The sections-store join matters for shared events: a record's sectionid can
+ * belong to a different section than the event's owner (cross-section invitee
+ * via OSM event sharing). Joining sectionname from event.sectionname instead
+ * would mis-label those rows under the event-owner's section name.
+ *
  * @returns {Promise<Array<Object>>} Enriched attendance records
  */
 export async function loadAllAttendanceFromDatabase() {

--- a/src/shared/utils/attendanceHelpers_new.js
+++ b/src/shared/utils/attendanceHelpers_new.js
@@ -10,6 +10,9 @@ import logger, { LOG_CATEGORIES } from '../services/utils/logger.js';
 export async function loadAllAttendanceFromDatabase() {
   try {
     const sections = await databaseService.getSections();
+    const sectionNameById = new Map(
+      (sections || []).map(s => [Number(s.sectionid), s.sectionname]),
+    );
     const allEvents = [];
 
     for (const section of sections) {
@@ -26,7 +29,10 @@ export async function loadAllAttendanceFromDatabase() {
           ...record,
           eventname: event.name ?? null,
           eventdate: event.startdate ?? null,
-          sectionname: event.sectionname ?? null,
+          sectionname:
+            sectionNameById.get(Number(record.sectionid)) ??
+            event.sectionname ??
+            null,
         }));
       } catch {
         return [];

--- a/src/shared/utils/sharedEventAttendance.js
+++ b/src/shared/utils/sharedEventAttendance.js
@@ -2,18 +2,31 @@
  * Dedup attendance records across a group of events that represent the same logical
  * occasion (e.g. one shared OSM event surfaced as a separate per-section event row).
  *
- * Rule: for each scout, prefer the record from the event whose owner section matches
- * the scout's own section. If the user has no event in the group for the scout's
- * section (i.e. the user lacks access to that section), keep any shared-event record
- * we can find as a fallback so the scout still appears.
+ * Applied per record:
+ *   1. If the record's sectionid matches its event's owner sectionid, keep it
+ *      (own-section record — the canonical copy for that scout).
+ *   2. Otherwise, if the record's sectionid is the owner of any other event in the
+ *      group, drop it — we'll get the canonical copy from that event instead
+ *      (cross-section duplicate).
+ *   3. Otherwise (no event in the group covers the scout's section, i.e. the user
+ *      lacks direct access to that section), keep the record as a fallback so the
+ *      scout still appears.
+ *
+ * Note: the rule is purely sectionid-based. The function does NOT inspect
+ * isSharedSection — it works whether the duplicate copy on the wrong event was
+ * synced as shared or as regular attendance.
  *
  * Without this dedup, a scout invited to a shared event appears once via their own
  * section's event AND again via the shared records on the other section's event,
  * which inflates per-section counts and double-counts the same person.
  *
- * @param {Array<Object>} events - Events in the group (e.g. produced by groupEventsByName)
- * @param {Array<Object>} records - Attendance records for those events
- * @returns {Array<Object>} Filtered records, one per scout per group
+ * @param {Array<{eventid: string|number, sectionid: string|number}>} events
+ *   Events in the group (e.g. produced by groupEventsByName). Required fields:
+ *   eventid, sectionid (the event-owner section).
+ * @param {Array<{eventid: string|number, sectionid: string|number}>} records
+ *   Attendance records for those events. Required fields: eventid (must match an
+ *   event in the group), sectionid (the scout's actual section).
+ * @returns {Array<Object>} Filtered records, one per scout per group.
  */
 export function dedupAttendanceForEventGroup(events, records) {
   if (!Array.isArray(events) || events.length === 0 || !Array.isArray(records)) {
@@ -33,4 +46,32 @@ export function dedupAttendanceForEventGroup(events, records) {
     if (accessibleSectionIds.has(personSid)) return false;
     return true;
   });
+}
+
+/**
+ * Apply dedupAttendanceForEventGroup to a per-event attendance map and return a new
+ * map keyed by eventid. Used by the dashboard EventCard wiring (EventDashboard,
+ * EventsOverview) to dedup before handing attendanceData to the card.
+ *
+ * @param {Array<{eventid: string|number, sectionid: string|number}>} events
+ *   Events in one name-group.
+ * @param {Map<string|number, Array<Object>>} attendanceByEventId
+ *   Map from eventid to the raw attendance records for that event.
+ * @returns {Map<string, Array<Object>>} Map from String(eventid) to the deduped
+ *   subset of records that should be rendered on that event's card.
+ */
+export function dedupAttendanceMapForEventGroup(events, attendanceByEventId) {
+  const allGroupRecords = (events ?? []).flatMap(
+    (event) => attendanceByEventId?.get(event.eventid) ?? [],
+  );
+  const deduped = dedupAttendanceForEventGroup(events ?? [], allGroupRecords);
+
+  const dedupedByEventId = new Map();
+  for (const record of deduped) {
+    const key = String(record.eventid);
+    const list = dedupedByEventId.get(key) ?? [];
+    list.push(record);
+    dedupedByEventId.set(key, list);
+  }
+  return dedupedByEventId;
 }

--- a/src/shared/utils/sharedEventAttendance.js
+++ b/src/shared/utils/sharedEventAttendance.js
@@ -1,0 +1,36 @@
+/**
+ * Dedup attendance records across a group of events that represent the same logical
+ * occasion (e.g. one shared OSM event surfaced as a separate per-section event row).
+ *
+ * Rule: for each scout, prefer the record from the event whose owner section matches
+ * the scout's own section. If the user has no event in the group for the scout's
+ * section (i.e. the user lacks access to that section), keep any shared-event record
+ * we can find as a fallback so the scout still appears.
+ *
+ * Without this dedup, a scout invited to a shared event appears once via their own
+ * section's event AND again via the shared records on the other section's event,
+ * which inflates per-section counts and double-counts the same person.
+ *
+ * @param {Array<Object>} events - Events in the group (e.g. produced by groupEventsByName)
+ * @param {Array<Object>} records - Attendance records for those events
+ * @returns {Array<Object>} Filtered records, one per scout per group
+ */
+export function dedupAttendanceForEventGroup(events, records) {
+  if (!Array.isArray(events) || events.length === 0 || !Array.isArray(records)) {
+    return records ?? [];
+  }
+
+  const ownerSectionByEventId = new Map(
+    events.map((e) => [String(e.eventid), Number(e.sectionid)]),
+  );
+  const accessibleSectionIds = new Set(events.map((e) => Number(e.sectionid)));
+
+  return records.filter((record) => {
+    const ownerSid = ownerSectionByEventId.get(String(record.eventid));
+    const personSid = Number(record.sectionid);
+
+    if (personSid === ownerSid) return true;
+    if (accessibleSectionIds.has(personSid)) return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

Pirate Camp (and any OSM event shared between two sections the user can both access) showed wrong attendance counts on every view — verified live in this session against the user's real data.

| View | Before | After |
|---|---|---|
| Dashboard card — Monday Squirrels Yes | 20 | 8 ✓ |
| Dashboard card — Thursday Squirrels Yes | 12 | 12 ✓ |
| Overview tab — Monday Squirrels Yes | 0 | 8 ✓ |
| Detailed tab — Monday Squirrels rows | none | 8 ✓ |
| Overview/Dashboard total Yes | 20 | 20 ✓ (matches reality) |

## Root cause

Two independent bugs:

1. **`useAttendanceData.loadAttendance`** partitioned attendance into regular vs. shared, then re-added shared rows only when their sectionid wasn't already in `regularSectionIds`. With both sections accessible, every shared row for either section was dropped — including the 8 Monday Squirrels who said "Yes" (Yes responses come back through the shared-attendance API even for the owner section's own people). The storage `[eventid, scoutid]` PK already prevents within-event duplicates, so the partition was solving a non-problem and dropping valid data.

2. **`loadAllAttendanceFromDatabase`** overrode `record.sectionname` with `event.sectionname` (event-owner's section name). The dashboard's `buildAttendanceGrid` groups by `sectionname`, so cross-section attendees were attributed to the event-owner's section row.

## Fix

- New `shared/utils/sharedEventAttendance.js` — `dedupAttendanceForEventGroup(events, records)`. Rule: for each scout, prefer the record from the event owned by their own section if accessible; fall back to shared records from any sibling event when the user lacks direct access.
- `useAttendanceData.loadAttendance` calls the dedup helper instead of the broken partition.
- `EventDashboard.buildEventCards` and `EventsOverview.buildEventCards` apply the same dedup to `attendanceMap` per name-group before handing `attendanceData` to `EventCard`.
- `attendanceHelpers_new.loadAllAttendanceFromDatabase` resolves `sectionname` from `record.sectionid` via a sections lookup (defensive fallback to event's name kept).

## Bonus UX (requested same session)

- `DetailedTab` default sort is now Age desc — leaders ("25+") at the top.

## Tests

- New `sharedEventAttendance.test.js` (10 tests) including the full Pirate Camp 8/12/12/9 reproduction.
- **454 passing (+10), 13 skipped, 0 lint errors, 0 build errors.**

## Out of scope (logged follow-up)

`eventDataLoader.syncEventAttendance` writes regular records with `sectionid: Number(event.sectionid)` instead of `record.sectionid`. The shared sync overwrites this for cross-section attendees so the visible bug doesn't depend on it, but cleaner to write the correct sectionid first. Touches the sync path for every event in the system — saved for a separate PR.

## Test plan

- [x] All existing unit tests pass (454/454 + 13 skipped)
- [x] New `sharedEventAttendance.test.js` covers own-section preference, fallback for inaccessible sections, no-op for non-shared events, edge cases
- [x] Verified live in Playwright against user's real OSM data: Pirate Camp dashboard / Overview / Detailed all show Monday=8 Yes / Thursday=12 Yes / Total=20 Yes
- [x] Verified live in Playwright that Detailed default sort puts leaders ("25+") at top
- [ ] iOS verification (the dedup helper is platform-agnostic and the changes are above the storage layer, but worth a sanity check on TestFlight before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)