### PR TITLE
fix(ios): sticky header + safe-area insets so content clears the cutout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Viking Scouts (1st Walton on Thames)</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,9 @@ function App() {
   return (
     <>
       <AppRouter />
-      <Toaster />
+      <Toaster
+        containerStyle={{ top: 'calc(env(safe-area-inset-top) + 1rem)' }}
+      />
     </>
   );
 }

--- a/src/shared/components/Footer.jsx
+++ b/src/shared/components/Footer.jsx
@@ -4,7 +4,10 @@ function Footer() {
   const version = import.meta.env.VITE_APP_VERSION;
   
   return (
-    <footer className="bg-gray-100 border-t border-gray-200 py-2 px-4 text-center">
+    <footer
+      className="bg-gray-100 border-t border-gray-200 py-2 px-4 text-center"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)' }}
+    >
       <div className="text-xs text-gray-500">
         Viking Event Management v{version}
       </div>

--- a/src/shared/components/VikingHeader.jsx
+++ b/src/shared/components/VikingHeader.jsx
@@ -22,7 +22,8 @@ function VikingHeader({
 
   return (
     <header
-      className="bg-white shadow-sm border-b border-gray-200 px-6 py-4"
+      className="bg-white shadow-sm border-b border-gray-200 px-6 py-4 sticky top-0 z-40"
+      style={{ paddingTop: 'calc(env(safe-area-inset-top) + 1rem)' }}
     >
       <div
         className="flex justify-between items-center max-w-7xl mx-auto"


### PR DESCRIPTION
On iOS the WKWebView renders edge-to-edge, so the \"Viking Scouts\" header and toasts were appearing under the dynamic island / status bar.

The fix:

- **`index.html`** — adds `viewport-fit=cover` to the viewport meta. Required for `env(safe-area-inset-*)` to return non-zero on iOS.
- **`VikingHeader.jsx`** — `sticky top-0 z-40` + `paddingTop: calc(env(safe-area-inset-top) + 1rem)` so the header sits below the cutout and stays pinned while scrolling.
- **`App.jsx`** — `<Toaster containerStyle={{ top: 'calc(env(safe-area-inset-top) + 1rem)' }} />` so toasts also clear the cutout.
- **`Footer.jsx`** — `paddingBottom: calc(env(safe-area-inset-bottom) + 0.5rem)` for home-indicator clearance on iPhones without a home button.

Sticky chosen over `position: fixed` because the header height varies (changes when user logs in/out, with the offline badge, with `DataFreshness`/`TokenCountdown` rendering). Sticky stays in the document flow so the main content automatically sits below it without a height calculation.

`env(safe-area-inset-*)` returns 0 on browsers without safe areas (Render web), so the change is no-op on web and only takes effect on iOS / PWA installs.

🤖 Generated with [Claude Code](https://claude.ai/code)