### PR TITLE
fix(attendance): preserve per-record sectionid in regular sync

### DIFF
--- a/src/shared/services/api/api/events.js
+++ b/src/shared/services/api/api/events.js
@@ -402,7 +402,7 @@ export async function getSharedEventAttendance(eventId, sectionId, token) {
         const coreSharedRecords = attendance.map(record => ({
           scoutid: record.scoutid,
           eventid: String(eventId),
-          sectionid: Number(record.sectionid || sectionId),
+          sectionid: Number(record.sectionid ?? sectionId),
           attending: record.attending,
           patrol: record.patrol ?? null,
           notes: record.notes ?? null,

--- a/src/shared/services/data/__tests__/attendanceDataService.test.js
+++ b/src/shared/services/data/__tests__/attendanceDataService.test.js
@@ -94,4 +94,29 @@ describe('AttendanceDataService', () => {
       'Your session has expired. Please log in again to continue.',
     );
   });
+
+  it('preserves record.sectionid in refreshAttendanceData', async () => {
+    const { getToken } = await import('../../auth/tokenService.js');
+    const { getEventAttendance } = await import('../../api/api/events.js');
+
+    getToken.mockReturnValue('test-token');
+    getEventAttendance.mockResolvedValue([
+      { scoutid: 1, sectionid: 10 },
+      { scoutid: 2, sectionid: 99 },
+    ]);
+
+    databaseService.getSections = vi.fn().mockResolvedValue([
+      { sectionid: 10, sectionname: 'Beavers' },
+    ]);
+    databaseService.getEvents = vi.fn().mockResolvedValue([
+      { sectionid: 10, eventid: 'event1', termid: 'term1', name: 'Pirate Camp', startdate: '2026-06-01', sectionname: 'Beavers' },
+    ]);
+    databaseService.saveAttendance = vi.fn().mockResolvedValue();
+
+    await attendanceDataService.refreshAttendanceData();
+
+    const savedRecords = databaseService.saveAttendance.mock.calls[0][1];
+    expect(savedRecords[0].sectionid).toBe(10);
+    expect(savedRecords[1].sectionid).toBe(99);
+  });
 });

--- a/src/shared/services/data/__tests__/attendanceDataService.test.js
+++ b/src/shared/services/data/__tests__/attendanceDataService.test.js
@@ -119,4 +119,27 @@ describe('AttendanceDataService', () => {
     expect(savedRecords[0].sectionid).toBe(10);
     expect(savedRecords[1].sectionid).toBe(99);
   });
+
+  it('uses ?? not ||: record.sectionid of 0 is preserved, not coerced to event.sectionid', async () => {
+    const { getToken } = await import('../../auth/tokenService.js');
+    const { getEventAttendance } = await import('../../api/api/events.js');
+
+    getToken.mockReturnValue('test-token');
+    getEventAttendance.mockResolvedValue([
+      { scoutid: 1, sectionid: 0 },
+    ]);
+
+    databaseService.getSections = vi.fn().mockResolvedValue([
+      { sectionid: 10, sectionname: 'Beavers' },
+    ]);
+    databaseService.getEvents = vi.fn().mockResolvedValue([
+      { sectionid: 10, eventid: 'event1', termid: 'term1', name: 'Pirate Camp', startdate: '2026-06-01', sectionname: 'Beavers' },
+    ]);
+    databaseService.saveAttendance = vi.fn().mockResolvedValue();
+
+    await attendanceDataService.refreshAttendanceData();
+
+    const savedRecords = databaseService.saveAttendance.mock.calls[0][1];
+    expect(savedRecords[0].sectionid).toBe(0);
+  });
 });

--- a/src/shared/services/data/__tests__/eventDataLoader.test.js
+++ b/src/shared/services/data/__tests__/eventDataLoader.test.js
@@ -133,5 +133,17 @@ describe('EventDataLoader', () => {
       expect(savedRecords[0].sectionid).toBe(10);
       expect(savedRecords[1].sectionid).toBe(99);
     });
