### PR TITLE
feat(events): scope in-event refresh to events being viewed

### DIFF
--- a/src/features/events/components/attendance/EventAttendance.jsx
+++ b/src/features/events/components/attendance/EventAttendance.jsx
@@ -561,9 +561,13 @@ function EventAttendance({ events, members: membersProp, onBack }) {
         throw new Error(result.message);
       }
 
-      logger.info('Attendance data synced successfully', {}, LOG_CATEGORIES.COMPONENT);
+      logger.info('Attendance data synced', { partial: !!result.partial }, LOG_CATEGORIES.COMPONENT);
 
-      notifySuccess('Attendance data synced successfully');
+      if (result.partial) {
+        notifyWarning(result.message);
+      } else {
+        notifySuccess('Attendance data synced successfully');
+      }
 
       if (loadVikingEventData) {
         try {

--- a/src/features/events/components/attendance/EventAttendance.jsx
+++ b/src/features/events/components/attendance/EventAttendance.jsx
@@ -551,9 +551,11 @@ function EventAttendance({ events, members: membersProp, onBack }) {
     try {
       setRefreshingAttendance(true);
 
-      logger.info('Manual attendance refresh initiated from EventAttendance', {}, LOG_CATEGORIES.COMPONENT);
+      logger.info('Manual attendance refresh initiated from EventAttendance', {
+        eventCount: events?.length || 0,
+      }, LOG_CATEGORIES.COMPONENT);
 
-      const result = await eventDataLoader.syncAllEventAttendance(true);
+      const result = await eventDataLoader.syncEventsAttendance(events || []);
 
       if (!result.success) {
         throw new Error(result.message);

--- a/src/shared/services/data/__tests__/eventDataLoader.test.js
+++ b/src/shared/services/data/__tests__/eventDataLoader.test.js
@@ -146,4 +146,169 @@ describe('EventDataLoader', () => {
       expect(savedRecords[0].sectionid).toBe(0);
     });
   });
+
+  describe('syncEventsAttendance (scoped)', () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.saveAttendance).mockResolvedValue();
+      vi.mocked(databaseService.saveSharedAttendance).mockResolvedValue();
+      vi.mocked(databaseService.saveSharedEventMetadata).mockResolvedValue();
+      vi.mocked(api.getSharedEventAttendance).mockResolvedValue({ items: [] });
+      vi.mocked(api.createMemberSectionRecordsForSharedAttendees).mockResolvedValue();
+    });
+
+    it('returns success no-op for empty input without calling getToken', async () => {
+      const result = await eventDataLoader.syncEventsAttendance([]);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Nothing to refresh.');
+      expect(tokenService.getToken).not.toHaveBeenCalled();
+      expect(api.getEventAttendance).not.toHaveBeenCalled();
+    });
+
+    it('does NOT iterate sections (anti-regression: stays scoped)', async () => {
+      vi.mocked(tokenService.getToken).mockReturnValue('valid-token');
+      vi.mocked(api.getEventAttendance).mockResolvedValue([]);
+
+      await eventDataLoader.syncEventsAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1' },
+      ]);
+
+      expect(databaseService.getSections).not.toHaveBeenCalled();
+      expect(databaseService.getEvents).not.toHaveBeenCalled();
+    });
+
+    it('does NOT update lastSyncTime (preserves global cooldown contract)', async () => {
+      vi.mocked(tokenService.getToken).mockReturnValue('valid-token');
+      vi.mocked(api.getEventAttendance).mockResolvedValue([]);
+      eventDataLoader.lastSyncTime = null;
+
+      await eventDataLoader.syncEventsAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1' },
+      ]);
+
+      expect(eventDataLoader.lastSyncTime).toBe(null);
+    });
+
+    it('aggregates partial failure: 1 of 3 fails => success=true, partial=true', async () => {
+      vi.mocked(tokenService.getToken).mockReturnValue('valid-token');
+      vi.mocked(api.getEventAttendance).mockImplementation((sectionid, eventid) => {
+        if (eventid === 'E2') return Promise.reject(new Error('rate limited'));
+        return Promise.resolve([]);
+      });
+
+      const result = await eventDataLoader.syncEventsAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1', name: 'A' },
+        { eventid: 'E2', sectionid: 11, termid: 'T1', name: 'B' },
+        { eventid: 'E3', sectionid: 12, termid: 'T1', name: 'C' },
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(result.partial).toBe(true);
+      expect(result.details.syncedEvents).toBe(2);
+      expect(result.details.failedEvents).toBe(1);
+      expect(result.details.errors).toHaveLength(1);
+      expect(result.details.errors[0].eventId).toBe('E2');
+    });
+
+    it('all events fail => success=false', async () => {
+      vi.mocked(tokenService.getToken).mockReturnValue('valid-token');
+      vi.mocked(api.getEventAttendance).mockRejectedValue(new Error('500'));
+
+      const result = await eventDataLoader.syncEventsAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1', name: 'A' },
+        { eventid: 'E2', sectionid: 11, termid: 'T1', name: 'B' },
+      ]);
+
+      expect(result.success).toBe(false);
+      expect(result.details.syncedEvents).toBe(0);
+      expect(result.details.failedEvents).toBe(2);
+    });
+
+    it('skips events missing required fields and reports skippedEvents count', async () => {
+      vi.mocked(tokenService.getToken).mockReturnValue('valid-token');
+      vi.mocked(api.getEventAttendance).mockResolvedValue([]);
+
+      const result = await eventDataLoader.syncEventsAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1' },
+        { eventid: 'E2', sectionid: 11 },
+      ]);
+
+      expect(result.details.skippedEvents).toBe(1);
+      expect(result.details.validEvents).toBe(1);
+      expect(api.getEventAttendance).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles missing auth token without throwing', async () => {
+      vi.mocked(tokenService.getToken).mockReturnValue(null);
+
+      const result = await eventDataLoader.syncEventsAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1' },
+      ]);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('session has expired');
+      expect(api.getEventAttendance).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncSharedAttendance filtering', () => {
+    beforeEach(() => {
+      vi.mocked(databaseService.saveAttendance).mockResolvedValue();
+      vi.mocked(databaseService.saveSharedAttendance).mockResolvedValue();
+      vi.mocked(databaseService.saveSharedEventMetadata).mockResolvedValue();
+      vi.mocked(api.createMemberSectionRecordsForSharedAttendees).mockResolvedValue();
+    });
+
+    it('skips getSharedEventAttendance for events with no shared metadata', async () => {
+      vi.mocked(databaseService.getSharedEventMetadata).mockResolvedValue(null);
+
+      const result = await eventDataLoader.syncSharedAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1', name: 'A' },
+        { eventid: 'E2', sectionid: 11, termid: 'T1', name: 'B' },
+      ], 'token');
+
+      expect(api.getSharedEventAttendance).not.toHaveBeenCalled();
+      expect(result.skippedNonShared).toBe(2);
+      expect(result.sharedEvents).toBe(0);
+      expect(result.errorCount).toBe(0);
+    });
+
+    it('only calls getSharedEventAttendance for events flagged isSharedEvent', async () => {
+      vi.mocked(databaseService.getSharedEventMetadata).mockImplementation((eventId) => {
+        if (eventId === 'E1') return Promise.resolve({ is_shared_event: 1 });
+        return Promise.resolve(null);
+      });
+      vi.mocked(api.getSharedEventAttendance).mockResolvedValue({ items: [] });
+
+      const result = await eventDataLoader.syncSharedAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1', name: 'A' },
+        { eventid: 'E2', sectionid: 11, termid: 'T1', name: 'B' },
+      ], 'token');
+
+      expect(api.getSharedEventAttendance).toHaveBeenCalledTimes(1);
+      expect(api.getSharedEventAttendance).toHaveBeenCalledWith('E1', 10, 'token');
+      expect(result.skippedNonShared).toBe(1);
+      expect(result.sharedEvents).toBe(1);
+    });
+
+    it('aggregates per-event failures into errors[] without aborting the loop', async () => {
+      vi.mocked(databaseService.getSharedEventMetadata).mockResolvedValue({ isSharedEvent: true });
+      vi.mocked(api.getSharedEventAttendance).mockImplementation((eventId) => {
+        if (eventId === 'E2') return Promise.reject(new Error('429 rate limited'));
+        return Promise.resolve({ items: [] });
+      });
+
+      const result = await eventDataLoader.syncSharedAttendance([
+        { eventid: 'E1', sectionid: 10, termid: 'T1', name: 'A' },
+        { eventid: 'E2', sectionid: 11, termid: 'T1', name: 'B' },
+        { eventid: 'E3', sectionid: 12, termid: 'T1', name: 'C' },
+      ], 'token');
+
+      expect(result.successCount).toBe(2);
+      expect(result.errorCount).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].eventId).toBe('E2');
+      expect(result.errors[0].error).toContain('429');
+    });
+  });
 });

