### PR TITLE
feat(camp-groups): per-member status icons + opt-in move mode toggle

### DIFF
--- a/src/features/events/components/CampGroupCard.jsx
+++ b/src/features/events/components/CampGroupCard.jsx
@@ -210,20 +210,27 @@ function CampGroupCard({
       <div className={cn('p-4 pt-0')}>
         {youngPeople.length > 0 ? (
           <div className="grid grid-cols-2 gap-2">
-            {youngPeople.map((youngPerson) => (
-              <DraggableMember
-                key={youngPerson.scoutid}
-                member={youngPerson}
-                group={group}
-                onMemberClick={handleMemberClick}
-                onDragStart={onDragStart}
-                onDragEnd={onDragEnd}
-                isDragging={
-                  String(draggingMemberId) === String(youngPerson.scoutid)
-                }
-                disabled={dragDisabled}
-              />
-            ))}
+            {youngPeople.map((youngPerson) => {
+              // Per-member disable: even when move mode is on, scouts whose
+              // section is missing its Viking Event Mgmt flexi record can't be
+              // moved (no flexirecordid/columnid to target on the API).
+              const memberHasFlexi = youngPerson.vikingEventData !== null && youngPerson.vikingEventData !== undefined;
+              const memberDisabled = dragDisabled || !memberHasFlexi;
+              return (
+                <DraggableMember
+                  key={youngPerson.scoutid}
+                  member={youngPerson}
+                  group={group}
+                  onMemberClick={handleMemberClick}
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
+                  isDragging={
+                    String(draggingMemberId) === String(youngPerson.scoutid)
+                  }
+                  disabled={memberDisabled}
+                />
+              );
+            })}
           </div>
         ) : (
           <div

--- a/src/features/events/components/CampGroupsView.jsx
+++ b/src/features/events/components/CampGroupsView.jsx
@@ -110,6 +110,12 @@ function organizeByCampGroups(attendees, pendingMoves = new Map(), recentlyCompl
     member.vikingEventData?.CampGroup !== undefined,
   );
 
+  // True when at least one young person has flexi data — used to surface the
+  // move-mode toggle even when other sections are missing their flexi records.
+  // Without this, a single missing-flexi section hides the toggle for sections
+  // that ARE configured.
+  const someVikingEventData = youngPeople.some(member => member.vikingEventData !== null && member.vikingEventData !== undefined);
+
   return {
     groups: sortedGroups,
     summary: {
@@ -117,6 +123,7 @@ function organizeByCampGroups(attendees, pendingMoves = new Map(), recentlyCompl
       totalMembers,
       hasUnassigned: !!sortedGroups['Group Unassigned'],
       vikingEventDataAvailable: hasVikingEventData,
+      someVikingEventDataAvailable: someVikingEventData,
     },
   };
 }
@@ -137,7 +144,7 @@ function organizeByCampGroups(attendees, pendingMoves = new Map(), recentlyCompl
 function CampGroupsView({
   attendees = [],
   events = [],
-  members: _members = [],
+  members = [],
   vikingEventData,
   onMemberClick,
   onDataRefresh,
@@ -154,13 +161,32 @@ function CampGroupsView({
   const [pendingMoves, setPendingMoves] = useState(new Map());
   const [recentlyCompletedMoves, setRecentlyCompletedMoves] = useState(new Map());
 
+  // Move mode is OFF by default. On mobile, drag/drop is too easy to trigger
+  // accidentally — gating it behind an explicit toggle prevents misclicks.
+  const [moveMode, setMoveMode] = useState(false);
+
   const isMobile = isMobileLayout();
+
+  // Merge full member records into attendees so the per-tile MemberStatusIcons
+  // cluster has access to flattened contact-group fields (essential_information__*,
+  // consents__*, etc). The attendance records that flow in via `attendees` only
+  // carry attendance + vikingEventData; without this merge, groupContactInfo
+  // returns an empty object and no icons render.
+  const enrichedAttendees = useMemo(() => {
+    if (!attendees || attendees.length === 0) return attendees;
+    if (!members || members.length === 0) return attendees;
+    const memberById = new Map(members.map(m => [String(m.scoutid), m]));
+    return attendees.map(record => {
+      const full = memberById.get(String(record.scoutid));
+      return full ? { ...full, ...record } : record;
+    });
+  }, [attendees, members]);
 
   // Simple data organization like RegisterTab - just group the pre-processed attendees
   // Include optimistic updates for immediate UI feedback
   const { groups, summary } = useMemo(() =>
-    organizeByCampGroups(attendees, pendingMoves, recentlyCompletedMoves),
-  [attendees, pendingMoves, recentlyCompletedMoves],
+    organizeByCampGroups(enrichedAttendees, pendingMoves, recentlyCompletedMoves),
+  [enrichedAttendees, pendingMoves, recentlyCompletedMoves],
   );
 
   // Unique sections involved in the events shown here — drives the missing-FlexiRecord banner.
@@ -732,31 +758,77 @@ function CampGroupsView({
             </span>
           </div>
           
-          {/* Edit Names Button */}
-          {summary.totalGroups > 0 && (
-            <button
-              onClick={handleEditGroupNames}
-              disabled={groupNamesLoading}
-              className="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-scout-blue disabled:opacity-50 disabled:cursor-not-allowed"
-              type="button"
-            >
-              <svg
-                className="w-4 h-4 mr-2"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+          <div className="flex items-center gap-2">
+            {/* Move Mode Toggle */}
+            {summary.totalGroups > 0 && summary.someVikingEventDataAvailable && (
+              <button
+                onClick={() => setMoveMode((prev) => !prev)}
+                aria-pressed={moveMode}
+                className={`inline-flex items-center px-3 py-2 shadow-sm text-sm leading-4 font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-scout-blue transition-colors ${
+                  moveMode
+                    ? 'bg-scout-blue text-white border border-scout-blue hover:bg-scout-blue-dark'
+                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+                }`}
+                type="button"
+                title={moveMode ? 'Disable moving members between groups' : 'Enable moving members between groups'}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                />
-              </svg>
-              Edit Names
-            </button>
-          )}
+                <svg
+                  className="w-4 h-4 mr-2"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+                  />
+                </svg>
+                {moveMode ? 'Move mode ON' : 'Enable move'}
+              </button>
+            )}
+
+            {/* Edit Names Button */}
+            {summary.totalGroups > 0 && (
+              <button
+                onClick={handleEditGroupNames}
+                disabled={groupNamesLoading}
+                className="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-scout-blue disabled:opacity-50 disabled:cursor-not-allowed"
+                type="button"
+              >
+                <svg
+                  className="w-4 h-4 mr-2"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+                Edit Names
+              </button>
+            )}
+          </div>
         </div>
+
+        {moveMode && (
+          <div
+            className="mb-4 px-3 py-2 rounded-md bg-scout-blue/10 border border-scout-blue/30 text-sm text-scout-blue-dark flex items-center gap-2"
+            role="status"
+          >
+            <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span>
+              <strong>Move mode is on.</strong> Drag members between groups. Tap <em>Move mode ON</em> again to lock.
+            </span>
+          </div>
+        )}
 
         {!summary.vikingEventDataAvailable && eventSections.length > 0 && (
           hasOperationalEventSection ? (
@@ -783,8 +855,7 @@ function CampGroupsView({
             onMemberMove={handleMemberMove}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
-            // Enable drag and drop functionality
-            dragDisabled={false}
+            dragDisabled={!moveMode}
             className="h-fit"
           />
         ))}

--- a/src/features/events/components/DraggableMember.jsx
+++ b/src/features/events/components/DraggableMember.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { isFieldCleared } from '../../../shared/constants/signInDataConstants.js';
+import MemberStatusIcons from '../../../shared/components/ui/MemberStatusIcons.jsx';
 
 function DraggableMember({ 
   member, 
@@ -195,7 +196,12 @@ function DraggableMember({
       }`}>
         {member.firstname} {member.lastname}
       </div>
-      
+
+      {/* Status icons (medical / photo consent / dietary / non-swimmer) */}
+      <div className="flex items-center gap-1 mt-0.5 min-h-[1rem]">
+        <MemberStatusIcons member={member} size="sm" />
+      </div>
+
       {/* Additional member info if available */}
       {member.patrol && (
         <div className="text-xs text-gray-500 mt-1">{member.patrol}</div>

--- a/src/features/events/components/attendance/RegisterTab.jsx
+++ b/src/features/events/components/attendance/RegisterTab.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { CameraIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import SignInOutButton from '../SignInOutButton.jsx';
 import { isFieldCleared } from '../../../../shared/constants/signInDataConstants.js';
 import { formatUKDateTime } from '../../../../shared/utils/dateFormatting.js';
-import { groupContactInfo } from '../../../../shared/utils/contactGroups.js';
-import { categorizeMedicalData, MEDICAL_DATA_STATES } from '../../../../shared/utils/medicalDataUtils.js';
+import MemberStatusIcons from '../../../../shared/components/ui/MemberStatusIcons.jsx';
 
 // Sentinel values that push empty entries to the end regardless of direction.
 // Camp Group is sorted as a string (numeric strings still compare correctly),
@@ -225,73 +223,7 @@ function RegisterTab({
                     </button>
                     {(() => {
                       const fullMember = members.find(m => m.scoutid.toString() === member.scoutid.toString());
-                      if (!fullMember) return null;
-
-                      const contactGroups = groupContactInfo(fullMember);
-                      const consentGroup = contactGroups.consents || contactGroups.permissions;
-                      const essentialInfo = contactGroups.essential_information;
-
-                      const icons = [];
-
-                      if (consentGroup) {
-                        const photographsConsent = consentGroup.photographs || consentGroup.Photographs;
-                        if (photographsConsent === 'No' || photographsConsent === 'no') {
-                          icons.push(
-                            <span key="camera" className="relative inline-block" title="No photography consent">
-                              <CameraIcon className="w-4 h-4 text-red-600" />
-                              <svg className="absolute inset-0 w-4 h-4" viewBox="0 0 24 24">
-                                <line x1="2" y1="2" x2="22" y2="22" stroke="currentColor" strokeWidth="2" className="text-red-600" />
-                              </svg>
-                            </span>,
-                          );
-                        }
-                      }
-
-                      if (essentialInfo) {
-                        const allergiesState = categorizeMedicalData(essentialInfo.allergies, 'allergies');
-                        const medicalState = categorizeMedicalData(essentialInfo.medical_details, 'medical_details');
-                        const dietaryState = categorizeMedicalData(essentialInfo.dietary_requirements, 'dietary_requirements');
-
-                        const hasMedicalOrAllergies =
-                          allergiesState === MEDICAL_DATA_STATES.HAS_DATA ||
-                          medicalState === MEDICAL_DATA_STATES.HAS_DATA;
-
-                        const hasDietaryRequirements = dietaryState === MEDICAL_DATA_STATES.HAS_DATA;
-
-                        if (hasMedicalOrAllergies) {
-                          icons.push(
-                            <ExclamationTriangleIcon
-                              key="medical"
-                              className="w-4 h-4 text-yellow-600"
-                              title="Has medical details or allergies"
-                            />,
-                          );
-                        }
-
-                        if (hasDietaryRequirements) {
-                          icons.push(
-                            <span key="dietary" className="text-sm" title="Has dietary requirements">
-                              🍽️
-                            </span>,
-                          );
-                        }
-
-                        const swimmer = essentialInfo.swimmer;
-                        const isNonSwimmer = swimmer === 'No' || swimmer === 'no' || swimmer === null || swimmer === undefined || swimmer === '';
-                        if (isNonSwimmer) {
-                          icons.push(
-                            <span
-                              key="swimmer"
-                              className="text-sm"
-                              title={swimmer === 'No' || swimmer === 'no' ? 'Non-swimmer' : 'Swimmer status unknown'}
-                            >
-                              🛟
-                            </span>,
-                          );
-                        }
-                      }
-
-                      return icons.length > 0 ? icons : null;
+                      return <MemberStatusIcons member={fullMember} size="sm" />;
                     })()}
                   </div>
                 </td>

--- a/src/shared/components/ui/MemberStatusIcons.jsx
+++ b/src/shared/components/ui/MemberStatusIcons.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { CameraIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { groupContactInfo } from '../../utils/contactGroups.js';
+import { categorizeMedicalData, MEDICAL_DATA_STATES } from '../../utils/medicalDataUtils.js';
+
+/**
+ * Renders the small per-member status icon cluster used on Register, Attendance,
+ * and Camp Group views. Centralises the previously duplicated logic so the four
+ * call sites stay in sync when the icon set changes.
+ *
+ * Icons rendered (all conditional):
+ *  - 📷 with strikethrough — explicit "no" photography consent
+ *  - ⚠️                   — has medical details or allergies
+ *  - 🍽️                  — has dietary requirements
+ *  - 🛟                   — confirmed non-swimmer or unknown swimmer status
+ *
+ * @param {Object} props
+ * @param {Object} props.member - Full member record. Contact-group fields are
+ *   read via `groupContactInfo(member)` so the caller doesn't need to
+ *   pre-compute them.
+ * @param {('sm'|'base')} [props.size='sm'] - Visual size. `sm` matches the
+ *   compact RegisterTab cluster; `base` matches the larger Attendance tiles.
+ * @returns {React.ReactNode|null} Icon array, or null when no flags apply.
+ */
+function MemberStatusIcons({ member, size = 'sm' }) {
+  if (!member) return null;
+
+  const contactGroups = groupContactInfo(member);
+  const consentGroup = contactGroups.consents || contactGroups.permissions;
+  const essentialInfo = contactGroups.essential_information;
+
+  const iconClass = size === 'base' ? 'w-5 h-5' : 'w-4 h-4';
+  const emojiClass = size === 'base' ? 'text-base' : 'text-sm';
+
+  const icons = [];
+
+  if (consentGroup) {
+    const photographsConsent = consentGroup.photographs || consentGroup.Photographs;
+    if (photographsConsent === 'No' || photographsConsent === 'no') {
+      icons.push(
+        <span key="camera" className="relative inline-block" title="No photography consent">
+          <CameraIcon className={`${iconClass} text-red-600`} />
+          <svg className={`absolute inset-0 ${iconClass}`} viewBox="0 0 24 24">
+            <line x1="2" y1="2" x2="22" y2="22" stroke="currentColor" strokeWidth="2" className="text-red-600" />
+          </svg>
+        </span>,
+      );
+    }
+  }
+
+  if (essentialInfo) {
+    const allergiesState = categorizeMedicalData(essentialInfo.allergies, 'allergies');
+    const medicalState = categorizeMedicalData(essentialInfo.medical_details, 'medical_details');
+    const dietaryState = categorizeMedicalData(essentialInfo.dietary_requirements, 'dietary_requirements');
+
+    const hasMedicalOrAllergies =
+      allergiesState === MEDICAL_DATA_STATES.HAS_DATA ||
+      medicalState === MEDICAL_DATA_STATES.HAS_DATA;
+
+    const hasDietaryRequirements = dietaryState === MEDICAL_DATA_STATES.HAS_DATA;
+
+    if (hasMedicalOrAllergies) {
+      icons.push(
+        <ExclamationTriangleIcon
+          key="medical"
+          className={`${iconClass} text-yellow-600`}
+          title="Has medical details or allergies"
+        />,
+      );
+    }
+
+    if (hasDietaryRequirements) {
+      icons.push(
+        <span key="dietary" className={emojiClass} title="Has dietary requirements">
+          🍽️
+        </span>,
+      );
+    }
+
+    const swimmer = essentialInfo.swimmer;
+    const isNonSwimmer = swimmer === 'No' || swimmer === 'no' || swimmer === null || swimmer === undefined || swimmer === '';
+    if (isNonSwimmer) {
+      icons.push(
+        <span
+          key="swimmer"
+          className={emojiClass}
+          title={swimmer === 'No' || swimmer === 'no' ? 'Non-swimmer' : 'Swimmer status unknown'}
+        >
+          🛟
+        </span>,
+      );
+    }
+  }
+
+  return icons.length > 0 ? <>{icons}</> : null;
+}
+
+export default MemberStatusIcons;

--- a/src/shared/components/ui/SectionCardsFlexMasonry.jsx
+++ b/src/shared/components/ui/SectionCardsFlexMasonry.jsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from 'react';
-import { CameraIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { groupContactInfo } from '../../utils/contactGroups.js';
-import { categorizeMedicalData, MEDICAL_DATA_STATES } from '../../utils/medicalDataUtils.js';
+import MemberStatusIcons from './MemberStatusIcons.jsx';
 
 const RESPONSIVE_BREAKPOINTS = {
   LARGE: 1024,
@@ -118,73 +116,7 @@ const SectionCardsFlexMasonry = ({ sections, isYoungPerson, onMemberClick }) => 
                         >
                           {member.firstname} {member.lastname}
                         </button>
-                        {(() => {
-                          const contactGroups = groupContactInfo(member);
-                          const consentGroup = contactGroups.consents || contactGroups.permissions;
-                          const essentialInfo = contactGroups.essential_information;
-
-                          const icons = [];
-
-                          if (consentGroup) {
-                            const photographsConsent = consentGroup.photographs || consentGroup.Photographs;
-                            if (photographsConsent === 'No' || photographsConsent === 'no') {
-                              icons.push(
-                                <span key="camera" className="relative inline-block" title="No photography consent">
-                                  <CameraIcon className="w-5 h-5 text-red-600" />
-                                  <svg className="absolute inset-0 w-5 h-5" viewBox="0 0 24 24">
-                                    <line x1="2" y1="2" x2="22" y2="22" stroke="currentColor" strokeWidth="2" className="text-red-600" />
-                                  </svg>
-                                </span>,
-                              );
-                            }
-                          }
-
-                          if (essentialInfo) {
-                            const allergiesState = categorizeMedicalData(essentialInfo.allergies, 'allergies');
-                            const medicalState = categorizeMedicalData(essentialInfo.medical_details, 'medical_details');
-                            const dietaryState = categorizeMedicalData(essentialInfo.dietary_requirements, 'dietary_requirements');
-
-                            const hasMedicalOrAllergies =
-                              allergiesState === MEDICAL_DATA_STATES.HAS_DATA ||
-                              medicalState === MEDICAL_DATA_STATES.HAS_DATA;
-
-                            const hasDietaryRequirements = dietaryState === MEDICAL_DATA_STATES.HAS_DATA;
-
-                            if (hasMedicalOrAllergies) {
-                              icons.push(
-                                <ExclamationTriangleIcon
-                                  key="medical"
-                                  className="w-5 h-5 text-yellow-600"
-                                  title="Has medical details or allergies"
-                                />,
-                              );
-                            }
-
-                            if (hasDietaryRequirements) {
-                              icons.push(
-                                <span key="dietary" className="text-base" title="Has dietary requirements">
-                                  🍽️
-                                </span>,
-                              );
-                            }
-
-                            const swimmer = essentialInfo.swimmer;
-                            const isNonSwimmer = swimmer === 'No' || swimmer === 'no' || swimmer === null || swimmer === undefined || swimmer === '';
-                            if (isNonSwimmer) {
-                              icons.push(
-                                <span
-                                  key="swimmer"
-                                  className="text-base"
-                                  title={swimmer === 'No' || swimmer === 'no' ? 'Non-swimmer' : 'Swimmer status unknown'}
-                                >
-                                  🛟
-                                </span>,
-                              );
-                            }
-                          }
-
-                          return icons.length > 0 ? icons : null;
-                        })()}
+                        <MemberStatusIcons member={member} size="base" />
                       </div>
                     </div>
                     <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Adds the existing per-member status icon cluster (📷 / ⚠️ / 🍽️ / 🛟) to camp group tiles, and gates drag-to-move behind an explicit opt-in toggle so it's harder to misfire on mobile.

- **Status icons on camp group tiles** — same cluster as Register/Attendance. New shared `MemberStatusIcons` component consolidates the previously duplicated logic across `RegisterTab` and `SectionCardsFlexMasonry`; all three (now four) call sites use it.
- **Opt-in move mode** — new toggle next to "Edit Names" defaults OFF; tiles aren't draggable until enabled. When ON, button highlights blue and an info banner surfaces above the grid.
- **Partial flexi coverage** — toggle uses a new `someVikingEventDataAvailable` summary flag (any YP has flexi) instead of `every`, so a single missing-flexi section no longer hides the toggle for sections that are configured. Per-member, YPs from missing-flexi sections stay non-draggable even with move mode on (no `flexirecordid` to target).

## Implementation notes

`groupContactInfo` reads flattened fields (`essential_information__*`, `consents__*`). The attendance records that flow in via `attendees` only carry attendance + `vikingEventData`; without the new `enrichedAttendees` memo (merge by scoutid against the `members` prop), `groupContactInfo` returns an empty object and no icons render on the camp groups tab — even though the same data flow works for Register because that tab does its own per-row member lookup.

## Test plan

- [x] `npm run lint` — clean (only pre-existing architectural warnings)
- [x] `npm run test:run` — 513 pass, 13 skipped
- [ ] Sanity check on device:
  - [ ] Camp groups tab — icons visible per member, matching Register/Attendance
  - [ ] Move mode default OFF — no drag handle icon, no grab cursor, page scrolls normally on touch
  - [ ] Move mode ON — drag-and-drop works as before, banner visible
  - [ ] Mixed-flexi event — toggle still appears when at least one section has flexi; YPs from missing-flexi section can't be dragged

🤖 Generated with [Claude Code](https://claude.com/claude-code)