### PR TITLE
fix: address PR #201/#202 review findings

### DIFF
--- a/src/features/auth/hooks/useAuth.jsx
+++ b/src/features/auth/hooks/useAuth.jsx
@@ -8,6 +8,8 @@ import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js
 import databaseService from '../../../shared/services/storage/database.js';
 import IndexedDBService from '../../../shared/services/storage/indexedDBService.js';
 import dataLoadingService from '../../../shared/services/data/dataLoadingService.js';
+import { notifyLoading, notifySuccess, notifyWarning, dismissToast } from '../../../shared/utils/notifications.js';
+import { getLoadingResultMessage } from '../../../shared/services/referenceData/referenceDataService.js';
 
 // Create Auth Context
 const AuthContext = createContext(null);
@@ -249,7 +251,6 @@ function useAuthLogic() {
     try {
       logger.info('Starting comprehensive data load after successful OAuth', { source }, LOG_CATEGORIES.AUTH);
 
-      const { notifyLoading } = await import('../../../shared/utils/notifications.js');
       syncingToastId = notifyLoading('Syncing data from OSM...');
 
       const allDataResults = await dataLoadingService.loadAllDataAfterAuth(accessToken, {
@@ -276,7 +277,6 @@ function useAuthLogic() {
       });
 
       if (syncingToastId) {
-        const { dismissToast } = await import('../../../shared/utils/notifications.js');
         dismissToast(syncingToastId);
         syncingToastId = null;
       }
@@ -286,7 +286,6 @@ function useAuthLogic() {
           summary: allDataResults.summary,
         }, LOG_CATEGORIES.AUTH);
 
-        const { notifySuccess } = await import('../../../shared/utils/notifications.js');
         notifySuccess('Data synced successfully');
       } else {
         logger.warn('Comprehensive data load had issues', {
@@ -305,17 +304,14 @@ function useAuthLogic() {
       setLastSyncTime(syncTime);
 
       if (allDataResults.hasErrors && allDataResults.errors?.some(e => e.category === 'reference')) {
-        const { getLoadingResultMessage } = await import('../../../shared/services/referenceData/referenceDataService.js');
         const referenceData = allDataResults?.results?.reference ?? allDataResults;
         const userMessage = getLoadingResultMessage(referenceData);
         if (userMessage) {
-          const { notifyWarning } = await import('../../../shared/utils/notifications.js');
           notifyWarning(userMessage);
         }
       }
     } catch (dataLoadError) {
       if (syncingToastId) {
-        const { dismissToast } = await import('../../../shared/utils/notifications.js');
         dismissToast(syncingToastId);
         syncingToastId = null;
       }

--- a/src/features/events/components/CampGroupCard.jsx
+++ b/src/features/events/components/CampGroupCard.jsx
@@ -211,10 +211,7 @@ function CampGroupCard({
         {youngPeople.length > 0 ? (
           <div className="grid grid-cols-2 gap-2">
             {youngPeople.map((youngPerson) => {
-              // Per-member disable: even when move mode is on, scouts whose
-              // section is missing its Viking Event Mgmt flexi record can't be
-              // moved (no flexirecordid/columnid to target on the API).
-              const memberHasFlexi = youngPerson.vikingEventData !== null && youngPerson.vikingEventData !== undefined;
+              const memberHasFlexi = youngPerson.vikingEventData?.CampGroup !== undefined;
               const memberDisabled = dragDisabled || !memberHasFlexi;
               return (
                 <DraggableMember

--- a/src/features/events/components/CampGroupsView.jsx
+++ b/src/features/events/components/CampGroupsView.jsx
@@ -110,11 +110,7 @@ function organizeByCampGroups(attendees, pendingMoves = new Map(), recentlyCompl
     member.vikingEventData?.CampGroup !== undefined,
   );
 
-  // True when at least one young person has flexi data — used to surface the
-  // move-mode toggle even when other sections are missing their flexi records.
-  // Without this, a single missing-flexi section hides the toggle for sections
-  // that ARE configured.
-  const someVikingEventData = youngPeople.some(member => member.vikingEventData !== null && member.vikingEventData !== undefined);
+  const someVikingEventData = youngPeople.some(member => member.vikingEventData?.CampGroup !== undefined);
 
   return {
     groups: sortedGroups,
@@ -161,21 +157,24 @@ function CampGroupsView({
   const [pendingMoves, setPendingMoves] = useState(new Map());
   const [recentlyCompletedMoves, setRecentlyCompletedMoves] = useState(new Map());
 
-  // Move mode is OFF by default. On mobile, drag/drop is too easy to trigger
-  // accidentally — gating it behind an explicit toggle prevents misclicks.
   const [moveMode, setMoveMode] = useState(false);
 
   const isMobile = isMobileLayout();
 
-  // Merge full member records into attendees so the per-tile MemberStatusIcons
-  // cluster has access to flattened contact-group fields (essential_information__*,
-  // consents__*, etc). The attendance records that flow in via `attendees` only
-  // carry attendance + vikingEventData; without this merge, groupContactInfo
-  // returns an empty object and no icons render.
+  /**
+   * Merge full member records into attendees so the per-tile
+   * `MemberStatusIcons` cluster has access to flattened contact-group fields
+   * (`essential_information__*`, `consents__*`, etc). Attendance records on
+   * their own only carry attendance + `vikingEventData`; without this merge,
+   * `groupContactInfo` returns an empty object and no icons render.
+   */
   const enrichedAttendees = useMemo(() => {
     if (!attendees || attendees.length === 0) return attendees;
     if (!members || members.length === 0) return attendees;
-    const memberById = new Map(members.map(m => [String(m.scoutid), m]));
+    const memberById = new Map(
+      members.filter(m => m?.scoutid !== undefined && m?.scoutid !== null)
+        .map(m => [String(m.scoutid), m]),
+    );
     return attendees.map(record => {
       const full = memberById.get(String(record.scoutid));
       return full ? { ...full, ...record } : record;
@@ -375,9 +374,7 @@ function CampGroupsView({
       const flexiRecordContext = extractFlexiRecordContext(sectionVikingEventData, sectionId, termId, realSectionType);
 
       if (!flexiRecordContext) {
-        const errorMsg = 'Camp groups not available for this section. Please ensure the "Viking Event Mgmt" FlexiRecord exists in OSM with a "CampGroup" field (no space).';
-        notifyError(errorMsg);
-        throw new Error(errorMsg);
+        throw new Error('Camp groups not available for this section. Please ensure the "Viking Event Mgmt" FlexiRecord exists in OSM with a "CampGroup" field (no space).');
       }
 
       const memberName = member.name || `${member.firstname} ${member.lastname}`;
@@ -759,7 +756,6 @@ function CampGroupsView({
           </div>
           
           <div className="flex items-center gap-2">
-            {/* Move Mode Toggle */}
             {summary.totalGroups > 0 && summary.someVikingEventDataAvailable && (
               <button
                 onClick={() => setMoveMode((prev) => !prev)}
@@ -789,7 +785,6 @@ function CampGroupsView({
               </button>
             )}
 
-            {/* Edit Names Button */}
             {summary.totalGroups > 0 && (
               <button
                 onClick={handleEditGroupNames}

--- a/src/features/events/components/DraggableMember.jsx
+++ b/src/features/events/components/DraggableMember.jsx
@@ -197,7 +197,6 @@ function DraggableMember({
         {member.firstname} {member.lastname}
       </div>
 
-      {/* Status icons (medical / photo consent / dietary / non-swimmer) */}
       <div className="flex items-center gap-1 mt-0.5 min-h-[1rem]">
         <MemberStatusIcons member={member} size="sm" />
       </div>

--- a/src/features/events/components/attendance/RegisterTab.jsx
+++ b/src/features/events/components/attendance/RegisterTab.jsx
@@ -4,10 +4,12 @@ import { isFieldCleared } from '../../../../shared/constants/signInDataConstants
 import { formatUKDateTime } from '../../../../shared/utils/dateFormatting.js';
 import MemberStatusIcons from '../../../../shared/components/ui/MemberStatusIcons.jsx';
 
-// Sentinel values that push empty entries to the end regardless of direction.
-// Camp Group is sorted as a string (numeric strings still compare correctly),
-// signed-in time is sorted by timestamp.
+/** Sort sentinel that places empty Camp Group values after every real
+ *  string (U+FFFF non-character compares greater than any BMP code point). */
 const CAMP_GROUP_EMPTY = '￿';
+
+/** Sort sentinel that places not-yet-signed-in members after every real
+ *  timestamp regardless of direction. */
 const SIGNED_IN_EMPTY = Number.MAX_SAFE_INTEGER;
 
 const sortData = (data, key, direction) => {

--- a/src/shared/components/AuthButton.jsx
+++ b/src/shared/components/AuthButton.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 /**
- * AuthButton - Context-aware authentication button for header
+ * AuthButton - Context-aware authentication button for header.
  *
  * Displays different button text and behavior based on authentication state:
  * - No data: "Sign in to OSM"
@@ -9,10 +9,15 @@ import React from 'react';
  * - Token expired: "Sign in to refresh"
  * - Syncing: "Syncing..." (disabled)
  *
+ * Returns null when `authState === 'authenticated'` and not actively syncing —
+ * each authenticated page surfaces its own contextual refresh control, so a
+ * generic header button would be redundant.
+ *
  * @param {Object} props - Component props
  * @param {string} props.authState - Current authentication state
  * @param {Function} props.onLogin - Login handler function
- * @param {Function} props.onRefresh - Refresh handler function
+ * @param {Function} props.onRefresh - Refresh handler function (unused while
+ *   the authenticated branch returns null; kept on the props contract).
  * @param {boolean} props.isLoading - Whether sync is in progress
  * @param {boolean} props.isOfflineMode - Whether the app is in offline mode
  * @param {string} props.className - Additional CSS classes
@@ -28,10 +33,6 @@ function AuthButton({
   size,
   ...rest
 }) {
-  // When authenticated and not actively syncing, hide the button entirely.
-  // Every authenticated page provides its own contextual refresh control;
-  // a duplicate generic "Refresh" in the header was visually noisy and
-  // mislabeled (it only refreshed reference data).
   if (!isLoading && authState === 'authenticated') {
     return null;
   }

--- a/src/shared/services/storage/__tests__/databaseService.parity.test.js
+++ b/src/shared/services/storage/__tests__/databaseService.parity.test.js
@@ -277,11 +277,17 @@ describe('DatabaseService — Cross-backend parity for flexi data', () => {
     return ds.getFlexiData(recordId, sectionId, termId);
   }
 
-  // Strip backend-specific bookkeeping fields that are not part of the
-  // consumer-facing parity contract. SQLite reconstructs `updated_at` from
-  // CURRENT_TIMESTAMP; IndexedDB uses Date.now(); neither is asserted equal.
-  // IndexedDB also preserves arbitrary wrapper fields from the API response
-  // (e.g. `identifier`, `_cacheTimestamp`); SQLite stores per-row only.
+  /**
+   * Strip backend-specific bookkeeping fields that are not part of the
+   * consumer-facing parity contract. SQLite reconstructs `updated_at` from
+   * `CURRENT_TIMESTAMP`; IndexedDB uses `Date.now()`; neither is asserted
+   * equal. IndexedDB also preserves arbitrary wrapper fields from the API
+   * response (e.g. `identifier`); SQLite stores per-row only and recovers
+   * `_cacheTimestamp` from the row timestamp on read (asserted separately).
+   *
+   * @param {Object|null} out - Raw output from `getFlexiData`.
+   * @returns {Object|null} Output with bookkeeping fields removed.
+   */
   function normalizeFlexiForComparison(out) {
     if (!out) return out;
     const { updated_at: _u, _cacheTimestamp: _c, identifier: _i, ...rest } = out;
@@ -361,5 +367,40 @@ describe('DatabaseService — Cross-backend parity for flexi data', () => {
 
     expect(sqliteOut.items[0].f_1).toBe('3');
     expect(idbOut.items[0].f_1).toBe('3');
+  });
+
+  it('both backends populate `_cacheTimestamp` (cache-TTL parity)', async () => {
+    const fixture = {
+      _cacheTimestamp: 1714000000000,
+      items: [{ scoutid: '1001', firstname: 'Alice', lastname: 'Smith', f_1: '1' }],
+    };
+
+    const dsSqlite = await loadService('native');
+    await dsSqlite.initialize();
+    await dsSqlite.saveFlexiData('extra1', 5, 't1', fixture);
+    const sqliteOut = await dsSqlite.getFlexiData('extra1', 5, 't1');
+
+    if (activeDb) { activeDb.close(); activeDb = null; }
+
+    const dsWeb = await loadService('web');
+    await dsWeb.initialize();
+    await dsWeb.saveFlexiData('extra1', 5, 't1', fixture);
+    const idbOut = await dsWeb.getFlexiData('extra1', 5, 't1');
+
+    expect(typeof sqliteOut._cacheTimestamp).toBe('number');
+    expect(typeof idbOut._cacheTimestamp).toBe('number');
+    expect(Number.isFinite(sqliteOut._cacheTimestamp)).toBe(true);
+    expect(Number.isFinite(idbOut._cacheTimestamp)).toBe(true);
+  });
+
+  it('both backends expose the same top-level key set (whitelist parity)', async () => {
+    const sqliteOut = await runFlexiRoundTrip('native', 'extra1', 5, 't1', FLEXI_FIXTURE);
+    const idbOut = await runFlexiRoundTrip('web', 'extra1', 5, 't1', FLEXI_FIXTURE);
+
+    const required = ['items', 'extraid', 'sectionid', 'termid', 'updated_at', '_cacheTimestamp'];
+    for (const key of required) {
+      expect(sqliteOut).toHaveProperty(key);
+      expect(idbOut).toHaveProperty(key);
+    }
   });
 });

--- a/src/shared/services/storage/database.js
+++ b/src/shared/services/storage/database.js
@@ -67,6 +67,29 @@ import logger, { LOG_CATEGORIES } from '../utils/logger.js';
  * await databaseService.saveEvents(1, events);
  * const sectionEvents = await databaseService.getEvents(1);
  */
+
+/**
+ * Parses a SQLite `updated_at` value to milliseconds since epoch, treating
+ * bare `'YYYY-MM-DD HH:MM:SS'` strings (as produced by `CURRENT_TIMESTAMP`)
+ * as UTC. Without the explicit `Z`, JavaScript's `Date.parse` interprets the
+ * string as local time, producing a multi-hour drift vs IndexedDB's
+ * `Date.now()` writes.
+ *
+ * @param {*} ts - Raw value from a SQLite row
+ * @returns {number|null} Epoch milliseconds, or null if the value is missing
+ *   or unparseable.
+ */
+function parseSqliteTimestamp(ts) {
+  if (ts === undefined || ts === null) return null;
+  if (typeof ts === 'number') return ts;
+  if (typeof ts !== 'string') return null;
+  const isoCandidate = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(ts)
+    ? `${ts.replace(' ', 'T')}Z`
+    : ts;
+  const parsed = Date.parse(isoCandidate);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 class DatabaseService {
   /**
    * Creates a new DatabaseService instance
@@ -2066,12 +2089,22 @@ class DatabaseService {
    * Retrieves flexi data for a record, section, and term from normalized storage.
    *
    * Returns an identical consumer-facing shape on both backends:
-   * `{ items, extraid, sectionid, termid, updated_at }` or null when no rows
-   * exist. On the SQLite path, per-scout rows are reconstructed into `items[]`
-   * by merging the parsed JSON `data` column with the explicit columns
-   * (scoutid/firstname/lastname). The IndexedDB path also preserves any
-   * wrapper fields the original API response carried (e.g. `identifier`),
-   * which the SQLite path does not store; consumers must not rely on those.
+   * `{ items, extraid, sectionid, termid, updated_at, _cacheTimestamp }` or
+   * null when no rows exist. On the SQLite path, per-scout rows are
+   * reconstructed into `items[]` by merging the parsed JSON `data` column
+   * with the explicit columns (scoutid/firstname/lastname).
+   *
+   * `_cacheTimestamp` is the millisecond epoch the row was written and is
+   * required for cross-backend parity with the cache-TTL check in
+   * `flexiRecordService.checkCacheTTL`. The IndexedDB path persists it
+   * verbatim from the saved record; the SQLite path derives it from the
+   * row's `updated_at` column (parsed as UTC — SQLite's
+   * `DEFAULT CURRENT_TIMESTAMP` produces a no-TZ string that JS would
+   * otherwise interpret as local time).
+   *
+   * The IndexedDB path also preserves arbitrary wrapper fields the original
+   * API response carried (e.g. `identifier`); the SQLite path does not
+   * store those — consumers must not rely on them.
    *
    * @async
    * @param {string} recordId - Flexi record identifier
@@ -2100,8 +2133,14 @@ class DatabaseService {
         if (row.data) {
           try {
             parsed = JSON.parse(row.data);
-          } catch (_parseError) {
-            parsed = {};
+          } catch (parseError) {
+            logger.warn('Failed to parse flexi_data.data JSON', {
+              extraid: row.extraid,
+              sectionid: row.sectionid,
+              termid: row.termid,
+              scoutid: row.scoutid,
+              error: parseError.message,
+            }, LOG_CATEGORIES.DATABASE);
           }
         }
         return {
@@ -2112,12 +2151,7 @@ class DatabaseService {
         };
       });
 
-      let updatedAt = Date.now();
-      const ts = rows[0]?.updated_at;
-      if (ts !== undefined && ts !== null) {
-        const parsedTs = typeof ts === 'number' ? ts : Date.parse(ts);
-        if (!Number.isNaN(parsedTs)) updatedAt = parsedTs;
-      }
+      const updatedAt = parseSqliteTimestamp(rows[0]?.updated_at) ?? Date.now();
 
       return {
         items,
@@ -2125,6 +2159,7 @@ class DatabaseService {
         sectionid: Number(sectionId),
         termid: String(termId),
         updated_at: updatedAt,
+        _cacheTimestamp: updatedAt,
       };
     } catch (error) {
       logger.error('Failed to get flexi data', {

--- a/src/shared/services/storage/indexedDBService.js
+++ b/src/shared/services/storage/indexedDBService.js
@@ -1811,12 +1811,14 @@ export class IndexedDBService {
   static async saveFlexiRecordData(extraId, sectionId, termId, data) {
     try {
       const db = await getDB();
+      const now = Date.now();
       const record = {
         ...data,
         extraid: String(extraId),
         sectionid: Number(sectionId),
         termid: String(termId),
-        updated_at: Date.now(),
+        updated_at: now,
+        _cacheTimestamp: data?._cacheTimestamp ?? now,
       };
       await db.put(STORES.FLEXI_DATA, record);
       return record;


### PR DESCRIPTION
## Summary

Follow-up to PRs #201 + #202, addressing the critical and important findings from the multi-agent post-merge review. Nitpick UX items (swimmer-icon visual disambiguation between explicit "No" and "unknown") deferred.

### Storage parity hardening

- **`_cacheTimestamp` parity** — iOS `getFlexiData` now returns `_cacheTimestamp` (derived from the row's `updated_at`), matching the IndexedDB shape. Without this, every `flexiRecordService.checkCacheTTL` check on iOS treated cache as expired and forced an API hit. IndexedDB save also now always sets `_cacheTimestamp` (defaulting to `Date.now()`) so both backends produce a consistent read shape regardless of caller input.
- **UTC-explicit `updated_at` parsing** — SQLite's `CURRENT_TIMESTAMP` produces a no-TZ string; JS `Date.parse` interprets it as local time. New `parseSqliteTimestamp` helper appends `Z` so SQLite and IndexedDB timestamps stay in lockstep across timezones.
- **JSON parse failures logged** — silent `{}` coalesce on `flexi_data.data` parse errors was hiding row-level corruption. Now logs row PK + error message.
- **2 new parity tests** — `_cacheTimestamp` numeric on both backends, and a whitelist key-set parity test (`items, extraid, sectionid, termid, updated_at, _cacheTimestamp` present on both).

### UI / lifecycle fixes

- **Double error toast on missing flexi context** — `CampGroupsView.handleMemberMove` was firing `notifyError(errorMsg)` *and* throwing a same-message error that the outer catch would also `notifyError`. Now throws once.
- **Per-member drag gate tightened** — was keyed on object presence, which let an empty `{}` slip through to a guaranteed-fail move. Now checks `vikingEventData?.CampGroup !== undefined`.
- **`enrichedAttendees` defensive filter** — members with missing `scoutid` no longer collapse onto a single `"undefined"` Map key.
- **Static imports in `useAuth.jsx`** — three dynamic imports of `notifications.js` inside the same try/catch were noisy and could leave the loading toast stranded if a chunk failed mid-cleanup. All hoisted to top.

### CLAUDE.md compliance

Project policy: "DO NOT ADD INLINE COMMENTS unless explicitly requested." The prior PRs added ~10 inline-comment blocks. Stripped from `CampGroupsView`, `CampGroupCard`, `DraggableMember`, `RegisterTab`, `AuthButton`. The two load-bearing blocks (`normalizeFlexiForComparison` parity-test contract; `RegisterTab` sort-sentinel constants) converted to JSDoc.

## Test plan

- [x] `npm run lint` — clean (0 errors)
- [x] `npm run test:run` — 515 pass (2 new), 13 skipped
- [x] Manual sanity check on dev server — camp groups still render, move toggle still gates drag, header is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)