+
+    it('uses ?? not ||: record.sectionid of 0 is preserved, not coerced to event.sectionid', async () => {
+      vi.mocked(api.getEventAttendance).mockResolvedValue([
+        { scoutid: 1, sectionid: 0, attending: 'Yes' },
+      ]);
+      vi.mocked(databaseService.saveAttendance).mockResolvedValue();
+
+      await eventDataLoader.syncEventAttendance({ eventid: 'E1', sectionid: 10, termid: 'T1' }, 'token');
+
+      const savedRecords = vi.mocked(databaseService.saveAttendance).mock.calls[0][1];
+      expect(savedRecords[0].sectionid).toBe(0);
+    });
   });
 });

--- a/src/shared/services/data/__tests__/eventDataLoader.test.js
+++ b/src/shared/services/data/__tests__/eventDataLoader.test.js
@@ -94,4 +94,44 @@ describe('EventDataLoader', () => {
       ]);
     });
   });
+
+  describe('syncEventAttendance', () => {
+    it('preserves record.sectionid when present', async () => {
+      vi.mocked(api.getEventAttendance).mockResolvedValue([
+        { scoutid: 1, sectionid: 99, attending: 'Yes' },
+      ]);
+      vi.mocked(databaseService.saveAttendance).mockResolvedValue();
+
+      await eventDataLoader.syncEventAttendance({ eventid: 'E1', sectionid: 10, termid: 'T1' }, 'token');
+
+      const savedRecords = vi.mocked(databaseService.saveAttendance).mock.calls[0][1];
+      expect(savedRecords[0].sectionid).toBe(99);
+    });
+
+    it('falls back to event.sectionid when record.sectionid absent', async () => {
+      vi.mocked(api.getEventAttendance).mockResolvedValue([
+        { scoutid: 1, attending: 'Yes' },
+      ]);
+      vi.mocked(databaseService.saveAttendance).mockResolvedValue();
+
+      await eventDataLoader.syncEventAttendance({ eventid: 'E1', sectionid: 10, termid: 'T1' }, 'token');
+
+      const savedRecords = vi.mocked(databaseService.saveAttendance).mock.calls[0][1];
+      expect(savedRecords[0].sectionid).toBe(10);
+    });
+
+    it('cross-section attendee preserves their section (Pirate Camp scenario)', async () => {
+      vi.mocked(api.getEventAttendance).mockResolvedValue([
+        { scoutid: 1, sectionid: 10, attending: 'Yes' },
+        { scoutid: 2, sectionid: 99, attending: 'No' },
+      ]);
+      vi.mocked(databaseService.saveAttendance).mockResolvedValue();
+
+      await eventDataLoader.syncEventAttendance({ eventid: 'E1', sectionid: 10, termid: 'T1' }, 'token');
+
+      const savedRecords = vi.mocked(databaseService.saveAttendance).mock.calls[0][1];
+      expect(savedRecords[0].sectionid).toBe(10);
+      expect(savedRecords[1].sectionid).toBe(99);
+    });
+  });
 });