--- a/src/shared/services/data/eventDataLoader.js
+++ b/src/shared/services/data/eventDataLoader.js
@@ -24,21 +24,71 @@ class EventDataLoader {
   }
 
   /**
-   * Syncs attendance for a specific set of events only — used by the in-event
-   * refresh button to avoid the full multi-section sync (which can hit OSM
-   * rate limits and is slow). Per-event attendance + shared-attendance
-   * lookups run concurrently for the supplied events.
+   * Syncs attendance for a caller-supplied set of events only, avoiding the
+   * full all-events sync (which iterates every cached event across every
+   * section the user has access to and can hit OSM rate limits).
+   *
+   * Behaviour:
+   * - Per-event attendance + shared-attendance lookups run concurrently for
+   *   each valid event (`sectionid` + `eventid` + `termid` all present).
+   * - Events missing required fields are silently skipped and counted in
+   *   `details.skippedEvents`.
+   * - If a sync is already in flight (global or scoped), this call short-
+   *   circuits with `success: true` and a "sync already in progress"
+   *   message, leaving the in-flight pass to complete.
+   * - Empty input is a no-op success (no API calls, no toast-worthy error).
+   * - `Promise.allSettled` is used: per-event failures populate
+   *   `details.errors` and are tagged in Sentry, but do not abort the rest.
+   * - `success` is true when at least one event synced; partial failures are
+   *   still `success: true` so the caller can present a warning rather than
+   *   a hard error. Only zero-success runs report `success: false`.
+   * - `lastSyncTime` is intentionally NOT updated — that field gates the
+   *   global sync's cooldown, and a scoped refresh shouldn't suppress a
+   *   subsequent global refresh.
+   * - `syncSharedAttendance` runs after per-event syncs; its per-event
+   *   failures are best-effort logged (debug) and do not affect the
+   *   returned `success`.
    *
    * @param {Array<Object>} events - Events to refresh. Each must have
-   *   `sectionid`, `eventid`, and `termid`. Other events in the cache are
-   *   left untouched.
-   * @returns {Promise<{success: boolean, message: string, details?: Object}>}
+   *   `sectionid`, `eventid`, and `termid`.
+   * @returns {Promise<{success: boolean, message: string, details?: {
+   *   totalEvents: number, validEvents: number, skippedEvents: number,
+   *   syncedEvents: number, failedEvents: number,
+   *   errors: Array<{eventId: *, eventName: string, error: string}>
+   * }}>}
    */
   async syncEventsAttendance(events) {
     if (!Array.isArray(events) || events.length === 0) {
-      return { success: false, message: 'No events provided to sync.' };
+      return { success: true, message: 'Nothing to refresh.' };
     }
 
+    if (this.isLoading) {
+      logger.debug('Scoped sync skipped — sync already in progress', {}, LOG_CATEGORIES.DATA_SERVICE);
+      if (this.refreshPromise) {
+        return await this.refreshPromise;
+      }
+      return { success: true, message: 'Sync already in progress' };
+    }
+
+    this.isLoading = true;
+    this.refreshPromise = this._doScopedSync(events);
+    try {
+      return await this.refreshPromise;
+    } finally {
+      this.isLoading = false;
+      this.refreshPromise = null;
+    }
+  }
+
+  /**
+   * Internal implementation of `syncEventsAttendance`. Caller is responsible
+   * for setting/clearing `this.isLoading` and `this.refreshPromise` around
+   * this call.
+   *
+   * @param {Array<Object>} events
+   * @returns {Promise<Object>}
+   */
+  async _doScopedSync(events) {
     try {
       const token = getToken();
       if (!token) {
@@ -55,7 +105,10 @@ class EventDataLoader {
         logger.warn('No valid events in scoped sync set (missing required fields)', {
           inputCount: events.length,
         }, LOG_CATEGORIES.DATA_SERVICE);
-        return { success: false, message: 'No valid events to sync.' };
+        return {
+          success: false,
+          message: 'No valid events to sync — check that sectionid, eventid, and termid are all present.',
+        };
       }
 
       logger.info('Starting scoped attendance sync', {
@@ -66,16 +119,16 @@ class EventDataLoader {
       const syncPromises = validEvents.map(event => this.syncEventAttendanceSafe(event, token));
       const results = await Promise.allSettled(syncPromises);
 
-      await this.syncSharedAttendance(validEvents, token);
+      const sharedResult = await this.syncSharedAttendance(validEvents, token);
 
       const syncResults = {
         totalEvents: events.length,
         validEvents: validEvents.length,
-        displayableEvents: validEvents.length,
         skippedEvents: events.length - validEvents.length,
         syncedEvents: 0,
         failedEvents: 0,
         errors: [],
+        shared: sharedResult,
       };
 
       results.forEach((result, index) => {
@@ -106,9 +159,21 @@ class EventDataLoader {
 
       logger.info('Scoped attendance sync completed', { ...syncResults }, LOG_CATEGORIES.DATA_SERVICE);
 
+      const sharedFailed = sharedResult.errorCount > 0;
+      const partial = (syncResults.failedEvents > 0 || sharedFailed) && syncResults.syncedEvents > 0;
+
+      let message = `Synced ${syncResults.syncedEvents}/${syncResults.validEvents} events`;
+      if (syncResults.failedEvents > 0) {
+        message += `; ${syncResults.failedEvents} failed`;
+      }
+      if (sharedFailed) {
+        message += `; shared-attendance had ${sharedResult.errorCount} failure${sharedResult.errorCount === 1 ? '' : 's'}`;
+      }
+
       return {
-        success: syncResults.failedEvents === 0,
-        message: `Synced ${syncResults.syncedEvents}/${syncResults.validEvents} events`,
+        success: syncResults.syncedEvents > 0,
+        partial,
+        message,
         details: syncResults,
       };
     } catch (error) {
@@ -378,28 +443,58 @@ class EventDataLoader {
   }
 
   /**
-   * Syncs shared attendance for all events to the normalized store
-   * @param {Array<Object>} events - Events to sync shared attendance for
-   * @param {string} token - Auth token
-   * @returns {Promise<Object>} Sync results summary
+   * Syncs shared attendance for events flagged as shared in
+   * `shared_event_metadata`. Events without metadata (or with
+   * `isSharedEvent === false`) are skipped — `eventsService` populates the
+   * flag at event-load time so by the time attendance sync runs, only
+   * genuinely shared events incur an API call here.
+   *
+   * Per-event failures are reported via the returned `errorCount` and
+   * `errors` array, and individually captured to Sentry. They do NOT abort
+   * the loop — best-effort across the set.
+   *
+   * @param {Array<Object>} events - Events to consider for shared sync.
+   * @param {string} token - Auth token.
+   * @returns {Promise<{apiCallCount: number, successCount: number,
+   *   errorCount: number, sharedEvents: number, skippedNonShared: number,
+   *   errors: Array<{eventId: *, eventName: string, error: string}>
+   * }>}
    */
   async syncSharedAttendance(events, token) {
     let apiCallCount = 0;
     let successCount = 0;
     let errorCount = 0;
+    const errors = [];
+
+    const sharedFlags = await Promise.all(
+      events.map(async (event) => {
+        try {
+          const meta = await databaseService.getSharedEventMetadata(event.eventid);
+          const isShared = meta?.is_shared_event === 1
+            || meta?.is_shared_event === true
+            || meta?.isSharedEvent === true;
+          return { event, isShared };
+        } catch (lookupError) {
+          logger.warn('Failed to read shared_event_metadata; assuming not shared', {
+            eventId: event.eventid,
+            error: lookupError.message,
+          }, LOG_CATEGORIES.DATA_SERVICE);
+          return { event, isShared: false };
+        }
+      }),
+    );
+
+    const sharedEvents = sharedFlags.filter(({ isShared }) => isShared).map(({ event }) => event);
+    const skippedNonShared = events.length - sharedEvents.length;
 
     logger.info('Starting shared attendance sync', {
       totalEvents: events.length,
+      sharedEvents: sharedEvents.length,
+      skippedNonShared,
     }, LOG_CATEGORIES.DATA_SERVICE);
 
-    for (const event of events) {
+    for (const event of sharedEvents) {
       try {
-        logger.debug('Syncing shared attendance for event', {
-          eventName: event.name,
-          eventId: event.eventid,
-          sectionId: event.sectionid,
-        }, LOG_CATEGORIES.DATA_SERVICE);
-
         const sharedAttendanceData = await getSharedEventAttendance(
           event.eventid,
           event.sectionid,
@@ -444,16 +539,30 @@ class EventDataLoader {
       } catch (apiError) {
         apiCallCount++;
         errorCount++;
-        logger.debug('Shared attendance sync failed for event', {
+        errors.push({
+          eventId: event.eventid,
+          eventName: event.name,
+          error: apiError.message,
+        });
+        logger.warn('Shared attendance sync failed for event', {
           eventName: event.name,
           eventId: event.eventid,
+          sectionId: event.sectionid,
           error: apiError.message,
         }, LOG_CATEGORIES.DATA_SERVICE);
+        if (apiError instanceof Error) {
+          sentryUtils.captureException(apiError, {
+            tags: { operation: 'sync_shared_attendance' },
+            contexts: { event: { id: String(event.eventid), name: event.name, sectionid: event.sectionid } },
+          });
+        }
       }
     }
 
     logger.info('Shared attendance sync completed', {
       totalEvents: events.length,
+      sharedEvents: sharedEvents.length,
+      skippedNonShared,
       successCount,
       errorCount,
       apiCallCount,
@@ -463,7 +572,9 @@ class EventDataLoader {
       apiCallCount,
       successCount,
       errorCount,
-      sharedEvents: successCount + errorCount,
+      sharedEvents: sharedEvents.length,
+      skippedNonShared,
+      errors,
     };
   }
 }

--- a/src/shared/services/data/eventDataLoader.js
+++ b/src/shared/services/data/eventDataLoader.js
@@ -23,6 +23,103 @@ class EventDataLoader {
     return await this.refreshAllEventAttendance();
   }
 
+  /**
+   * Syncs attendance for a specific set of events only — used by the in-event
+   * refresh button to avoid the full multi-section sync (which can hit OSM
+   * rate limits and is slow). Per-event attendance + shared-attendance
+   * lookups run concurrently for the supplied events.
+   *
+   * @param {Array<Object>} events - Events to refresh. Each must have
+   *   `sectionid`, `eventid`, and `termid`. Other events in the cache are
+   *   left untouched.
+   * @returns {Promise<{success: boolean, message: string, details?: Object}>}
+   */
+  async syncEventsAttendance(events) {
+    if (!Array.isArray(events) || events.length === 0) {
+      return { success: false, message: 'No events provided to sync.' };
+    }
+
+    try {
+      const token = getToken();
+      if (!token) {
+        const scoutMessage = 'Your session has expired. Please log in again to sync events.';
+        logger.warn('No auth token available for scoped event sync', {}, LOG_CATEGORIES.DATA_SERVICE);
+        return { success: false, message: scoutMessage };
+      }
+
+      const validEvents = events.filter(event =>
+        event && event.sectionid && event.eventid && event.termid,
+      );
+
+      if (validEvents.length === 0) {
+        logger.warn('No valid events in scoped sync set (missing required fields)', {
+          inputCount: events.length,
+        }, LOG_CATEGORIES.DATA_SERVICE);
+        return { success: false, message: 'No valid events to sync.' };
+      }
+
+      logger.info('Starting scoped attendance sync', {
+        eventCount: validEvents.length,
+        eventIds: validEvents.map(e => e.eventid),
+      }, LOG_CATEGORIES.DATA_SERVICE);
+
+      const syncPromises = validEvents.map(event => this.syncEventAttendanceSafe(event, token));
+      const results = await Promise.allSettled(syncPromises);
+
+      await this.syncSharedAttendance(validEvents, token);
+
+      const syncResults = {
+        totalEvents: events.length,
+        validEvents: validEvents.length,
+        displayableEvents: validEvents.length,
+        skippedEvents: events.length - validEvents.length,
+        syncedEvents: 0,
+        failedEvents: 0,
+        errors: [],
+      };
+
+      results.forEach((result, index) => {
+        const event = validEvents[index];
+        if (result.status === 'fulfilled') {
+          syncResults.syncedEvents++;
+        } else {
+          syncResults.failedEvents++;
+          syncResults.errors.push({
+            eventId: event.eventid,
+            eventName: event.name,
+            error: result.reason?.message || 'Unknown error',
+          });
+          const reasonMsg = result.reason?.message || String(result.reason);
+          logger.warn(`Failed to sync attendance for event "${event.name}" (id=${event.eventid}): ${reasonMsg}`, {
+            eventName: event.name,
+            eventId: event.eventid,
+            error: result.reason?.message,
+          }, LOG_CATEGORIES.DATA_SERVICE);
+          if (result.reason instanceof Error) {
+            sentryUtils.captureException(result.reason, {
+              tags: { operation: 'sync_event_attendance_scoped' },
+              contexts: { event: { id: String(event.eventid), name: event.name, sectionid: event.sectionid } },
+            });
+          }
+        }
+      });
+
+      logger.info('Scoped attendance sync completed', { ...syncResults }, LOG_CATEGORIES.DATA_SERVICE);
+
+      return {
+        success: syncResults.failedEvents === 0,
+        message: `Synced ${syncResults.syncedEvents}/${syncResults.validEvents} events`,
+        details: syncResults,
+      };
+    } catch (error) {
+      const scoutMessage = getScoutFriendlyMessage(error, 'sync event attendance');
+      logger.error('Scoped attendance sync failed', {
+        error: error.message,
+      }, LOG_CATEGORIES.DATA_SERVICE);
+      return { success: false, message: scoutMessage };
+    }
+  }
+
   async refreshAllEventAttendance() {
     if (this.isLoading) {
       logger.debug('Event attendance sync already in progress', {}, LOG_CATEGORIES.DATA_SERVICE);


### PR DESCRIPTION
## Summary

The "Refresh" button inside `EventAttendance` was calling `syncAllEventAttendance(true)`, which iterates every cached event across every section the user has access to. Three problems with that:

1. **Slow** — refreshing the Friday Arrivals view kicks off N parallel API calls for unrelated events.
2. **Rate-limit risk** — easy to trip OSM's rate limiter when a leader hits refresh on a busy device.
3. **Misleading** — the user clicks "Refresh" inside *one* event and expects *that* event to refresh.

## Change

Adds `eventDataLoader.syncEventsAttendance(events)` — a scoped variant that runs the existing per-event sync (`syncEventAttendanceSafe`) and shared-attendance sync against a caller-supplied list. `EventAttendance.handleRefreshAttendance` now passes its own `events` prop, so the API call set is scoped to the events being viewed (typically 1, or a small group for shared cross-section events).

The viking event data refresh after the attendance sync was already scoped via `loadVikingEventData()` (which iterates the `events` prop), so no change there.

The dashboard's blue "Refresh Data" button still uses `syncAllEventAttendance` via `dataLoadingService.loadAllDataAfterAuth` — that's the right place for a global sync.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 515 pass, 13 skipped
- [ ] Sanity check on device:
  - [ ] In an event view, click Refresh — only that event's API endpoint should be hit (verify in Network/console logs: only `eventCount: 1` in the debug log)
  - [ ] Multi-section shared event — both sections' attendance refresh together
  - [ ] Dashboard Refresh Data button still does a global sync (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)