### PR TITLE
feat(flexi-records): create missing FlexiRecords from inline banner

### DIFF
--- a/src/features/events/components/CampGroupsView.jsx
+++ b/src/features/events/components/CampGroupsView.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { Alert } from '../../../shared/components/ui';
 import CampGroupCard from './CampGroupCard.jsx';
 import { MemberDetailModal } from '../../../shared/components/ui';
 import GroupNamesEditModal from './GroupNamesEditModal.jsx';
@@ -9,6 +8,7 @@ import { assignMemberToCampGroup, batchAssignMembers, extractFlexiRecordContext,
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import { notifyError, notifyInfo, notifySuccess } from '../../../shared/utils/notifications.js';
 import databaseService from '../../../shared/services/storage/database.js';
+import { MissingFlexiRecordsBanner } from '../../flexi-records';
 
 /**
  * Organizes member attendance data by camp groups with optimistic updates
@@ -162,6 +162,20 @@ function CampGroupsView({
     organizeByCampGroups(attendees, pendingMoves, recentlyCompletedMoves),
   [attendees, pendingMoves, recentlyCompletedMoves],
   );
+
+  // Unique sections involved in the events shown here — drives the missing-FlexiRecord banner.
+  const eventSections = useMemo(() => {
+    const seen = new Map();
+    for (const event of events || []) {
+      const sectionid = event.sectionid;
+      if (sectionid === null || sectionid === undefined || seen.has(sectionid)) continue;
+      seen.set(sectionid, {
+        sectionid,
+        sectionname: event.sectionname || event.section_name || `Section ${sectionid}`,
+      });
+    }
+    return Array.from(seen.values());
+  }, [events]);
 
   // Handle member click - simple version like RegisterTab
   const handleMemberClick = (member) => {
@@ -725,13 +739,7 @@ function CampGroupsView({
         </div>
 
         {!summary.vikingEventDataAvailable && (
-          <Alert variant="warning" className="mb-4">
-            <Alert.Title>No Viking Event Management Data</Alert.Title>
-            <Alert.Description>
-              No &quot;Viking Event Mgmt&quot; flexirecord found for the sections involved in these events. 
-              All members will be shown in the &quot;Unassigned&quot; group.
-            </Alert.Description>
-          </Alert>
+          <MissingFlexiRecordsBanner sections={eventSections} />
         )}
       </div>
 

--- a/src/features/events/components/CampGroupsView.jsx
+++ b/src/features/events/components/CampGroupsView.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import CampGroupCard from './CampGroupCard.jsx';
-import { MemberDetailModal } from '../../../shared/components/ui';
+import { Alert, MemberDetailModal } from '../../../shared/components/ui';
 import GroupNamesEditModal from './GroupNamesEditModal.jsx';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import { isMobileLayout } from '../../../shared/utils/platform.js';
@@ -176,6 +176,17 @@ function CampGroupsView({
     }
     return Array.from(seen.values());
   }, [events]);
+
+  // The banner's hook silently filters out adults / waiting-list sections, so for
+  // adults-only events it would render nothing — leaving the user staring at an
+  // empty "Unassigned" grid. Detect that case at the parent and show an explanation.
+  const hasOperationalEventSection = useMemo(
+    () => eventSections.some(s => {
+      const name = (s.sectionname || '').toLowerCase();
+      return !(name.includes('adults') || name.includes('waiting'));
+    }),
+    [eventSections],
+  );
 
   // Handle member click - simple version like RegisterTab
   const handleMemberClick = (member) => {
@@ -739,7 +750,16 @@ function CampGroupsView({
         </div>
 
         {!summary.vikingEventDataAvailable && (
-          <MissingFlexiRecordsBanner sections={eventSections} />
+          hasOperationalEventSection ? (
+            <MissingFlexiRecordsBanner sections={eventSections} />
+          ) : (
+            <Alert variant="info" className="mb-4">
+              <Alert.Title>No Young People in this view</Alert.Title>
+              <Alert.Description>
+                Camp groups apply to Young People only. The selected event(s) involve only adult or waiting-list sections.
+              </Alert.Description>
+            </Alert>
+          )
         )}
       </div>
 

--- a/src/features/events/components/CampGroupsView.jsx
+++ b/src/features/events/components/CampGroupsView.jsx
@@ -8,7 +8,7 @@ import { assignMemberToCampGroup, batchAssignMembers, extractFlexiRecordContext,
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import { notifyError, notifyInfo, notifySuccess } from '../../../shared/utils/notifications.js';
 import databaseService from '../../../shared/services/storage/database.js';
-import { MissingFlexiRecordsBanner } from '../../flexi-records';
+import { MissingFlexiRecordsBanner, isOperationalSection } from '../../flexi-records';
 
 /**
  * Organizes member attendance data by camp groups with optimistic updates
@@ -164,15 +164,16 @@ function CampGroupsView({
   );
 
   // Unique sections involved in the events shown here — drives the missing-FlexiRecord banner.
+  // Sections without a real sectionname are skipped so they don't get classified as
+  // synthetic "Section <id>" placeholders that would defeat the adults-only check.
   const eventSections = useMemo(() => {
     const seen = new Map();
     for (const event of events || []) {
       const sectionid = event.sectionid;
       if (sectionid === null || sectionid === undefined || seen.has(sectionid)) continue;
-      seen.set(sectionid, {
-        sectionid,
-        sectionname: event.sectionname || event.section_name || `Section ${sectionid}`,
-      });
+      const sectionname = event.sectionname || event.section_name;
+      if (!sectionname) continue;
+      seen.set(sectionid, { sectionid, sectionname });
     }
     return Array.from(seen.values());
   }, [events]);
@@ -180,11 +181,11 @@ function CampGroupsView({
   // The banner's hook silently filters out adults / waiting-list sections, so for
   // adults-only events it would render nothing — leaving the user staring at an
   // empty "Unassigned" grid. Detect that case at the parent and show an explanation.
+  // Uses the same isOperationalSection helper the hook uses to keep classification
+  // logic consistent between parent (decides which UI to show) and hook (decides
+  // which sections to validate).
   const hasOperationalEventSection = useMemo(
-    () => eventSections.some(s => {
-      const name = (s.sectionname || '').toLowerCase();
-      return !(name.includes('adults') || name.includes('waiting'));
-    }),
+    () => eventSections.some(isOperationalSection),
     [eventSections],
   );
 
@@ -749,7 +750,7 @@ function CampGroupsView({
           )}
         </div>
 
-        {!summary.vikingEventDataAvailable && (
+        {!summary.vikingEventDataAvailable && eventSections.length > 0 && (
           hasOperationalEventSection ? (
             <MissingFlexiRecordsBanner sections={eventSections} />
           ) : (

--- a/src/features/events/components/__tests__/CampGroupsView.bannerBranching.test.jsx
+++ b/src/features/events/components/__tests__/CampGroupsView.bannerBranching.test.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { APP: 'APP', API: 'API', COMPONENT: 'COMPONENT', ERROR: 'ERROR' },
+}));
+
+vi.mock('../../../../shared/utils/platform.js', () => ({
+  isMobileLayout: () => false,
+}));
+
+vi.mock('../../services/campGroupAllocationService.js', () => ({
+  assignMemberToCampGroup: vi.fn(),
+  batchAssignMembers: vi.fn(),
+  extractFlexiRecordContext: vi.fn(),
+  bulkUpdateCampGroups: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/auth/tokenService.js', () => ({
+  getToken: vi.fn(() => 'tok'),
+}));
+
+vi.mock('../../../../shared/utils/notifications.js', () => ({
+  notifyError: vi.fn(),
+  notifyInfo: vi.fn(),
+  notifySuccess: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/storage/database.js', () => ({
+  default: { getSections: vi.fn(async () => []) },
+}));
+
+vi.mock('../CampGroupCard.jsx', () => ({ default: () => null }));
+vi.mock('../GroupNamesEditModal.jsx', () => ({ default: () => null }));
+
+vi.mock('../../../flexi-records', () => ({
+  MissingFlexiRecordsBanner: () => <div data-testid="missing-flexi-banner">banner</div>,
+  isOperationalSection: (section) => {
+    const name = (section?.sectionname || section?.name || '').toLowerCase();
+    if (!name) return false;
+    return !(name.includes('adults') || name.includes('waiting') || name.includes('waitinglist'));
+  },
+}));
+
+import CampGroupsView from '../CampGroupsView.jsx';
+
+describe('CampGroupsView — missing-flexi banner branching', () => {
+  it('renders the actionable banner when at least one event section is operational', () => {
+    render(
+      <CampGroupsView
+        attendees={[{ scoutid: 1, person_type: 'Leaders', name: 'A Leader' }]}
+        events={[
+          { sectionid: 1, sectionname: 'Beavers' },
+          { sectionid: 2, sectionname: 'Adults' },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId('missing-flexi-banner')).toBeInTheDocument();
+    expect(screen.queryByText(/no young people in this view/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the adults-only explanatory alert when every event section is non-operational', () => {
+    render(
+      <CampGroupsView
+        attendees={[{ scoutid: 1, person_type: 'Leaders', name: 'A Leader' }]}
+        events={[
+          { sectionid: 1, sectionname: 'Adults' },
+          { sectionid: 2, sectionname: 'Waiting List' },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/no young people in this view/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('missing-flexi-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders neither banner nor alert when there are no events to classify', () => {
+    render(<CampGroupsView attendees={[]} events={[]} />);
+    expect(screen.queryByTestId('missing-flexi-banner')).not.toBeInTheDocument();
+    expect(screen.queryByText(/no young people in this view/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the banner when an event section has no name (synthetic placeholder is skipped, but other sections may be operational)', () => {
+    render(
+      <CampGroupsView
+        attendees={[{ scoutid: 1, person_type: 'Leaders', name: 'A Leader' }]}
+        events={[
+          { sectionid: 1 },
+          { sectionid: 2, sectionname: 'Cubs' },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId('missing-flexi-banner')).toBeInTheDocument();
+  });
+});

--- a/src/features/flexi-records/__tests__/MissingFlexiRecordsBanner.test.jsx
+++ b/src/features/flexi-records/__tests__/MissingFlexiRecordsBanner.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../hooks/useMissingFlexiRecords.js', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../components/CreateMissingFlexiModal', () => ({
+  default: () => <div data-testid="create-modal" />,
+}));
+
+import useMissingFlexiRecords from '../hooks/useMissingFlexiRecords.js';
+import MissingFlexiRecordsBanner from '../components/MissingFlexiRecordsBanner';
+
+const someGap = {
+  section: { sectionid: 1, sectionname: 'Beavers' },
+  termId: 'T1',
+  missingRecords: [
+    { template: { name: 'Viking Section Movers', fields: [] }, reason: 'absent', missingFields: [] },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('MissingFlexiRecordsBanner', () => {
+  it('renders nothing when token_expired is true', () => {
+    localStorage.setItem('token_expired', 'true');
+    useMissingFlexiRecords.mockReturnValue({ loading: false, missing: [someGap], refresh: vi.fn() });
+    const { container } = render(<MissingFlexiRecordsBanner sections={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when nothing is missing', () => {
+    useMissingFlexiRecords.mockReturnValue({ loading: false, missing: [], refresh: vi.fn() });
+    const { container } = render(<MissingFlexiRecordsBanner sections={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a warning alert with a CTA when records are missing', () => {
+    useMissingFlexiRecords.mockReturnValue({ loading: false, missing: [someGap], refresh: vi.fn() });
+    render(<MissingFlexiRecordsBanner sections={[]} />);
+    expect(screen.getByText(/FlexiRecords need to be set up/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /review and create/i })).toBeInTheDocument();
+  });
+
+  it('renders nothing while loading', () => {
+    useMissingFlexiRecords.mockReturnValue({ loading: true, missing: [], refresh: vi.fn() });
+    const { container } = render(<MissingFlexiRecordsBanner sections={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
+++ b/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
@@ -30,8 +30,8 @@ beforeEach(() => {
 describe('createOrCompleteFlexiRecord', () => {
   it('creates the FlexiRecord and adds every template field when none exist', async () => {
     getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
-    createFlexiRecord.mockResolvedValueOnce({ success: true, flexirecordid: 9001, name: template.name });
-    addFlexiColumn.mockResolvedValue({ success: true, columnid: 'f_1' });
+    createFlexiRecord.mockResolvedValueOnce({ flexirecordid: 9001, name: template.name });
+    addFlexiColumn.mockResolvedValue({ columnid: 'f_1', name: 'Some Field' });
     getFlexiRecordsList.mockResolvedValue({ items: [] });
     getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
 
@@ -45,6 +45,44 @@ describe('createOrCompleteFlexiRecord', () => {
     expect(addFlexiColumn).toHaveBeenCalledTimes(template.fields.length);
   });
 
+  it('accepts createFlexiRecord responses that use extraid instead of flexirecordid', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
+    createFlexiRecord.mockResolvedValueOnce({ extraid: 5555 });
+    addFlexiColumn.mockResolvedValue({});
+    getFlexiRecordsList.mockResolvedValue({ items: [] });
+    getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(true);
+    expect(result.flexirecordid).toBe(5555);
+  });
+
+  it('treats addFlexiColumn responses with an error key as a per-field failure', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
+    createFlexiRecord.mockResolvedValueOnce({ flexirecordid: 1 });
+    addFlexiColumn.mockResolvedValue({ error: 'Permission denied' });
+    getFlexiRecordsList.mockResolvedValue({ items: [] });
+    getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBe(template.fields.length);
+    expect(result.errors[0].error).toBe('Permission denied');
+  });
+
+  it('bails with a meta error when createFlexiRecord returns no id', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
+    createFlexiRecord.mockResolvedValueOnce({ error: 'Permission denied' });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].field).toBe('_meta');
+    expect(addFlexiColumn).not.toHaveBeenCalled();
+  });
+
   it('skips creation and only adds the missing fields when the record already exists', async () => {
     getFlexiRecordsList.mockResolvedValueOnce({
       items: [{ name: template.name, extraid: 7777 }],
@@ -55,7 +93,7 @@ describe('createOrCompleteFlexiRecord', () => {
         f_2: { name: 'AssignedTerm' },
       },
     });
-    addFlexiColumn.mockResolvedValue({ success: true });
+    addFlexiColumn.mockResolvedValue({});
     getFlexiRecordsList.mockResolvedValue({ items: [{ name: template.name, extraid: 7777 }] });
     getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
 
@@ -94,11 +132,11 @@ describe('createOrCompleteFlexiRecord', () => {
 
   it('records per-field errors when addFlexiColumn fails midway and returns partial success', async () => {
     getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
-    createFlexiRecord.mockResolvedValueOnce({ success: true, flexirecordid: 1 });
+    createFlexiRecord.mockResolvedValueOnce({ flexirecordid: 1 });
     addFlexiColumn
-      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({})
       .mockRejectedValueOnce(new Error('rate limited'))
-      .mockResolvedValue({ success: true });
+      .mockResolvedValue({});
     getFlexiRecordsList.mockResolvedValue({ items: [] });
     getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
 

--- a/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
+++ b/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { API: 'API', APP: 'APP', ERROR: 'ERROR' },
+}));
+
+vi.mock('../../../shared/services/api/api/flexiRecords.js', () => ({
+  createFlexiRecord: vi.fn(),
+  addFlexiColumn: vi.fn(),
+}));
+
+vi.mock('../../events/services/flexiRecordService.js', () => ({
+  getFlexiRecordsList: vi.fn(),
+  getFlexiRecordStructure: vi.fn(),
+}));
+
+import { createFlexiRecord, addFlexiColumn } from '../../../shared/services/api/api/flexiRecords.js';
+import { getFlexiRecordsList, getFlexiRecordStructure } from '../../events/services/flexiRecordService.js';
+import { createOrCompleteFlexiRecord } from '../services/flexiRecordCreationService.js';
+import { VIKING_SECTION_MOVERS } from '../services/flexiRecordTemplates.js';
+
+const section = { sectionid: 42, sectionname: 'Beavers' };
+const template = VIKING_SECTION_MOVERS;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createOrCompleteFlexiRecord', () => {
+  it('creates the FlexiRecord and adds every template field when none exist', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
+    createFlexiRecord.mockResolvedValueOnce({ success: true, flexirecordid: 9001, name: template.name });
+    addFlexiColumn.mockResolvedValue({ success: true, columnid: 'f_1' });
+    getFlexiRecordsList.mockResolvedValue({ items: [] });
+    getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(true);
+    expect(result.createdRecord).toBe(true);
+    expect(result.flexirecordid).toBe(9001);
+    expect(result.addedFields).toEqual(template.fields);
+    expect(createFlexiRecord).toHaveBeenCalledTimes(1);
+    expect(addFlexiColumn).toHaveBeenCalledTimes(template.fields.length);
+  });
+
+  it('skips creation and only adds the missing fields when the record already exists', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({
+      items: [{ name: template.name, extraid: 7777 }],
+    });
+    getFlexiRecordStructure.mockResolvedValueOnce({
+      fieldMapping: {
+        f_1: { name: 'AssignedSection' },
+        f_2: { name: 'AssignedTerm' },
+      },
+    });
+    addFlexiColumn.mockResolvedValue({ success: true });
+    getFlexiRecordsList.mockResolvedValue({ items: [{ name: template.name, extraid: 7777 }] });
+    getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.createdRecord).toBe(false);
+    expect(result.flexirecordid).toBe(7777);
+    expect(createFlexiRecord).not.toHaveBeenCalled();
+    expect(addFlexiColumn).toHaveBeenCalledTimes(template.fields.length - 2);
+    const addedNames = addFlexiColumn.mock.calls.map(c => c[2]);
+    expect(addedNames).not.toContain('AssignedSection');
+    expect(addedNames).not.toContain('AssignedTerm');
+    expect(result.success).toBe(true);
+  });
+
+  it('is a no-op when the record already has every template field', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({
+      items: [{ name: template.name, extraid: 5 }],
+    });
+    getFlexiRecordStructure.mockResolvedValueOnce({
+      fieldMapping: Object.fromEntries(
+        template.fields.map((name, idx) => [`f_${idx}`, { name }]),
+      ),
+    });
+    getFlexiRecordsList.mockResolvedValue({ items: [{ name: template.name, extraid: 5 }] });
+    getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(true);
+    expect(result.createdRecord).toBe(false);
+    expect(result.addedFields).toEqual([]);
+    expect(createFlexiRecord).not.toHaveBeenCalled();
+    expect(addFlexiColumn).not.toHaveBeenCalled();
+  });
+
+  it('records per-field errors when addFlexiColumn fails midway and returns partial success', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({ items: [] });
+    createFlexiRecord.mockResolvedValueOnce({ success: true, flexirecordid: 1 });
+    addFlexiColumn
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockResolvedValue({ success: true });
+    getFlexiRecordsList.mockResolvedValue({ items: [] });
+    getFlexiRecordStructure.mockResolvedValue({ fieldMapping: {} });
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ field: template.fields[1], error: 'rate limited' });
+    expect(result.addedFields).toContain(template.fields[0]);
+    expect(result.addedFields).not.toContain(template.fields[1]);
+  });
+
+  it('returns a meta error when the token is missing', async () => {
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: '' });
+    expect(result.success).toBe(false);
+    expect(result.errors[0].field).toBe('_meta');
+    expect(getFlexiRecordsList).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
+++ b/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
@@ -155,4 +155,19 @@ describe('createOrCompleteFlexiRecord', () => {
     expect(result.errors[0].field).toBe('_meta');
     expect(getFlexiRecordsList).not.toHaveBeenCalled();
   });
+
+  it('bails with a meta error if structure fetch fails on an existing record (avoids re-adding existing columns)', async () => {
+    getFlexiRecordsList.mockResolvedValueOnce({
+      items: [{ name: template.name, extraid: 4242 }],
+    });
+    getFlexiRecordStructure.mockRejectedValueOnce(new Error('OSM unavailable'));
+
+    const result = await createOrCompleteFlexiRecord({ section, template, termId: 'T1', token: 'tok' });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe('_meta');
+    expect(result.errors[0].error).toContain('OSM unavailable');
+    expect(addFlexiColumn).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
+++ b/src/features/flexi-records/__tests__/flexiRecordCreationService.test.js
@@ -147,6 +147,7 @@ describe('createOrCompleteFlexiRecord', () => {
     expect(result.errors[0]).toMatchObject({ field: template.fields[1], error: 'rate limited' });
     expect(result.addedFields).toContain(template.fields[0]);
     expect(result.addedFields).not.toContain(template.fields[1]);
+    expect(result.flexirecordid).toBe(1);
   });
 
   it('returns a meta error when the token is missing', async () => {

--- a/src/features/flexi-records/__tests__/useMissingFlexiRecords.test.js
+++ b/src/features/flexi-records/__tests__/useMissingFlexiRecords.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { APP: 'APP' },
+}));
+
+vi.mock('../../../shared/services/auth/tokenService.js', () => ({
+  getToken: vi.fn(() => 'tok'),
+}));
+
+vi.mock('../../../shared/services/api/api/terms.js', () => ({
+  fetchMostRecentTermId: vi.fn(async () => 'T1'),
+}));
+
+vi.mock('../../movements/services/vikingSectionMoversValidation.js', () => ({
+  validateVikingSectionMoversFlexiRecord: vi.fn(),
+}));
+
+vi.mock('../services/vikingEventMgmtValidation.js', () => ({
+  validateVikingEventMgmtFlexiRecord: vi.fn(),
+}));
+
+import { validateVikingSectionMoversFlexiRecord } from '../../movements/services/vikingSectionMoversValidation.js';
+import { validateVikingEventMgmtFlexiRecord } from '../services/vikingEventMgmtValidation.js';
+import useMissingFlexiRecords from '../hooks/useMissingFlexiRecords.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useMissingFlexiRecords', () => {
+  it('skips adults and waitinglist sections', async () => {
+    validateVikingSectionMoversFlexiRecord.mockResolvedValue({ isValid: true, hasFlexiRecord: true, missingFields: [] });
+    validateVikingEventMgmtFlexiRecord.mockResolvedValue({ isValid: true, hasFlexiRecord: true, missingFields: [] });
+
+    const sections = [
+      { sectionid: 1, sectionname: 'Adults' },
+      { sectionid: 2, sectionname: 'Waiting List' },
+    ];
+
+    const { result } = renderHook(() => useMissingFlexiRecords(sections));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.missing).toEqual([]);
+    expect(validateVikingSectionMoversFlexiRecord).not.toHaveBeenCalled();
+    expect(validateVikingEventMgmtFlexiRecord).not.toHaveBeenCalled();
+  });
+
+  it('reports absent when the record does not exist', async () => {
+    validateVikingSectionMoversFlexiRecord.mockResolvedValue({
+      isValid: false,
+      hasFlexiRecord: false,
+      missingFields: [],
+    });
+    validateVikingEventMgmtFlexiRecord.mockResolvedValue({
+      isValid: true,
+      hasFlexiRecord: true,
+      missingFields: [],
+    });
+
+    const { result } = renderHook(() =>
+      useMissingFlexiRecords([{ sectionid: 7, sectionname: 'Beavers' }]),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.missing).toHaveLength(1);
+    const [gap] = result.current.missing;
+    expect(gap.section.sectionid).toBe(7);
+    expect(gap.missingRecords).toHaveLength(1);
+    expect(gap.missingRecords[0].reason).toBe('absent');
+    expect(gap.missingRecords[0].template.name).toBe('Viking Section Movers');
+  });
+
+  it('reports incomplete when the record exists but is missing fields', async () => {
+    validateVikingSectionMoversFlexiRecord.mockResolvedValue({ isValid: true, hasFlexiRecord: true, missingFields: [] });
+    validateVikingEventMgmtFlexiRecord.mockResolvedValue({
+      isValid: false,
+      hasFlexiRecord: true,
+      missingFields: [{ fieldName: 'CampGroup' }, { fieldName: 'SignedInBy' }],
+    });
+
+    const { result } = renderHook(() =>
+      useMissingFlexiRecords([{ sectionid: 7, sectionname: 'Beavers' }]),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.missing).toHaveLength(1);
+    const [gap] = result.current.missing;
+    expect(gap.missingRecords[0].reason).toBe('incomplete');
+    expect(gap.missingRecords[0].missingFields).toEqual(['CampGroup', 'SignedInBy']);
+    expect(gap.missingRecords[0].template.name).toBe('Viking Event Mgmt');
+  });
+});

--- a/src/features/flexi-records/__tests__/useMissingFlexiRecords.test.js
+++ b/src/features/flexi-records/__tests__/useMissingFlexiRecords.test.js
@@ -92,4 +92,25 @@ describe('useMissingFlexiRecords', () => {
     expect(gap.missingRecords[0].missingFields).toEqual(['CampGroup', 'SignedInBy']);
     expect(gap.missingRecords[0].template.name).toBe('Viking Event Mgmt');
   });
+
+  it('skips sections where the validator hit a network error rather than reporting them as absent', async () => {
+    validateVikingSectionMoversFlexiRecord.mockResolvedValue({
+      isValid: false,
+      hasFlexiRecord: false,
+      networkError: true,
+      missingFields: [],
+    });
+    validateVikingEventMgmtFlexiRecord.mockResolvedValue({
+      isValid: true,
+      hasFlexiRecord: true,
+      missingFields: [],
+    });
+
+    const { result } = renderHook(() =>
+      useMissingFlexiRecords([{ sectionid: 7, sectionname: 'Beavers' }]),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.missing).toEqual([]);
+  });
 });

--- a/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
+++ b/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
@@ -120,50 +120,68 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
     let okCount = 0;
     let failCount = 0;
 
-    for (const key of keysToRun) {
-      const cell = snapshot[key];
-      if (!cell) {
-        logger.warn('runCreation: missing cell in snapshot — skipping', { key }, LOG_CATEGORIES.COMPONENT);
-        continue;
-      }
+    try {
+      for (const key of keysToRun) {
+        const cell = snapshot[key];
+        if (!cell) {
+          logger.warn('runCreation: missing cell in snapshot — skipping', { key }, LOG_CATEGORIES.COMPONENT);
+          continue;
+        }
 
-      setCells(prev => ({
-        ...prev,
-        [key]: { ...prev[key], status: 'inProgress', error: null },
-      }));
+        setCells(prev => ({
+          ...prev,
+          [key]: { ...prev[key], status: 'inProgress', error: null },
+        }));
 
-      const result = await createOrCompleteFlexiRecord({
-        section: { sectionid: cell.sectionid, sectionname: cell.sectionname },
-        template: cell.template,
-        termId: cell.termId,
-        token,
-      });
+        try {
+          const result = await createOrCompleteFlexiRecord({
+            section: { sectionid: cell.sectionid, sectionname: cell.sectionname },
+            template: cell.template,
+            termId: cell.termId,
+            token,
+          });
 
-      if (result.success) {
-        okCount += 1;
-        setCells(prev => {
-          const previousAdded = prev[key]?.addedFields || [];
-          const merged = Array.from(new Set([...previousAdded, ...result.addedFields]));
-          return {
+          if (result.success) {
+            okCount += 1;
+            setCells(prev => {
+              const previousAdded = prev[key]?.addedFields || [];
+              const merged = Array.from(new Set([...previousAdded, ...result.addedFields]));
+              return {
+                ...prev,
+                [key]: { ...prev[key], status: 'success', addedFields: merged, error: null },
+              };
+            });
+          } else {
+            failCount += 1;
+            const detail = result.errors.map(e => `${e.field}: ${e.error}`).join('; ') || 'Unknown error';
+            setCells(prev => {
+              const previousAdded = prev[key]?.addedFields || [];
+              const merged = Array.from(new Set([...previousAdded, ...result.addedFields]));
+              return {
+                ...prev,
+                [key]: { ...prev[key], status: 'failed', error: detail, addedFields: merged },
+              };
+            });
+          }
+        } catch (error) {
+          logger.error('runCreation: unexpected exception during create', {
+            key,
+            error: error.message,
+          }, LOG_CATEGORIES.COMPONENT);
+          failCount += 1;
+          setCells(prev => ({
             ...prev,
-            [key]: { ...prev[key], status: 'success', addedFields: merged, error: null },
-          };
-        });
-      } else {
-        failCount += 1;
-        const detail = result.errors.map(e => `${e.field}: ${e.error}`).join('; ') || 'Unknown error';
-        setCells(prev => {
-          const previousAdded = prev[key]?.addedFields || [];
-          const merged = Array.from(new Set([...previousAdded, ...result.addedFields]));
-          return {
-            ...prev,
-            [key]: { ...prev[key], status: 'failed', error: detail, addedFields: merged },
-          };
-        });
+            [key]: {
+              ...prev[key],
+              status: 'failed',
+              error: error.message || 'Unexpected error',
+            },
+          }));
+        }
       }
+    } finally {
+      setRunning(false);
     }
-
-    setRunning(false);
 
     if (okCount && !failCount) {
       notifySuccess(`Created ${okCount} FlexiRecord${okCount === 1 ? '' : 's'} successfully.`);
@@ -183,20 +201,15 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
   };
 
   const handleRetryFailed = () => {
-    const failedKeys = Object.entries(cells)
-      .filter(([, c]) => c.status === 'failed')
-      .map(([k]) => k);
-    if (failedKeys.length === 0) return;
+    const failedEntries = Object.entries(cells).filter(([, c]) => c.status === 'failed');
+    if (failedEntries.length === 0) return;
 
-    const retrySnapshot = {};
-    setCells(prev => {
-      const next = { ...prev };
-      for (const k of failedKeys) {
-        next[k] = { ...next[k], status: 'pending', error: null };
-        retrySnapshot[k] = next[k];
-      }
-      return next;
-    });
+    const failedKeys = failedEntries.map(([k]) => k);
+    const retrySnapshot = Object.fromEntries(
+      failedEntries.map(([k, c]) => [k, { ...c, status: 'pending', error: null }]),
+    );
+
+    setCells(prev => ({ ...prev, ...retrySnapshot }));
     runCreation(failedKeys, retrySnapshot);
   };
 

--- a/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
+++ b/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
@@ -1,0 +1,318 @@
+import React, { useEffect, useId, useMemo, useState } from 'react';
+import Modal from '../../../shared/components/ui/Modal';
+import { notifySuccess, notifyError } from '../../../shared/utils/notifications.js';
+import { getToken } from '../../../shared/services/auth/tokenService.js';
+import { createOrCompleteFlexiRecord } from '../services/flexiRecordCreationService.js';
+
+const BUTTON_BASE = 'inline-flex items-center justify-center rounded-md font-medium px-4 py-2 text-base focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed';
+const BUTTON_PRIMARY = `${BUTTON_BASE} bg-scout-blue text-white hover:bg-scout-blue-dark focus:ring-scout-blue-light`;
+const BUTTON_SECONDARY = `${BUTTON_BASE} bg-gray-500 text-white hover:bg-gray-600 focus:ring-gray-300`;
+
+const STATUS_ICON = {
+  pending: <span className="inline-block w-3 h-3 rounded-full bg-gray-300" aria-label="pending" />,
+  inProgress: <span className="inline-block w-3 h-3 rounded-full bg-blue-500 animate-pulse" aria-label="in progress" />,
+  success: <span className="inline-block w-3 h-3 rounded-full bg-green-500" aria-label="success" />,
+  failed: <span className="inline-block w-3 h-3 rounded-full bg-red-500" aria-label="failed" />,
+  skipped: <span className="inline-block w-3 h-3 rounded-full bg-gray-200 border border-gray-300" aria-label="skipped" />,
+};
+
+/**
+ * Build the initial table model from the missing-records gap list.
+ * Each cell key is `${sectionid}::${templateName}` for stable React keys.
+ */
+function buildInitialCells(missing) {
+  const cells = {};
+  for (const gap of missing) {
+    for (const record of gap.missingRecords) {
+      const key = `${gap.section.sectionid}::${record.template.name}`;
+      cells[key] = {
+        sectionid: gap.section.sectionid,
+        sectionname: gap.section.sectionname,
+        termId: gap.termId,
+        template: record.template,
+        reason: record.reason,
+        missingFields: record.missingFields,
+        selected: true,
+        status: 'pending',
+        error: null,
+        addedFields: [],
+      };
+    }
+  }
+  return cells;
+}
+
+/**
+ * Modal that lets the user create / complete missing FlexiRecords for sections.
+ *
+ * @param {Object} props
+ * @param {boolean} props.isOpen
+ * @param {() => void} props.onClose - Called when the user closes the modal (after creation completes)
+ * @param {Array<import('../hooks/useMissingFlexiRecords.js').SectionGap>} props.missing
+ */
+export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
+  const titleId = useId();
+  const [showFields, setShowFields] = useState(false);
+  const [cells, setCells] = useState(() => buildInitialCells(missing || []));
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setCells(buildInitialCells(missing || []));
+      setShowFields(false);
+    }
+  }, [isOpen, missing]);
+
+  const sections = useMemo(() => {
+    const seen = new Map();
+    Object.values(cells).forEach(c => {
+      if (!seen.has(c.sectionid)) {
+        seen.set(c.sectionid, { sectionid: c.sectionid, sectionname: c.sectionname });
+      }
+    });
+    return Array.from(seen.values());
+  }, [cells]);
+
+  const templates = useMemo(() => {
+    const seen = new Map();
+    Object.values(cells).forEach(c => {
+      if (!seen.has(c.template.name)) seen.set(c.template.name, c.template);
+    });
+    return Array.from(seen.values());
+  }, [cells]);
+
+  const cellKey = (sectionid, templateName) => `${sectionid}::${templateName}`;
+  const cellFor = (sectionid, templateName) => cells[cellKey(sectionid, templateName)];
+
+  const selectedCount = Object.values(cells).filter(c => c.selected && c.status === 'pending').length;
+  const failedCount = Object.values(cells).filter(c => c.status === 'failed').length;
+  const successCount = Object.values(cells).filter(c => c.status === 'success').length;
+  const allDone = !running && Object.values(cells).every(c => c.status !== 'pending' || !c.selected);
+
+  const toggleCell = (key) => {
+    if (running) return;
+    setCells(prev => {
+      const cell = prev[key];
+      if (!cell || cell.status !== 'pending') return prev;
+      return { ...prev, [key]: { ...cell, selected: !cell.selected } };
+    });
+  };
+
+  const runCreation = async (keysToRun) => {
+    const token = getToken();
+    if (!token) {
+      notifyError('Cannot create FlexiRecords without a valid OSM session.');
+      return;
+    }
+
+    setRunning(true);
+    let okCount = 0;
+    let failCount = 0;
+
+    for (const key of keysToRun) {
+      setCells(prev => ({
+        ...prev,
+        [key]: { ...prev[key], status: 'inProgress', error: null },
+      }));
+
+      const cell = cells[key];
+      const result = await createOrCompleteFlexiRecord({
+        section: { sectionid: cell.sectionid, sectionname: cell.sectionname },
+        template: cell.template,
+        termId: cell.termId,
+        token,
+      });
+
+      if (result.success) {
+        okCount += 1;
+        setCells(prev => ({
+          ...prev,
+          [key]: { ...prev[key], status: 'success', addedFields: result.addedFields, error: null },
+        }));
+      } else {
+        failCount += 1;
+        const detail = result.errors.map(e => `${e.field}: ${e.error}`).join('; ') || 'Unknown error';
+        setCells(prev => ({
+          ...prev,
+          [key]: { ...prev[key], status: 'failed', error: detail, addedFields: result.addedFields },
+        }));
+      }
+    }
+
+    setRunning(false);
+
+    if (okCount && !failCount) {
+      notifySuccess(`Created ${okCount} FlexiRecord${okCount === 1 ? '' : 's'} successfully.`);
+    } else if (okCount && failCount) {
+      notifyError(`Created ${okCount}, failed ${failCount}. Review the table for details.`);
+    } else if (failCount && !okCount) {
+      notifyError(`All ${failCount} create operations failed. Review the table for details.`);
+    }
+  };
+
+  const handleSubmit = () => {
+    const keys = Object.entries(cells)
+      .filter(([, c]) => c.selected && c.status === 'pending')
+      .map(([k]) => k);
+    if (keys.length === 0) return;
+    runCreation(keys);
+  };
+
+  const handleRetryFailed = () => {
+    const failedKeys = Object.entries(cells)
+      .filter(([, c]) => c.status === 'failed')
+      .map(([k]) => k);
+    if (failedKeys.length === 0) return;
+    setCells(prev => {
+      const next = { ...prev };
+      for (const k of failedKeys) {
+        next[k] = { ...next[k], status: 'pending', error: null };
+      }
+      return next;
+    });
+    runCreation(failedKeys);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={running ? undefined : onClose}
+      size="3xl"
+      closeOnOverlayClick={false}
+      closeOnEscape={!running}
+      ariaLabelledBy={titleId}
+    >
+      <Modal.Header>
+        <Modal.Title id={titleId}>Create missing FlexiRecords</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p className="text-gray-700 mb-4">
+          The following sections are missing FlexiRecords required by sign-in, camp groups, or movements features.
+          Untick anything you don&apos;t want to create.
+        </p>
+
+        <div className="overflow-x-auto border border-gray-200 rounded-md">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th scope="col" className="text-left px-3 py-2 font-semibold text-gray-700">Section</th>
+                {templates.map(t => (
+                  <th key={t.name} scope="col" className="text-left px-3 py-2 font-semibold text-gray-700">
+                    {t.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {sections.map(section => (
+                <tr key={section.sectionid}>
+                  <td className="px-3 py-2 text-gray-900">{section.sectionname}</td>
+                  {templates.map(t => {
+                    const cell = cellFor(section.sectionid, t.name);
+                    if (!cell) {
+                      return (
+                        <td key={t.name} className="px-3 py-2 text-gray-400">
+                          <span aria-label="already present">—</span>
+                        </td>
+                      );
+                    }
+                    const label = cell.reason === 'absent'
+                      ? 'Create record'
+                      : `Add ${cell.missingFields.length} field${cell.missingFields.length === 1 ? '' : 's'}`;
+                    return (
+                      <td key={t.name} className="px-3 py-2">
+                        <label className="inline-flex items-center gap-2 cursor-pointer">
+                          {cell.status === 'pending' ? (
+                            <input
+                              type="checkbox"
+                              className="rounded border-gray-300 text-scout-blue focus:ring-scout-blue"
+                              checked={cell.selected}
+                              onChange={() => toggleCell(cellKey(section.sectionid, t.name))}
+                              disabled={running}
+                            />
+                          ) : (
+                            STATUS_ICON[cell.status] || STATUS_ICON.pending
+                          )}
+                          <span className={cell.status === 'failed' ? 'text-red-700' : 'text-gray-700'}>
+                            {label}
+                          </span>
+                        </label>
+                        {cell.status === 'failed' && cell.error && (
+                          <div className="mt-1 text-xs text-red-700 break-words">{cell.error}</div>
+                        )}
+                        {cell.status === 'success' && cell.addedFields.length > 0 && (
+                          <div className="mt-1 text-xs text-gray-500">
+                            Added: {cell.addedFields.join(', ')}
+                          </div>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <button
+          type="button"
+          className="mt-4 text-sm text-scout-blue hover:underline"
+          onClick={() => setShowFields(s => !s)}
+        >
+          {showFields ? 'Hide' : 'Show'} fields that will be created
+        </button>
+
+        {showFields && (
+          <dl className="mt-2 text-sm text-gray-700 space-y-2">
+            {templates.map(t => (
+              <div key={t.name}>
+                <dt className="font-semibold">{t.name}</dt>
+                <dd className="ml-4 text-gray-600">
+                  Fields: {t.fields.join(', ')}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </Modal.Body>
+      <Modal.Footer align="between">
+        <div className="text-sm text-gray-600 self-center">
+          {running && 'Working…'}
+          {!running && allDone && (
+            <span>
+              {successCount} succeeded{failedCount > 0 ? `, ${failedCount} failed` : ''}
+            </span>
+          )}
+          {!running && !allDone && selectedCount > 0 && (
+            <span>{selectedCount} selected</span>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {failedCount > 0 && !running && (
+            <button type="button" className={BUTTON_SECONDARY} onClick={handleRetryFailed}>
+              Retry failed
+            </button>
+          )}
+          <button
+            type="button"
+            className={BUTTON_SECONDARY}
+            onClick={onClose}
+            disabled={running}
+          >
+            {allDone ? 'Close' : 'Cancel'}
+          </button>
+          {!allDone && (
+            <button
+              type="button"
+              className={BUTTON_PRIMARY}
+              onClick={handleSubmit}
+              disabled={running || selectedCount === 0}
+            >
+              {running ? 'Creating…' : `Create ${selectedCount} FlexiRecord${selectedCount === 1 ? '' : 's'}`}
+            </button>
+          )}
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
+++ b/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useId, useMemo, useState } from 'react';
 import Modal from '../../../shared/components/ui/Modal';
 import { notifySuccess, notifyError } from '../../../shared/utils/notifications.js';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import { createOrCompleteFlexiRecord } from '../services/flexiRecordCreationService.js';
 
 const BUTTON_BASE = 'inline-flex items-center justify-center rounded-md font-medium px-4 py-2 text-base focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed';
@@ -98,6 +99,16 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
     });
   };
 
+  /**
+   * Iterate over selected cells and call createOrCompleteFlexiRecord for each.
+   *
+   * The snapshot is captured at call-time by the caller (handleSubmit /
+   * handleRetryFailed) — passing it explicitly avoids the stale-closure
+   * problem that would otherwise read pre-update values during the loop.
+   *
+   * @param {string[]} keysToRun - Cell keys to process this run
+   * @param {Object<string, Object>} snapshot - Frozen view of `cells` for this run
+   */
   const runCreation = async (keysToRun, snapshot) => {
     const token = getToken();
     if (!token) {
@@ -111,7 +122,10 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
 
     for (const key of keysToRun) {
       const cell = snapshot[key];
-      if (!cell) continue;
+      if (!cell) {
+        logger.warn('runCreation: missing cell in snapshot — skipping', { key }, LOG_CATEGORIES.COMPONENT);
+        continue;
+      }
 
       setCells(prev => ({
         ...prev,

--- a/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
+++ b/src/features/flexi-records/components/CreateMissingFlexiModal.jsx
@@ -98,7 +98,7 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
     });
   };
 
-  const runCreation = async (keysToRun) => {
+  const runCreation = async (keysToRun, snapshot) => {
     const token = getToken();
     if (!token) {
       notifyError('Cannot create FlexiRecords without a valid OSM session.');
@@ -110,12 +110,14 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
     let failCount = 0;
 
     for (const key of keysToRun) {
+      const cell = snapshot[key];
+      if (!cell) continue;
+
       setCells(prev => ({
         ...prev,
         [key]: { ...prev[key], status: 'inProgress', error: null },
       }));
 
-      const cell = cells[key];
       const result = await createOrCompleteFlexiRecord({
         section: { sectionid: cell.sectionid, sectionname: cell.sectionname },
         template: cell.template,
@@ -125,17 +127,25 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
 
       if (result.success) {
         okCount += 1;
-        setCells(prev => ({
-          ...prev,
-          [key]: { ...prev[key], status: 'success', addedFields: result.addedFields, error: null },
-        }));
+        setCells(prev => {
+          const previousAdded = prev[key]?.addedFields || [];
+          const merged = Array.from(new Set([...previousAdded, ...result.addedFields]));
+          return {
+            ...prev,
+            [key]: { ...prev[key], status: 'success', addedFields: merged, error: null },
+          };
+        });
       } else {
         failCount += 1;
         const detail = result.errors.map(e => `${e.field}: ${e.error}`).join('; ') || 'Unknown error';
-        setCells(prev => ({
-          ...prev,
-          [key]: { ...prev[key], status: 'failed', error: detail, addedFields: result.addedFields },
-        }));
+        setCells(prev => {
+          const previousAdded = prev[key]?.addedFields || [];
+          const merged = Array.from(new Set([...previousAdded, ...result.addedFields]));
+          return {
+            ...prev,
+            [key]: { ...prev[key], status: 'failed', error: detail, addedFields: merged },
+          };
+        });
       }
     }
 
@@ -155,7 +165,7 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
       .filter(([, c]) => c.selected && c.status === 'pending')
       .map(([k]) => k);
     if (keys.length === 0) return;
-    runCreation(keys);
+    runCreation(keys, { ...cells });
   };
 
   const handleRetryFailed = () => {
@@ -163,14 +173,17 @@ export default function CreateMissingFlexiModal({ isOpen, onClose, missing }) {
       .filter(([, c]) => c.status === 'failed')
       .map(([k]) => k);
     if (failedKeys.length === 0) return;
+
+    const retrySnapshot = {};
     setCells(prev => {
       const next = { ...prev };
       for (const k of failedKeys) {
         next[k] = { ...next[k], status: 'pending', error: null };
+        retrySnapshot[k] = next[k];
       }
       return next;
     });
-    runCreation(failedKeys);
+    runCreation(failedKeys, retrySnapshot);
   };
 
   return (

--- a/src/features/flexi-records/components/MissingFlexiRecordsBanner.jsx
+++ b/src/features/flexi-records/components/MissingFlexiRecordsBanner.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import Alert from '../../../shared/components/ui/Alert';
+import useMissingFlexiRecords from '../hooks/useMissingFlexiRecords.js';
+import CreateMissingFlexiModal from './CreateMissingFlexiModal';
+
+/**
+ * Determine whether the current session can perform OSM write operations.
+ * Mirrors the offline-token gate enforced by tokenService.checkWritePermission.
+ */
+function canWrite() {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage?.getItem('token_expired') !== 'true';
+}
+
+/**
+ * Banner that surfaces missing required FlexiRecords for the supplied sections
+ * and lets the user fix them inline.
+ *
+ * Renders nothing when:
+ *  - the session can't perform write operations (offline + expired token), or
+ *  - every supplied section already has both required records.
+ *
+ * @param {Object} props
+ * @param {Array<{ sectionid: string|number, sectionname?: string }>} props.sections
+ */
+export default function MissingFlexiRecordsBanner({ sections }) {
+  const { loading, missing, refresh } = useMissingFlexiRecords(sections);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  if (!canWrite()) return null;
+  if (loading) return null;
+  if (!missing || missing.length === 0) return null;
+
+  const sectionsCount = missing.length;
+  const recordsCount = missing.reduce((sum, gap) => sum + gap.missingRecords.length, 0);
+
+  const summary = sectionsCount === 1
+    ? `${sectionsCount} section is missing ${recordsCount} required FlexiRecord${recordsCount === 1 ? '' : 's'}.`
+    : `${sectionsCount} sections are missing ${recordsCount} required FlexiRecord${recordsCount === 1 ? '' : 's'}.`;
+
+  const handleClose = async () => {
+    setModalOpen(false);
+    await refresh();
+  };
+
+  return (
+    <>
+      <Alert variant="warning" className="mb-4">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <div className="font-semibold">FlexiRecords need to be set up</div>
+            <div className="text-sm">
+              {summary} Sign-in, camp groups, and movements features depend on them.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            className="self-start sm:self-auto inline-flex items-center justify-center rounded-md bg-yellow-600 px-3 py-2 text-sm font-medium text-white hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2"
+          >
+            Review and create
+          </button>
+        </div>
+      </Alert>
+      <CreateMissingFlexiModal
+        isOpen={modalOpen}
+        onClose={handleClose}
+        missing={missing}
+      />
+    </>
+  );
+}

--- a/src/features/flexi-records/hooks/useMissingFlexiRecords.js
+++ b/src/features/flexi-records/hooks/useMissingFlexiRecords.js
@@ -1,0 +1,171 @@
+/**
+ * Detect which sections are missing one of the required FlexiRecords.
+ *
+ * Runs both validators (Movers + Event Mgmt) for every section the caller
+ * cares about, then collects the gaps into a single structure the banner and
+ * modal both consume.
+ *
+ * Adults/waitinglist sections are excluded — they don't use either FlexiRecord.
+ *
+ * @module useMissingFlexiRecords
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getToken } from '../../../shared/services/auth/tokenService.js';
+import { fetchMostRecentTermId } from '../../../shared/services/api/api/terms.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+import { validateVikingSectionMoversFlexiRecord } from '../../movements/services/vikingSectionMoversValidation.js';
+import { validateVikingEventMgmtFlexiRecord } from '../services/vikingEventMgmtValidation.js';
+import {
+  VIKING_SECTION_MOVERS,
+  VIKING_EVENT_MGMT,
+} from '../services/flexiRecordTemplates.js';
+
+/**
+ * @typedef {Object} MissingRecord
+ * @property {import('../services/flexiRecordTemplates.js').FlexiRecordTemplate} template
+ * @property {'absent'|'incomplete'} reason
+ * @property {string[]} missingFields - Names of template fields that are missing
+ */
+
+/**
+ * @typedef {Object} SectionGap
+ * @property {{ sectionid: string|number, sectionname: string }} section
+ * @property {string|number|null} termId - Most-recent term ID for the section (or null if lookup failed)
+ * @property {MissingRecord[]} missingRecords
+ */
+
+const TEMPLATES_BY_NAME = {
+  [VIKING_SECTION_MOVERS.name]: VIKING_SECTION_MOVERS,
+  [VIKING_EVENT_MGMT.name]: VIKING_EVENT_MGMT,
+};
+
+const VALIDATORS = [
+  { template: VIKING_SECTION_MOVERS, validate: validateVikingSectionMoversFlexiRecord },
+  { template: VIKING_EVENT_MGMT, validate: validateVikingEventMgmtFlexiRecord },
+];
+
+/**
+ * Filter out section types that don't need either FlexiRecord.
+ * Mirrors the existing filter in SectionMovementTracker.checkForMissingFlexiRecords.
+ */
+function isOperationalSection(section) {
+  const name = (section?.sectionname || section?.name || '').toLowerCase();
+  if (!name) return false;
+  return !(name.includes('adults') || name.includes('waiting') || name.includes('waitinglist'));
+}
+
+/**
+ * Convert a validator result into a MissingRecord (or null if nothing missing).
+ *
+ * @param {Object} validation - Result from one of the validators
+ * @param {import('../services/flexiRecordTemplates.js').FlexiRecordTemplate} template
+ * @returns {MissingRecord|null}
+ */
+function toMissingRecord(validation, template) {
+  if (validation.isValid) return null;
+
+  if (!validation.hasFlexiRecord) {
+    return {
+      template,
+      reason: 'absent',
+      missingFields: [...template.fields],
+    };
+  }
+
+  const missingFieldNames = (validation.missingFields || []).map(f => f.fieldName);
+  if (missingFieldNames.length === 0) {
+    return null;
+  }
+
+  return {
+    template,
+    reason: 'incomplete',
+    missingFields: missingFieldNames,
+  };
+}
+
+/**
+ * Hook: discover which sections are missing required FlexiRecords.
+ *
+ * @param {Array} sections - Section objects (from databaseService.getSections)
+ * @returns {{ loading: boolean, missing: SectionGap[], refresh: () => Promise<void> }}
+ */
+export default function useMissingFlexiRecords(sections) {
+  const [loading, setLoading] = useState(false);
+  const [missing, setMissing] = useState([]);
+
+  // Stabilise the sections list across renders so detect() doesn't re-fire on
+  // every render of a parent that creates a fresh array literal each time.
+  const sectionKey = (sections || [])
+    .map(s => `${s?.sectionid ?? ''}::${s?.sectionname ?? s?.name ?? ''}`)
+    .join('|');
+
+  const stableSections = useMemo(() => sections || [], [sectionKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const detect = useCallback(async () => {
+    if (!stableSections || stableSections.length === 0) {
+      setMissing([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const token = getToken();
+      if (!token) {
+        logger.info('useMissingFlexiRecords: no token, skipping detection', {}, LOG_CATEGORIES.APP);
+        setMissing([]);
+        return;
+      }
+
+      const operational = stableSections.filter(isOperationalSection);
+      const gaps = [];
+
+      for (const section of operational) {
+        const sectionId = section.sectionid;
+        let termId;
+        try {
+          termId = await fetchMostRecentTermId(sectionId, token);
+        } catch (error) {
+          logger.warn('useMissingFlexiRecords: termId lookup failed', {
+            sectionId,
+            error: error.message,
+          }, LOG_CATEGORIES.APP);
+          continue;
+        }
+        if (!termId) continue;
+
+        const validations = await Promise.all(
+          VALIDATORS.map(({ validate }) => validate(sectionId, termId, token, false)),
+        );
+
+        const missingRecords = validations
+          .map((v, i) => toMissingRecord(v, VALIDATORS[i].template))
+          .filter(Boolean);
+
+        if (missingRecords.length > 0) {
+          gaps.push({
+            section: {
+              sectionid: sectionId,
+              sectionname: section.sectionname || section.name || 'Unknown Section',
+            },
+            termId,
+            missingRecords,
+          });
+        }
+      }
+
+      setMissing(gaps);
+    } finally {
+      setLoading(false);
+    }
+  }, [stableSections]);
+
+  useEffect(() => {
+    detect();
+  }, [detect]);
+
+  return { loading, missing, refresh: detect };
+}
+
+export { TEMPLATES_BY_NAME };

--- a/src/features/flexi-records/hooks/useMissingFlexiRecords.js
+++ b/src/features/flexi-records/hooks/useMissingFlexiRecords.js
@@ -58,11 +58,16 @@ function isOperationalSection(section) {
 /**
  * Convert a validator result into a MissingRecord (or null if nothing missing).
  *
+ * Network errors are treated as "unknown — don't surface": we'd rather hide the
+ * banner for a section we couldn't check than wrongly tell the user their record
+ * is missing when really OSM was just unreachable.
+ *
  * @param {Object} validation - Result from one of the validators
  * @param {import('../services/flexiRecordTemplates.js').FlexiRecordTemplate} template
  * @returns {MissingRecord|null}
  */
 function toMissingRecord(validation, template) {
+  if (validation.networkError) return null;
   if (validation.isValid) return null;
 
   if (!validation.hasFlexiRecord) {

--- a/src/features/flexi-records/hooks/useMissingFlexiRecords.js
+++ b/src/features/flexi-records/hooks/useMissingFlexiRecords.js
@@ -153,13 +153,24 @@ export default function useMissingFlexiRecords(sections) {
         }
         if (!termId) continue;
 
-        const validations = await Promise.all(
-          VALIDATORS.map(({ validate }) => validate(sectionId, termId, token, forceRefresh)),
+        const settled = await Promise.allSettled(
+          VALIDATORS.map(async ({ template, validate }) => ({
+            template,
+            validation: await validate(sectionId, termId, token, forceRefresh),
+          })),
         );
 
-        const missingRecords = validations
-          .map((v, i) => toMissingRecord(v, VALIDATORS[i].template))
-          .filter(Boolean);
+        const missingRecords = settled.flatMap(result => {
+          if (result.status !== 'fulfilled') {
+            logger.warn('useMissingFlexiRecords: validator failed for a section, continuing with rest', {
+              sectionId,
+              error: result.reason?.message ?? String(result.reason),
+            }, LOG_CATEGORIES.APP);
+            return [];
+          }
+          const missing = toMissingRecord(result.value.validation, result.value.template);
+          return missing ? [missing] : [];
+        });
 
         if (missingRecords.length > 0) {
           gaps.push({

--- a/src/features/flexi-records/hooks/useMissingFlexiRecords.js
+++ b/src/features/flexi-records/hooks/useMissingFlexiRecords.js
@@ -46,10 +46,19 @@ const VALIDATORS = [
 ];
 
 /**
- * Filter out section types that don't need either FlexiRecord.
- * Mirrors the existing filter in SectionMovementTracker.checkForMissingFlexiRecords.
+ * True when a section is one that uses the Movers / Event Mgmt FlexiRecords.
+ *
+ * Adults and waiting-list sections never use either record. An empty/missing
+ * section name is treated as non-operational so callers don't get a false
+ * positive on synthetic placeholders.
+ *
+ * Exported so call-sites that decide whether to render the banner UI use the
+ * exact same logic the hook uses internally — keeping parent and hook in sync.
+ *
+ * @param {{ sectionname?: string, name?: string }} section
+ * @returns {boolean}
  */
-function isOperationalSection(section) {
+export function isOperationalSection(section) {
   const name = (section?.sectionname || section?.name || '').toLowerCase();
   if (!name) return false;
   return !(name.includes('adults') || name.includes('waiting') || name.includes('waitinglist'));
@@ -93,6 +102,10 @@ function toMissingRecord(validation, template) {
 /**
  * Hook: discover which sections are missing required FlexiRecords.
  *
+ * The returned `refresh` always force-refreshes the underlying validators so the
+ * banner reflects current OSM state after a successful create — independent of
+ * whether the creation service's best-effort cache prime succeeded.
+ *
  * @param {Array} sections - Section objects (from databaseService.getSections)
  * @returns {{ loading: boolean, missing: SectionGap[], refresh: () => Promise<void> }}
  */
@@ -108,7 +121,7 @@ export default function useMissingFlexiRecords(sections) {
 
   const stableSections = useMemo(() => sections || [], [sectionKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const detect = useCallback(async () => {
+  const detect = useCallback(async (forceRefresh = false) => {
     if (!stableSections || stableSections.length === 0) {
       setMissing([]);
       return;
@@ -141,7 +154,7 @@ export default function useMissingFlexiRecords(sections) {
         if (!termId) continue;
 
         const validations = await Promise.all(
-          VALIDATORS.map(({ validate }) => validate(sectionId, termId, token, false)),
+          VALIDATORS.map(({ validate }) => validate(sectionId, termId, token, forceRefresh)),
         );
 
         const missingRecords = validations
@@ -167,10 +180,12 @@ export default function useMissingFlexiRecords(sections) {
   }, [stableSections]);
 
   useEffect(() => {
-    detect();
+    detect(false);
   }, [detect]);
 
-  return { loading, missing, refresh: detect };
+  const refresh = useCallback(() => detect(true), [detect]);
+
+  return { loading, missing, refresh };
 }
 
 export { TEMPLATES_BY_NAME };

--- a/src/features/flexi-records/index.js
+++ b/src/features/flexi-records/index.js
@@ -1,6 +1,6 @@
 export { default as MissingFlexiRecordsBanner } from './components/MissingFlexiRecordsBanner';
 export { default as CreateMissingFlexiModal } from './components/CreateMissingFlexiModal';
-export { default as useMissingFlexiRecords } from './hooks/useMissingFlexiRecords';
+export { default as useMissingFlexiRecords, isOperationalSection } from './hooks/useMissingFlexiRecords';
 export { createOrCompleteFlexiRecord } from './services/flexiRecordCreationService';
 export {
   REQUIRED_FLEXI_RECORDS,

--- a/src/features/flexi-records/index.js
+++ b/src/features/flexi-records/index.js
@@ -1,0 +1,9 @@
+export { default as MissingFlexiRecordsBanner } from './components/MissingFlexiRecordsBanner';
+export { default as CreateMissingFlexiModal } from './components/CreateMissingFlexiModal';
+export { default as useMissingFlexiRecords } from './hooks/useMissingFlexiRecords';
+export { createOrCompleteFlexiRecord } from './services/flexiRecordCreationService';
+export {
+  REQUIRED_FLEXI_RECORDS,
+  VIKING_SECTION_MOVERS,
+  VIKING_EVENT_MGMT,
+} from './services/flexiRecordTemplates';

--- a/src/features/flexi-records/services/flexiRecordCreationService.js
+++ b/src/features/flexi-records/services/flexiRecordCreationService.js
@@ -138,11 +138,16 @@ export async function createOrCompleteFlexiRecord({ section, template, termId, t
     try {
       existingFieldNames = await getExistingFieldNames(existingRecord.extraid, sectionId, termId, token);
     } catch (error) {
-      logger.warn('Failed to fetch existing structure before adding columns; will attempt to add all template fields', {
+      logger.error('Failed to fetch existing structure before adding columns', {
         sectionId,
         flexirecordid: existingRecord.extraid,
         error: error.message,
       }, LOG_CATEGORIES.API);
+      result.errors.push({
+        field: '_meta',
+        error: `Could not read existing record structure: ${error.message}. Try again — without it we'd risk re-adding columns that already exist.`,
+      });
+      return result;
     }
   } else {
     try {

--- a/src/features/flexi-records/services/flexiRecordCreationService.js
+++ b/src/features/flexi-records/services/flexiRecordCreationService.js
@@ -34,6 +34,26 @@ import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js
  */
 
 /**
+ * Extract a FlexiRecord id from an OSM response.
+ *
+ * The backend forwards OSM's raw JSON response; OSM's `?action=addRecordSet` shape
+ * is undocumented and varies (some endpoints return `flexirecordid`, some `extraid`,
+ * some `id`). Try each known key. Returns null if no id can be found.
+ *
+ * @private
+ * @param {*} response - Whatever createFlexiRecord returned
+ * @returns {string|number|null}
+ */
+function extractRecordId(response) {
+  if (!response || typeof response !== 'object') return null;
+  return response.flexirecordid
+    ?? response.extraid
+    ?? response.id
+    ?? response.recordid
+    ?? null;
+}
+
+/**
  * Read the section's flexi list and find the record matching template.name.
  * Uses cached data when possible.
  *
@@ -41,7 +61,7 @@ import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js
  * @param {string|number} sectionId
  * @param {string} recordName
  * @param {string} token
- * @returns {Promise<{extraid: string|number}|null>}
+ * @returns {Promise<Object|null>} The full OSM record entry (includes name, extraid, etc.) or null
  */
 async function findExistingRecord(sectionId, recordName, token) {
   const flexiList = await getFlexiRecordsList(sectionId, token, false);
@@ -127,12 +147,20 @@ export async function createOrCompleteFlexiRecord({ section, template, termId, t
   } else {
     try {
       const created = await createFlexiRecord(sectionId, template.name, token, template.createOptions);
-      if (!created || !created.success || !created.flexirecordid) {
-        const detail = created?.error || 'createFlexiRecord did not return a flexirecordid';
+      logger.info('createFlexiRecord raw response', {
+        sectionId,
+        template: template.name,
+        responseKeys: created && typeof created === 'object' ? Object.keys(created) : [],
+        responseType: typeof created,
+        responseSnippet: created !== null && created !== undefined ? JSON.stringify(created).slice(0, 300) : 'null',
+      }, LOG_CATEGORIES.API);
+      const newId = extractRecordId(created);
+      if (newId === null || newId === undefined) {
+        const detail = created?.error || `createFlexiRecord did not return a record id (got ${JSON.stringify(created)?.slice(0, 200)})`;
         result.errors.push({ field: '_meta', error: detail });
         return result;
       }
-      result.flexirecordid = created.flexirecordid;
+      result.flexirecordid = newId;
       result.createdRecord = true;
     } catch (error) {
       logger.error('Failed to create FlexiRecord', {
@@ -150,11 +178,16 @@ export async function createOrCompleteFlexiRecord({ section, template, termId, t
   for (const fieldName of fieldsToAdd) {
     try {
       const added = await addFlexiColumn(sectionId, result.flexirecordid, fieldName, token);
-      if (!added || !added.success) {
-        const detail = added?.error || 'addFlexiColumn did not return success';
-        result.errors.push({ field: fieldName, error: detail });
+      if (added && typeof added === 'object' && added.error) {
+        result.errors.push({ field: fieldName, error: String(added.error) });
         continue;
       }
+      logger.debug('addFlexiColumn raw response', {
+        sectionId,
+        flexirecordid: result.flexirecordid,
+        fieldName,
+        responseKeys: added && typeof added === 'object' ? Object.keys(added) : [],
+      }, LOG_CATEGORIES.API);
       result.addedFields.push(fieldName);
     } catch (error) {
       logger.error('Failed to add FlexiRecord column', {

--- a/src/features/flexi-records/services/flexiRecordCreationService.js
+++ b/src/features/flexi-records/services/flexiRecordCreationService.js
@@ -88,7 +88,10 @@ function detectFailureMessage(response) {
 
 /**
  * Read the section's flexi list and find the record matching template.name.
- * Uses cached data when possible.
+ *
+ * Force-refreshes the list because this lookup precedes a non-idempotent
+ * createFlexiRecord call — a stale cached read could miss a record created
+ * in another tab/session and cause us to duplicate it.
  *
  * @private
  * @param {string|number} sectionId
@@ -97,7 +100,7 @@ function detectFailureMessage(response) {
  * @returns {Promise<Object|null>} The full OSM record entry (includes name, extraid, etc.) or null
  */
 async function findExistingRecord(sectionId, recordName, token) {
-  const flexiList = await getFlexiRecordsList(sectionId, token, false);
+  const flexiList = await getFlexiRecordsList(sectionId, token, true);
   const items = flexiList?.items || [];
   return items.find(record => record.name === recordName) || null;
 }

--- a/src/features/flexi-records/services/flexiRecordCreationService.js
+++ b/src/features/flexi-records/services/flexiRecordCreationService.js
@@ -179,14 +179,20 @@ export async function createOrCompleteFlexiRecord({ section, template, termId, t
     try {
       const added = await addFlexiColumn(sectionId, result.flexirecordid, fieldName, token);
       if (added && typeof added === 'object' && added.error) {
+        logger.warn('addFlexiColumn returned error response', {
+          sectionId,
+          flexirecordid: result.flexirecordid,
+          fieldName,
+          osmError: added.error,
+          responseSnippet: JSON.stringify(added).slice(0, 300),
+        }, LOG_CATEGORIES.API);
         result.errors.push({ field: fieldName, error: String(added.error) });
         continue;
       }
-      logger.debug('addFlexiColumn raw response', {
+      logger.debug('addFlexiColumn success', {
         sectionId,
         flexirecordid: result.flexirecordid,
         fieldName,
-        responseKeys: added && typeof added === 'object' ? Object.keys(added) : [],
       }, LOG_CATEGORIES.API);
       result.addedFields.push(fieldName);
     } catch (error) {

--- a/src/features/flexi-records/services/flexiRecordCreationService.js
+++ b/src/features/flexi-records/services/flexiRecordCreationService.js
@@ -38,7 +38,8 @@ import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js
  *
  * The backend forwards OSM's raw JSON response; OSM's `?action=addRecordSet` shape
  * is undocumented and varies (some endpoints return `flexirecordid`, some `extraid`,
- * some `id`). Try each known key. Returns null if no id can be found.
+ * some `id`). Keys are tried in declared order — first non-nullish wins.
+ * Returns null if no id can be found.
  *
  * @private
  * @param {*} response - Whatever createFlexiRecord returned
@@ -51,6 +52,38 @@ function extractRecordId(response) {
     ?? response.id
     ?? response.recordid
     ?? null;
+}
+
+/**
+ * Detect known OSM failure response shapes for addColumn / similar write endpoints.
+ *
+ * The backend forwards OSM's raw JSON. OSM's success shape is undocumented (and
+ * the JSDoc example `{ success: true }` was fictional), so we can't require a
+ * positive flag without risking false negatives. Instead we list the failure
+ * shapes seen in this codebase and treat anything else as success.
+ *
+ * Returns a string error message when the response looks like a failure, or null
+ * when it looks fine (or shape is unknown — keep current call path).
+ *
+ * @private
+ * @param {*} response
+ * @returns {string|null} Error message if the response signals failure, else null
+ */
+function detectFailureMessage(response) {
+  if (response === null || response === undefined) {
+    return 'Empty response from OSM';
+  }
+  if (typeof response !== 'object') {
+    return `Unexpected non-object response: ${String(response).slice(0, 200)}`;
+  }
+  if (response.error) return String(response.error);
+  if (response.success === false) return String(response.message || response.error_description || 'OSM returned success: false');
+  if (response.ok === false) return String(response.message || 'OSM returned ok: false');
+  if (response.result === 0) return String(response.message || 'OSM returned result: 0');
+  if (response.status === 'fail' || response.status === 'error') {
+    return String(response.message || response.error_description || `OSM returned status: ${response.status}`);
+  }
+  return null;
 }
 
 /**
@@ -183,15 +216,16 @@ export async function createOrCompleteFlexiRecord({ section, template, termId, t
   for (const fieldName of fieldsToAdd) {
     try {
       const added = await addFlexiColumn(sectionId, result.flexirecordid, fieldName, token);
-      if (added && typeof added === 'object' && added.error) {
-        logger.warn('addFlexiColumn returned error response', {
+      const failureMessage = detectFailureMessage(added);
+      if (failureMessage) {
+        logger.warn('addFlexiColumn returned failure response', {
           sectionId,
           flexirecordid: result.flexirecordid,
           fieldName,
-          osmError: added.error,
+          osmError: failureMessage,
           responseSnippet: JSON.stringify(added).slice(0, 300),
         }, LOG_CATEGORIES.API);
-        result.errors.push({ field: fieldName, error: String(added.error) });
+        result.errors.push({ field: fieldName, error: failureMessage });
         continue;
       }
       logger.debug('addFlexiColumn success', {

--- a/src/features/flexi-records/services/flexiRecordCreationService.js
+++ b/src/features/flexi-records/services/flexiRecordCreationService.js
@@ -1,0 +1,184 @@
+/**
+ * Orchestrates creation of a missing FlexiRecord (or completion of an
+ * existing-but-incomplete one) for a single section.
+ *
+ * Handles three cases uniformly:
+ *  1. FlexiRecord absent: create it, then add every template field as a column.
+ *  2. FlexiRecord present but missing fields: add only the missing columns.
+ *  3. FlexiRecord present with all fields: no-op success.
+ *
+ * Failures inside the addColumn loop are non-fatal — the function continues with
+ * remaining fields and returns a partial-success result so the caller can show
+ * per-field status and offer "retry failed".
+ *
+ * @module flexiRecordCreationService
+ */
+
+import {
+  createFlexiRecord,
+  addFlexiColumn,
+} from '../../../shared/services/api/api/flexiRecords.js';
+import {
+  getFlexiRecordsList,
+  getFlexiRecordStructure,
+} from '../../events/services/flexiRecordService.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+
+/**
+ * @typedef {Object} CreationResult
+ * @property {boolean} success - True iff the FlexiRecord exists and all template fields are present after the run
+ * @property {string|number|null} flexirecordid - The OSM FlexiRecord ID (existing or newly created)
+ * @property {boolean} createdRecord - True if this run created a new FlexiRecord (false if it already existed)
+ * @property {string[]} addedFields - Field names successfully added as columns this run
+ * @property {Array<{ field: string, error: string }>} errors - Per-field errors for fields that failed to add
+ */
+
+/**
+ * Read the section's flexi list and find the record matching template.name.
+ * Uses cached data when possible.
+ *
+ * @private
+ * @param {string|number} sectionId
+ * @param {string} recordName
+ * @param {string} token
+ * @returns {Promise<{extraid: string|number}|null>}
+ */
+async function findExistingRecord(sectionId, recordName, token) {
+  const flexiList = await getFlexiRecordsList(sectionId, token, false);
+  const items = flexiList?.items || [];
+  return items.find(record => record.name === recordName) || null;
+}
+
+/**
+ * Get the set of field/column names already present on a FlexiRecord.
+ *
+ * @private
+ * @param {string|number} flexirecordid
+ * @param {string|number} sectionId
+ * @param {string|number} termId
+ * @param {string} token
+ * @returns {Promise<Set<string>>}
+ */
+async function getExistingFieldNames(flexirecordid, sectionId, termId, token) {
+  const structure = await getFlexiRecordStructure(flexirecordid, sectionId, termId, token, true);
+  const fieldMapping = structure?.fieldMapping || {};
+  return new Set(Object.values(fieldMapping).map(field => field.name));
+}
+
+/**
+ * Create or complete a FlexiRecord on one section.
+ *
+ * @param {Object} params
+ * @param {{ sectionid: string|number, sectionname?: string }} params.section - Section to operate on
+ * @param {import('./flexiRecordTemplates.js').FlexiRecordTemplate} params.template - Required FlexiRecord template
+ * @param {string|number} params.termId - Term ID used to look up the FlexiRecord structure
+ * @param {string} params.token - OSM authentication token
+ * @returns {Promise<CreationResult>}
+ */
+export async function createOrCompleteFlexiRecord({ section, template, termId, token }) {
+  const sectionId = section.sectionid;
+  const result = {
+    success: false,
+    flexirecordid: null,
+    createdRecord: false,
+    addedFields: [],
+    errors: [],
+  };
+
+  if (!sectionId) {
+    result.errors.push({ field: '_meta', error: 'Section ID is missing' });
+    return result;
+  }
+  if (!token) {
+    result.errors.push({ field: '_meta', error: 'OSM auth token is missing' });
+    return result;
+  }
+  if (!termId) {
+    result.errors.push({ field: '_meta', error: 'Term ID is missing' });
+    return result;
+  }
+
+  let existingRecord;
+  try {
+    existingRecord = await findExistingRecord(sectionId, template.name, token);
+  } catch (error) {
+    logger.error('Failed to read flexi list before create', {
+      sectionId,
+      template: template.name,
+      error: error.message,
+    }, LOG_CATEGORIES.API);
+    result.errors.push({ field: '_meta', error: `Failed to read flexi list: ${error.message}` });
+    return result;
+  }
+
+  let existingFieldNames = new Set();
+
+  if (existingRecord) {
+    result.flexirecordid = existingRecord.extraid;
+    try {
+      existingFieldNames = await getExistingFieldNames(existingRecord.extraid, sectionId, termId, token);
+    } catch (error) {
+      logger.warn('Failed to fetch existing structure before adding columns; will attempt to add all template fields', {
+        sectionId,
+        flexirecordid: existingRecord.extraid,
+        error: error.message,
+      }, LOG_CATEGORIES.API);
+    }
+  } else {
+    try {
+      const created = await createFlexiRecord(sectionId, template.name, token, template.createOptions);
+      if (!created || !created.success || !created.flexirecordid) {
+        const detail = created?.error || 'createFlexiRecord did not return a flexirecordid';
+        result.errors.push({ field: '_meta', error: detail });
+        return result;
+      }
+      result.flexirecordid = created.flexirecordid;
+      result.createdRecord = true;
+    } catch (error) {
+      logger.error('Failed to create FlexiRecord', {
+        sectionId,
+        template: template.name,
+        error: error.message,
+      }, LOG_CATEGORIES.API);
+      result.errors.push({ field: '_meta', error: `Failed to create record: ${error.message}` });
+      return result;
+    }
+  }
+
+  const fieldsToAdd = template.fields.filter(name => !existingFieldNames.has(name));
+
+  for (const fieldName of fieldsToAdd) {
+    try {
+      const added = await addFlexiColumn(sectionId, result.flexirecordid, fieldName, token);
+      if (!added || !added.success) {
+        const detail = added?.error || 'addFlexiColumn did not return success';
+        result.errors.push({ field: fieldName, error: detail });
+        continue;
+      }
+      result.addedFields.push(fieldName);
+    } catch (error) {
+      logger.error('Failed to add FlexiRecord column', {
+        sectionId,
+        flexirecordid: result.flexirecordid,
+        fieldName,
+        error: error.message,
+      }, LOG_CATEGORIES.API);
+      result.errors.push({ field: fieldName, error: error.message });
+    }
+  }
+
+  try {
+    await getFlexiRecordsList(sectionId, token, true);
+    if (result.flexirecordid) {
+      await getFlexiRecordStructure(result.flexirecordid, sectionId, termId, token, true);
+    }
+  } catch (error) {
+    logger.warn('Cache refresh after create/complete failed (non-fatal)', {
+      sectionId,
+      error: error.message,
+    }, LOG_CATEGORIES.API);
+  }
+
+  result.success = result.errors.length === 0;
+  return result;
+}

--- a/src/features/flexi-records/services/flexiRecordTemplates.js
+++ b/src/features/flexi-records/services/flexiRecordTemplates.js
@@ -1,0 +1,61 @@
+/**
+ * Required FlexiRecord templates for the Viking Event Mgmt app.
+ *
+ * Each template defines the OSM FlexiRecord name and the custom fields the app
+ * needs to be present on it. Field names must match exactly what the existing
+ * validators check for (vikingSectionMoversValidation.js, signInDataService.js)
+ * so a record created from these templates passes validation immediately.
+ *
+ * createOptions controls the OSM auto-fields (DOB, Age, Patrol). We disable them
+ * so the FlexiRecord starts with only our custom columns.
+ *
+ * @module flexiRecordTemplates
+ */
+
+/**
+ * @typedef {Object} FlexiRecordTemplate
+ * @property {string} name - Exact OSM FlexiRecord name (used for lookup and creation)
+ * @property {string[]} fields - Field/column names to ensure exist on the record
+ * @property {Object} createOptions - Options forwarded to createFlexiRecord
+ * @property {string} createOptions.dob - '0' or '1'
+ * @property {string} createOptions.age - '0' or '1'
+ * @property {string} createOptions.patrol - '0' or '1'
+ * @property {string} createOptions.type - OSM record type (default 'none')
+ * @property {string} description - Short user-facing description for the modal
+ */
+
+/** @type {FlexiRecordTemplate} */
+export const VIKING_SECTION_MOVERS = {
+  name: 'Viking Section Movers',
+  fields: [
+    'AssignedSection',
+    'AssignedTerm',
+    'AssignmentOverride',
+    'AssignmentDate',
+    'AssignedBy',
+  ],
+  createOptions: { dob: '0', age: '0', patrol: '0', type: 'none' },
+  description: 'Tracks section assignments for the Movements feature.',
+};
+
+/** @type {FlexiRecordTemplate} */
+export const VIKING_EVENT_MGMT = {
+  name: 'Viking Event Mgmt',
+  fields: [
+    'SignedInBy',
+    'SignedInWhen',
+    'SignedOutBy',
+    'SignedOutWhen',
+    'CampGroup',
+  ],
+  createOptions: { dob: '0', age: '0', patrol: '0', type: 'none' },
+  description: 'Stores sign-in / sign-out data and camp group assignments for events.',
+};
+
+/**
+ * Ordered list of all FlexiRecord templates the app requires per section.
+ * Iteration order is preserved by callers — keep the most user-visible record first.
+ *
+ * @type {FlexiRecordTemplate[]}
+ */
+export const REQUIRED_FLEXI_RECORDS = [VIKING_SECTION_MOVERS, VIKING_EVENT_MGMT];

--- a/src/features/flexi-records/services/flexiRecordTemplates.js
+++ b/src/features/flexi-records/services/flexiRecordTemplates.js
@@ -2,9 +2,9 @@
  * Required FlexiRecord templates for the Viking Event Mgmt app.
  *
  * Each template defines the OSM FlexiRecord name and the custom fields the app
- * needs to be present on it. Field names must match exactly what the existing
- * validators check for (vikingSectionMoversValidation.js, signInDataService.js)
- * so a record created from these templates passes validation immediately.
+ * needs to be present on it. Field names must match exactly what the validators
+ * check for (vikingSectionMoversValidation.js, vikingEventMgmtValidation.js) so
+ * a record created from these templates passes validation immediately.
  *
  * createOptions controls the OSM auto-fields (DOB, Age, Patrol). We disable them
  * so the FlexiRecord starts with only our custom columns.

--- a/src/features/flexi-records/services/vikingEventMgmtValidation.js
+++ b/src/features/flexi-records/services/vikingEventMgmtValidation.js
@@ -94,8 +94,8 @@ export async function validateVikingEventMgmtFlexiRecord(sectionId, termId, toke
 
     validation.availableFields = Object.keys(fieldMapping).map(fieldId => ({
       fieldId,
-      fieldName: fieldMapping[fieldId].name,
-      fieldType: fieldMapping[fieldId].type,
+      fieldName: fieldMapping[fieldId]?.name,
+      fieldType: fieldMapping[fieldId]?.type,
     }));
 
     const presentFieldNames = new Set(

--- a/src/features/flexi-records/services/vikingEventMgmtValidation.js
+++ b/src/features/flexi-records/services/vikingEventMgmtValidation.js
@@ -1,0 +1,129 @@
+/**
+ * Validation for the "Viking Event Mgmt" FlexiRecord.
+ *
+ * Sibling to vikingSectionMoversValidation — same return shape so the
+ * useMissingFlexiRecords hook can dispatch over both validators uniformly.
+ *
+ * Required fields (must all be present for sign-in / camp-groups features to work):
+ *   SignedInBy, SignedInWhen, SignedOutBy, SignedOutWhen, CampGroup
+ *
+ * @module vikingEventMgmtValidation
+ */
+
+import { getVikingEventData } from '../../events/services/flexiRecordService.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+
+/**
+ * Required fields for Viking Event Mgmt FlexiRecord functionality.
+ * All fields are core — there are no optional ones for this record.
+ */
+export const REQUIRED_VIKING_EVENT_MGMT_FIELDS = [
+  {
+    fieldName: 'SignedInBy',
+    displayName: 'Signed In By',
+    description: 'User who signed the member in to an event',
+    isCore: true,
+  },
+  {
+    fieldName: 'SignedInWhen',
+    displayName: 'Signed In When',
+    description: 'Timestamp when the member was signed in',
+    isCore: true,
+  },
+  {
+    fieldName: 'SignedOutBy',
+    displayName: 'Signed Out By',
+    description: 'User who signed the member out',
+    isCore: true,
+  },
+  {
+    fieldName: 'SignedOutWhen',
+    displayName: 'Signed Out When',
+    description: 'Timestamp when the member was signed out',
+    isCore: true,
+  },
+  {
+    fieldName: 'CampGroup',
+    displayName: 'Camp Group',
+    description: 'Camp group assignment shown in the camp groups view',
+    isCore: true,
+  },
+];
+
+/**
+ * Validate the Viking Event Mgmt FlexiRecord for a section/term.
+ *
+ * Returns a structured result with the same shape as
+ * validateVikingSectionMoversFlexiRecord so callers can treat them identically.
+ *
+ * @param {string|number} sectionId - Section ID
+ * @param {string|number} termId - Term ID
+ * @param {string} token - OSM authentication token
+ * @param {boolean} [forceRefresh=false] - Bypass cache
+ * @returns {Promise<Object>} Validation result
+ */
+export async function validateVikingEventMgmtFlexiRecord(sectionId, termId, token, forceRefresh = false) {
+  const validation = {
+    isValid: false,
+    hasFlexiRecord: false,
+    hasRequiredFields: false,
+    missingFields: [],
+    availableFields: [],
+    errors: [],
+    warnings: [],
+    guidance: [],
+    sectionId: String(sectionId),
+    termId: String(termId),
+  };
+
+  try {
+    const vikingEventData = await getVikingEventData(sectionId, termId, token, forceRefresh);
+
+    if (!vikingEventData) {
+      validation.hasFlexiRecord = false;
+      validation.errors.push('Viking Event Mgmt FlexiRecord not found for this section');
+      validation.missingFields = REQUIRED_VIKING_EVENT_MGMT_FIELDS.map(field => ({ ...field }));
+      return validation;
+    }
+
+    validation.hasFlexiRecord = true;
+
+    const structure = vikingEventData._structure || vikingEventData.structure;
+    const fieldMapping = structure?.fieldMapping || {};
+
+    validation.availableFields = Object.keys(fieldMapping).map(fieldId => ({
+      fieldId,
+      fieldName: fieldMapping[fieldId].name,
+      fieldType: fieldMapping[fieldId].type,
+    }));
+
+    const presentFieldNames = new Set(
+      Object.values(fieldMapping).map(field => field.name),
+    );
+
+    const missingFields = REQUIRED_VIKING_EVENT_MGMT_FIELDS
+      .filter(required => !presentFieldNames.has(required.fieldName))
+      .map(field => ({ ...field }));
+
+    validation.missingFields = missingFields;
+    validation.hasRequiredFields = missingFields.length === 0;
+    validation.isValid = validation.hasFlexiRecord && validation.hasRequiredFields;
+
+    if (!validation.hasRequiredFields) {
+      validation.errors.push(
+        `Missing ${missingFields.length} required field${missingFields.length > 1 ? 's' : ''}: ${missingFields.map(f => f.displayName).join(', ')}`,
+      );
+    }
+
+    return validation;
+  } catch (error) {
+    logger.error('Error validating Viking Event Mgmt FlexiRecord', {
+      sectionId,
+      termId,
+      error: error.message,
+    }, LOG_CATEGORIES.ERROR);
+
+    validation.errors.push(`Validation failed: ${error.message}`);
+    return validation;
+  }
+}

--- a/src/features/flexi-records/services/vikingEventMgmtValidation.js
+++ b/src/features/flexi-records/services/vikingEventMgmtValidation.js
@@ -67,6 +67,7 @@ export async function validateVikingEventMgmtFlexiRecord(sectionId, termId, toke
     isValid: false,
     hasFlexiRecord: false,
     hasRequiredFields: false,
+    networkError: false,
     missingFields: [],
     availableFields: [],
     errors: [],
@@ -123,6 +124,7 @@ export async function validateVikingEventMgmtFlexiRecord(sectionId, termId, toke
       error: error.message,
     }, LOG_CATEGORIES.ERROR);
 
+    validation.networkError = true;
     validation.errors.push(`Validation failed: ${error.message}`);
     return validation;
   }

--- a/src/features/movements/components/SectionMovementTracker.jsx
+++ b/src/features/movements/components/SectionMovementTracker.jsx
@@ -12,7 +12,7 @@
  * @author Vikings Event Management Team
  */
 
-import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from '../../../shared/components/ui';
 import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
@@ -22,8 +22,7 @@ import TermMovementCard from './TermMovementCard.jsx';
 import MovementSummaryTable from './MovementSummaryTable.jsx';
 import { getFutureTerms } from '../../../shared/utils/sectionMovements/termCalculations.js';
 import { groupSectionsByType } from '../../../shared/utils/sectionMovements/sectionGrouping.js';
-import { notifyError } from '../../../shared/utils/notifications.js';
-import databaseService from '../../../shared/services/storage/database.js';
+import { MissingFlexiRecordsBanner } from '../../flexi-records';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 
 /**
@@ -111,11 +110,8 @@ function SectionMovementTracker({ onBack }) {
   const [_allAssignments, _setAllAssignments] = useState(new Map());
   
   // Main data hook - provides members, sections, and FlexiRecord state
-  const { members, sections, loading, error, refetch, flexiRecordState } = useSectionMovements();
-  
-  // Tracks whether FlexiRecord validation has been performed (once per session)
-  const hasCheckedFlexiRecords = useRef(false);
-  
+  const { members, sections, loading, error, refetch } = useSectionMovements();
+
   // Calculate future terms based on user selection
   const futureTerms = getFutureTerms(numberOfTerms);
 
@@ -124,97 +120,6 @@ function SectionMovementTracker({ onBack }) {
     saveUserPreference('numberOfTerms', numberOfTerms);
   }, [numberOfTerms]);
 
-  /**
-   * Checks for missing 'Viking Section Movers' FlexiRecords across sections
-   *
-   * Validates that each section (excluding adults/waitinglist) has the required
-   * 'Viking Section Movers' FlexiRecord with proper fields. Shows user notification
-   * if any sections are missing this FlexiRecord.
-   *
-   * Required FlexiRecord fields: AssignedSection, AssignedTerm
-   * Optional FlexiRecord fields: AssignmentDate, AssignedBy
-   *
-   * @function checkForMissingFlexiRecords
-   * @param {Array} sectionsData - Array of section objects to validate
-   * @param {string|number} sectionsData[].sectionid - Section ID
-   * @param {string} sectionsData[].sectionname - Section display name
-   */
-  const checkForMissingFlexiRecords = useCallback(async (sectionsData) => {
-    if (!sectionsData || sectionsData.length === 0) return;
-
-    const missingSections = [];
-
-    for (const section of sectionsData) {
-      const sectionId = section.sectionid;
-      const sectionName = section.sectionname || section.name || 'Unknown Section';
-
-      // Filter out adults and waitinglist sections
-      const normalizedName = sectionName.toLowerCase();
-      if (normalizedName.includes('adults') ||
-          normalizedName.includes('waiting') ||
-          normalizedName.includes('waitinglist')) {
-        continue; // Skip these sections
-      }
-
-      // Check if this section is already loaded (has FlexiRecord data)
-      if (flexiRecordState.loadedSections && flexiRecordState.loadedSections.has(sectionId)) {
-        continue; // Section has FlexiRecord loaded, treat as present
-      }
-
-      try {
-        const flexiLists = await databaseService.getFlexiLists(sectionId);
-        const listsArray = Array.isArray(flexiLists) ? flexiLists : (flexiLists?.items || []);
-
-        if (listsArray.length === 0) {
-          missingSections.push(sectionName);
-          continue;
-        }
-
-        const hasVikingSectionMovers = listsArray.some(record =>
-          record.name === 'Viking Section Movers',
-        );
-
-        if (!hasVikingSectionMovers) {
-          missingSections.push(sectionName);
-        }
-      } catch (error) {
-        logger.warn('Failed to check FlexiRecord list for section', {
-          sectionId,
-          sectionName,
-          error: error.message,
-        }, LOG_CATEGORIES.COMPONENT);
-        missingSections.push(sectionName);
-      }
-    }
-
-    // Show notification if there are missing FlexiRecords
-    if (missingSections.length > 0) {
-      const sectionList = missingSections.join(', ');
-      const requiredFields = ['AssignedSection', 'AssignedTerm'];
-      const optionalFields = ['AssignmentDate', 'AssignedBy'];
-
-      const message = `Missing "Viking Section Movers" FlexiRecord for: ${sectionList}. ` +
-        `Contact your administrator to create this FlexiRecord with required fields: ${requiredFields.join(', ')} ` +
-        `and optional fields: ${optionalFields.join(', ')}.`;
-      notifyError(message);
-    }
-  }, [flexiRecordState.loadedSections]);
-
-  // Check for missing FlexiRecords when sections load and FlexiRecord discovery completes (only once per session)
-  useEffect(() => {
-    if (sections && sections.length > 0 && !hasCheckedFlexiRecords.current && flexiRecordState.loading === false) {
-      checkForMissingFlexiRecords(sections);
-      hasCheckedFlexiRecords.current = true;
-    }
-  }, [sections, checkForMissingFlexiRecords, flexiRecordState.loading]);
-
-  // Reset the check flag when component unmounts
-  useEffect(() => {
-    return () => {
-      hasCheckedFlexiRecords.current = false;
-    };
-  }, []);
-  
   /**
    * Complex memoized calculation of section movements across multiple terms
    * 
@@ -454,6 +359,7 @@ function SectionMovementTracker({ onBack }) {
       </div>
 
       <div className="p-4">
+        <MissingFlexiRecordsBanner sections={sections} />
         {termCalculations.length === 0 ? (
           <div className="text-center py-12">
             <p className="text-gray-500 text-lg mb-4">

--- a/src/features/movements/services/vikingSectionMoversValidation.js
+++ b/src/features/movements/services/vikingSectionMoversValidation.js
@@ -55,6 +55,7 @@ export async function validateVikingSectionMoversFlexiRecord(sectionId, termId, 
     isValid: false,
     hasFlexiRecord: false,
     hasRequiredFields: false,
+    networkError: false,
     missingFields: [],
     availableFields: [],
     errors: [],
@@ -191,6 +192,7 @@ export async function validateVikingSectionMoversFlexiRecord(sectionId, termId, 
       stack: error.stack,
     }, LOG_CATEGORIES.ERROR);
 
+    validation.networkError = true;
     validation.errors.push(`Validation failed: ${error.message}`);
     validation.guidance.push(
       'Check your internet connection and try again',


### PR DESCRIPTION
## Summary
- Replaces the dead-end "contact your administrator" toast/alert with an actionable banner that lets users create the missing **Viking Section Movers** and **Viking Event Mgmt** FlexiRecords inline, via the OSM write endpoints the backend already exposes.
- New feature module `src/features/flexi-records/`: templates, sibling validator for Viking Event Mgmt, creation service, detection hook, banner, modal.
- Wired in at the two existing detection points (`SectionMovementTracker`, `CampGroupsView`) — old detection logic deleted, no new routes.
- Partial-state aware: if the record exists but is missing some fields, only the missing columns are added.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 497/497 pass (12 new)
- [x] `npm run build` — succeeds
- [ ] Manual: log in with OSM, find a section missing one of the records, confirm banner appears on Movements page and Camp Groups view
- [ ] Manual: open the modal, deselect/reselect cells, confirm matrix layout
- [ ] Manual: submit and watch per-row progress dots; confirm cache refresh hides the banner on next load
- [ ] Manual: force a partial failure to confirm the "Retry failed" path
- [ ] Manual: set `localStorage.token_expired = 'true'` and reload — banner should be hidden

## Out of scope
- No new routes or admin page (entry-point scope was deliberately limited to the existing detection points).
- No deletion / renaming of FlexiRecords (OSM API doesn't support either).
- No bulk pre-population of field data (existing features fill data as users interact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)