--- a/src/shared/services/data/attendanceDataService.js
+++ b/src/shared/services/data/attendanceDataService.js
@@ -112,7 +112,7 @@ class AttendanceDataService {
           const coreRecords = attendanceRecords.map(record => ({
             ...record,
             eventid: event.eventid,
-            sectionid: event.sectionid,
+            sectionid: Number(record.sectionid || event.sectionid),
           }));
 
           if (coreRecords.length > 0) {

--- a/src/shared/services/data/attendanceDataService.js
+++ b/src/shared/services/data/attendanceDataService.js
@@ -112,7 +112,7 @@ class AttendanceDataService {
           const coreRecords = attendanceRecords.map(record => ({
             ...record,
             eventid: event.eventid,
-            sectionid: Number(record.sectionid || event.sectionid),
+            sectionid: Number(record.sectionid ?? event.sectionid),
           }));
 
           if (coreRecords.length > 0) {

--- a/src/shared/services/data/eventDataLoader.js
+++ b/src/shared/services/data/eventDataLoader.js
@@ -182,7 +182,7 @@ class EventDataLoader {
       const coreRecords = attendanceRecords.map(record => ({
         scoutid: record.scoutid,
         eventid: String(event.eventid),
-        sectionid: Number(record.sectionid || event.sectionid),
+        sectionid: Number(record.sectionid ?? event.sectionid),
         attending: record.attending,
         patrol: record.patrol ?? null,
         notes: record.notes ?? null,
@@ -320,7 +320,7 @@ class EventDataLoader {
           const coreSharedRecords = attendance.map(record => ({
             scoutid: record.scoutid,
             eventid: String(event.eventid),
-            sectionid: Number(record.sectionid || event.sectionid),
+            sectionid: Number(record.sectionid ?? event.sectionid),
             attending: record.attending,
             patrol: record.patrol ?? null,
             notes: record.notes ?? null,

--- a/src/shared/services/data/eventDataLoader.js
+++ b/src/shared/services/data/eventDataLoader.js
@@ -182,7 +182,7 @@ class EventDataLoader {
       const coreRecords = attendanceRecords.map(record => ({
         scoutid: record.scoutid,
         eventid: String(event.eventid),
-        sectionid: Number(event.sectionid),
+        sectionid: Number(record.sectionid || event.sectionid),
         attending: record.attending,
         patrol: record.patrol ?? null,
         notes: record.notes ?? null,

--- a/src/shared/utils/__tests__/sharedEventAttendance.test.js
+++ b/src/shared/utils/__tests__/sharedEventAttendance.test.js
@@ -50,7 +50,7 @@ describe('dedupAttendanceForEventGroup', () => {
       expect(result[0].eventid).toBe('1727583');
     });
 
-    it('keeps both records when a scout has different sectionids across events (eventDataLoader.js:185 data shape)', () => {
+    it('keeps both records when a scout has different sectionids across events (defense-in-depth after #197 fix)', () => {
       // Real-world data: scoutid 2216198 in IndexedDB has sectionid=Monday in
       // Monday's event (shared sync corrected it) and sectionid=Thursday in
       // Thursday's event (regular sync forced event.sectionid). Both records


### PR DESCRIPTION
Preserves per-record `sectionid` returned by OSM when syncing event attendance, instead of unconditionally overwriting it with the event-owner's `sectionid`.

`eventDataLoader.syncEventAttendance` and `attendanceDataService.refreshAttendanceData` both stamped `sectionid: event.sectionid` on every record they wrote, so a Monday Squirrel RSVPing No to Thursday's copy of "Pirate Camp" was stored with `sectionid=Thursday`. PR #195's `dedupAttendanceForEventGroup` masks this at render time, but any future code reading attendance directly would silently misattribute cross-section attendees.

The fix mirrors the pattern already in production at `eventDataLoader.js:323` (`syncSharedAttendance`) and `events.js:405` (`getSharedEventAttendance`):

```diff
-sectionid: Number(event.sectionid),
+sectionid: Number(record.sectionid || event.sectionid),
```

The `|| event.sectionid` fallback preserves current behavior if `record.sectionid` is ever absent.

Issue #197 only mentions `eventDataLoader.js`, but exploration found the same buggy pattern in `attendanceDataService.js:115` — fixed in the same PR since the root cause is identical.

Existing data at rest is unchanged; the next sync cycle (manual refresh / re-login) overwrites stale rows. Per the storage migration framework, no DB migration is needed.

The "keeps both records when a scout has different sectionids" test in `sharedEventAttendance.test.js` is retained and renamed — it now serves as defense-in-depth rather than a real-world repro.

Fixes #197

🤖 Generated with [Claude Code](https://claude.ai/code)