### PR TITLE
feat: add member photos and photo-consent filters to Sections page

### DIFF
--- a/src/features/sections/components/SectionsList.jsx
+++ b/src/features/sections/components/SectionsList.jsx
@@ -86,13 +86,12 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
   // Data filter state - for controlling which columns to show
   const [dataFilters, setDataFilters] = useState({
     contacts: false, // Primary and Emergency contacts (hidden by default as requested)
-    photos: false, // Member photo column (hidden by default)
+    photos: false,
   });
 
-  // Member filter state - for controlling which member rows are shown
   const [memberFilters, setMemberFilters] = useState({
-    noPhotoConsent: false, // Only show members without 'Yes' photographs consent
-    hideAdults: false, // Exclude person_type === 'Leaders'
+    noPhotoConsent: false,
+    hideAdults: false,
   });
 
   // Load members when sections change
@@ -236,7 +235,6 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
     setSelectedMember(null);
   };
 
-  // Members visible after applying the "No Photo Consent" and "Hide Adults" filters
   const visibleMembers = React.useMemo(() => {
     return members.filter((member) => {
       if (memberFilters.hideAdults && member.person_type === 'Leaders') {
@@ -518,7 +516,6 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                {/* Photo Header - conditionally shown */}
                 {dataFilters.photos && (
                   <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Photo
@@ -591,7 +588,6 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
 
                 return (
                   <tr key={member.scoutid || index} className="hover:bg-gray-50 text-xs">
-                    {/* Photo Cell - conditionally shown */}
                     {dataFilters.photos && (
                       <td className="px-3 py-2 whitespace-nowrap">
                         <MemberAvatar member={member} size="sm" />

--- a/src/features/sections/components/SectionsList.jsx
+++ b/src/features/sections/components/SectionsList.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { getListOfMembers } from '../../../shared/services/api/api/members.js';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import { MemberDetailModal, MedicalDataPill } from '../../../shared/components/ui/index.js';
+import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
 import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
 import { formatMedicalDataForDisplay } from '../../../shared/utils/medicalDataUtils.js';
 import { calculateAge } from '../../../shared/utils/ageUtils.js';
@@ -9,6 +10,20 @@ import { groupContactInfo } from '../../../shared/utils/contactGroups.js';
 import { notifyError, notifySuccess, notifyWarning } from '../../../shared/utils/notifications.js';
 import { resolveSectionName } from '../../../shared/utils/memberUtils.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+
+/**
+ * Determines whether a member's photographs consent is anything other than
+ * an explicit 'Yes' (i.e. 'No', empty, or missing all count as "not Yes").
+ * Checks both `photographs` and `Photographs` keys, case-insensitively.
+ *
+ * @param {Object} [consents] - The `memberData.consents` map.
+ * @returns {boolean} True when the member should be surfaced by the
+ *   "No Photo Consent" filter.
+ */
+export function isNotPhotoConsentYes(consents) {
+  const value = consents?.photographs ?? consents?.Photographs;
+  return String(value ?? '').trim().toLowerCase() !== 'yes';
+}
 
 function SectionsList({
   sections,
@@ -71,6 +86,13 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
   // Data filter state - for controlling which columns to show
   const [dataFilters, setDataFilters] = useState({
     contacts: false, // Primary and Emergency contacts (hidden by default as requested)
+    photos: false, // Member photo column (hidden by default)
+  });
+
+  // Member filter state - for controlling which member rows are shown
+  const [memberFilters, setMemberFilters] = useState({
+    noPhotoConsent: false, // Only show members without 'Yes' photographs consent
+    hideAdults: false, // Exclude person_type === 'Leaders'
   });
 
   // Load members when sections change
@@ -135,6 +157,11 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
     return {
       // Basic info
       name: `${member.firstname || member.first_name} ${member.lastname || member.last_name}`,
+      firstname: member.firstname || member.first_name || '',
+      lastname: member.lastname || member.last_name || '',
+      scoutid: member.scoutid,
+      photo_guid: member.photo_guid,
+      person_type: member.person_type,
       section: resolveSectionName(member),
       patrol: member.patrol || '',
       age: calculateAge(member.date_of_birth),
@@ -208,6 +235,26 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
     setShowMemberModal(false);
     setSelectedMember(null);
   };
+
+  // Members visible after applying the "No Photo Consent" and "Hide Adults" filters
+  const visibleMembers = React.useMemo(() => {
+    return members.filter((member) => {
+      if (memberFilters.hideAdults && member.person_type === 'Leaders') {
+        return false;
+      }
+      if (memberFilters.noPhotoConsent) {
+        const contactGroups = groupContactInfo(member);
+        const consents = {
+          ...(contactGroups.permissions || {}),
+          ...(contactGroups.consents || {}),
+        };
+        if (!isNotPhotoConsentYes(consents)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [members, memberFilters]);
 
   // Get all unique consent fields from all members for dynamic table rendering
   const allConsentFields = React.useMemo(() => {
@@ -314,7 +361,7 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
     <div>
       {/* Header with Export Button */}
       <div className="flex items-center justify-between mb-4">
-        <h4 className="text-lg font-medium text-gray-900">Members ({members.length})</h4>
+        <h4 className="text-lg font-medium text-gray-900">Members ({visibleMembers.length})</h4>
         {members.length > 0 && (
           <button
             onClick={exportToCSV}
@@ -411,12 +458,58 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
               >
                   Contacts
               </button>
+              <button
+                onClick={() => setDataFilters(prev => ({ ...prev, photos: !prev.photos }))}
+                className={`px-3 py-1 rounded-md text-sm font-medium border transition-colors ${
+                  dataFilters.photos
+                    ? 'bg-scout-blue text-white border-scout-blue'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+                type="button"
+              >
+                  Photos
+              </button>
+            </div>
+          </div>
+          <div className="flex-1">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+                Filter:
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  const turningOn = !memberFilters.noPhotoConsent;
+                  setMemberFilters(prev => ({ ...prev, noPhotoConsent: turningOn }));
+                  if (turningOn) {
+                    setDataFilters(prev => ({ ...prev, photos: true }));
+                  }
+                }}
+                className={`px-3 py-1 rounded-md text-sm font-medium border transition-colors ${
+                  memberFilters.noPhotoConsent
+                    ? 'bg-scout-blue text-white border-scout-blue'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+                type="button"
+              >
+                  No Photo Consent
+              </button>
+              <button
+                onClick={() => setMemberFilters(prev => ({ ...prev, hideAdults: !prev.hideAdults }))}
+                className={`px-3 py-1 rounded-md text-sm font-medium border transition-colors ${
+                  memberFilters.hideAdults
+                    ? 'bg-scout-blue text-white border-scout-blue'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+                type="button"
+              >
+                  Hide Adults
+              </button>
             </div>
           </div>
         </div>
       </div>
-        
-      {members.length === 0 ? (
+
+      {visibleMembers.length === 0 ? (
         <div className="bg-white rounded-lg border border-gray-200 p-8 text-center">
           <p className="text-gray-500">No members found for the selected sections.</p>
         </div>
@@ -425,6 +518,13 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
+                {/* Photo Header - conditionally shown */}
+                {dataFilters.photos && (
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Photo
+                  </th>
+                )}
+
                 {/* Basic Info Headers */}
                 <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 bg-gray-50">
                 Member
@@ -485,12 +585,19 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {members.map((member, index) => {
+              {visibleMembers.map((member, index) => {
               // Get comprehensive member data
                 const memberData = getComprehensiveMemberData(member);
 
                 return (
                   <tr key={member.scoutid || index} className="hover:bg-gray-50 text-xs">
+                    {/* Photo Cell - conditionally shown */}
+                    {dataFilters.photos && (
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <MemberAvatar member={member} size="sm" />
+                      </td>
+                    )}
+
                     {/* Basic Info Cells */}
                     <td className="px-3 py-2 whitespace-nowrap sticky left-0 bg-white">
                       <button

--- a/src/features/sections/components/__tests__/SectionsList.test.jsx
+++ b/src/features/sections/components/__tests__/SectionsList.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { isNotPhotoConsentYes } from '../SectionsList.jsx';
+
+describe('isNotPhotoConsentYes', () => {
+  it('returns false when photographs consent is Yes', () => {
+    expect(isNotPhotoConsentYes({ photographs: 'Yes' })).toBe(false);
+  });
+
+  it('returns false when photographs consent is Yes regardless of case', () => {
+    expect(isNotPhotoConsentYes({ photographs: 'yes' })).toBe(false);
+    expect(isNotPhotoConsentYes({ Photographs: 'YES' })).toBe(false);
+  });
+
+  it('returns true when photographs consent is No', () => {
+    expect(isNotPhotoConsentYes({ photographs: 'No' })).toBe(true);
+  });
+
+  it('returns true when photographs consent is empty', () => {
+    expect(isNotPhotoConsentYes({ photographs: '' })).toBe(true);
+  });
+
+  it('returns true when photographs consent is missing entirely', () => {
+    expect(isNotPhotoConsentYes({})).toBe(true);
+    expect(isNotPhotoConsentYes(undefined)).toBe(true);
+  });
+
+  it('checks the capitalized Photographs key when photographs is absent', () => {
+    expect(isNotPhotoConsentYes({ Photographs: 'Yes' })).toBe(false);
+    expect(isNotPhotoConsentYes({ Photographs: 'No' })).toBe(true);
+  });
+
+  it('prefers the lowercase photographs key when both are present', () => {
+    expect(isNotPhotoConsentYes({ photographs: 'Yes', Photographs: 'No' })).toBe(false);
+  });
+});

--- a/src/shared/components/ui/MemberAvatar.jsx
+++ b/src/shared/components/ui/MemberAvatar.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { buildMemberPhotoUrl } from '../../utils/memberPhotos.js';
+
+const SIZE_CLASSES = {
+  sm: 'h-8 w-8 text-xs',
+  md: 'h-12 w-12 text-sm',
+  lg: 'h-24 w-24 text-2xl',
+};
+
+const PHOTO_PIXEL_SIZE = {
+  sm: '125x125',
+  md: '125x125',
+  lg: '250x250',
+};
+
+/**
+ * Derive display initials for a member, preferring firstname/lastname but
+ * falling back to a `name` field for transformed member objects that only
+ * carry a combined name.
+ *
+ * @param {Object} [member] - Member data
+ * @returns {string} Up to two initials, or an empty string if none available
+ */
+function getInitials(member) {
+  if (!member) return '';
+
+  if (member.firstname || member.lastname) {
+    return `${member.firstname?.[0] || ''}${member.lastname?.[0] || ''}`;
+  }
+
+  if (member.name) {
+    const [first, second] = String(member.name).trim().split(/\s+/);
+    return `${first?.[0] || ''}${second?.[0] || ''}`;
+  }
+
+  return '';
+}
+
+/**
+ * Derive a human-readable display name for alt text/aria-labels.
+ *
+ * @param {Object} [member] - Member data
+ * @returns {string} The member's display name, or an empty string if none available
+ */
+function getDisplayName(member) {
+  if (!member) return '';
+
+  if (member.firstname || member.lastname) {
+    return `${member.firstname || ''} ${member.lastname || ''}`.trim();
+  }
+
+  return member.name || '';
+}
+
+/**
+ * Member Avatar Component
+ *
+ * Displays an OSM member's profile photo as a circular avatar, using the
+ * public unauthenticated OSM member photo CDN (see buildMemberPhotoUrl in
+ * shared/utils/memberPhotos.js). Falls back to a scout-purple circle with
+ * the member's initials when no photo_guid is present, or if the photo
+ * fails to load.
+ *
+ * Member object should contain: scoutid, photo_guid, and either
+ * firstname/lastname or a combined name field.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {Object} props.member - Member data (scoutid, photo_guid, firstname/lastname or name)
+ * @param {'sm'|'md'|'lg'} [props.size='sm'] - Avatar size: sm for table rows, md, lg for larger profile views
+ * @param {string} [props.className] - Additional classes merged onto the avatar element
+ * @returns {JSX.Element} Circular photo or initials fallback
+ *
+ * @example
+ * <MemberAvatar member={member} size="md" />
+ */
+function MemberAvatar({ member, size = 'sm', className = '' }) {
+  const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [member?.scoutid, member?.photo_guid]);
+
+  const sizeClasses = SIZE_CLASSES[size] || SIZE_CLASSES.sm;
+  const photoUrl = imgError
+    ? null
+    : buildMemberPhotoUrl(member?.scoutid, member?.photo_guid, PHOTO_PIXEL_SIZE[size] || PHOTO_PIXEL_SIZE.sm);
+  const displayName = getDisplayName(member);
+
+  if (photoUrl) {
+    return (
+      <img
+        src={photoUrl}
+        alt={displayName ? `Photo of ${displayName}` : 'Member photo'}
+        loading="lazy"
+        onError={() => setImgError(true)}
+        className={`rounded-full object-cover ${sizeClasses} ${className}`}
+      />
+    );
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label={displayName ? `${displayName} (no photo available)` : 'Member (no photo available)'}
+      className={`rounded-full bg-scout-purple text-white flex items-center justify-center font-semibold ${sizeClasses} ${className}`}
+    >
+      {getInitials(member)}
+    </div>
+  );
+}
+
+export default MemberAvatar;

--- a/src/shared/components/ui/__tests__/MemberAvatar.test.jsx
+++ b/src/shared/components/ui/__tests__/MemberAvatar.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MemberAvatar from '../MemberAvatar';
+
+describe('MemberAvatar', () => {
+  it('renders an img with the constructed photo URL when photo_guid is present', () => {
+    const member = { scoutid: 1234567, photo_guid: 'abc-guid', firstname: 'Jane', lastname: 'Doe' };
+    render(<MemberAvatar member={member} />);
+
+    const img = screen.getByRole('img', { name: /jane doe/i });
+    expect(img.tagName).toBe('IMG');
+    expect(img).toHaveAttribute(
+      'src',
+      'https://www.onlinescoutmanager.co.uk/sites/onlinescoutmanager.co.uk/public/member_photos/1234000/1234567/abc-guid/125x125_0.jpg',
+    );
+    expect(img).toHaveAttribute('loading', 'lazy');
+  });
+
+  it('uses the 250x250 variant for size lg', () => {
+    const member = { scoutid: 1234567, photo_guid: 'abc-guid', firstname: 'Jane', lastname: 'Doe' };
+    render(<MemberAvatar member={member} size="lg" />);
+
+    const img = screen.getByRole('img', { name: /jane doe/i });
+    expect(img).toHaveAttribute('src', expect.stringContaining('250x250_0.jpg'));
+  });
+
+  it('renders initials fallback when photo_guid is missing', () => {
+    const member = { scoutid: 1234567, photo_guid: null, firstname: 'Jane', lastname: 'Doe' };
+    const { container } = render(<MemberAvatar member={member} />);
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('derives initials from a combined name field when firstname/lastname are absent', () => {
+    const member = { scoutid: 1234567, photo_guid: null, name: 'Jane Doe' };
+    render(<MemberAvatar member={member} />);
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('falls back to initials when the image fails to load', () => {
+    const member = { scoutid: 1234567, photo_guid: 'abc-guid', firstname: 'Jane', lastname: 'Doe' };
+    const { container } = render(<MemberAvatar member={member} />);
+
+    const img = screen.getByRole('img', { name: /jane doe/i });
+    fireEvent.error(img);
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('applies the correct size classes for sm, md, and lg', () => {
+    const member = { scoutid: 1234567, photo_guid: null, firstname: 'Jane', lastname: 'Doe' };
+
+    const { rerender } = render(<MemberAvatar member={member} size="sm" />);
+    expect(screen.getByText('JD')).toHaveClass('h-8', 'w-8');
+
+    rerender(<MemberAvatar member={member} size="md" />);
+    expect(screen.getByText('JD')).toHaveClass('h-12', 'w-12');
+
+    rerender(<MemberAvatar member={member} size="lg" />);
+    expect(screen.getByText('JD')).toHaveClass('h-24', 'w-24');
+  });
+});

--- a/src/shared/components/ui/index.js
+++ b/src/shared/components/ui/index.js
@@ -40,6 +40,7 @@ export { default as ErrorState } from './ErrorState';
 export { default as SectionFilter } from './SectionFilter';
 export { default as SectionCardsFlexMasonry } from './SectionCardsFlexMasonry';
 export { default as MemberDetailModal } from './MemberDetailModal';
+export { default as MemberAvatar } from './MemberAvatar';
 export { default as MedicalDataDisplay } from './MedicalDataDisplay';
 export { MedicalDataPill, MedicalDataList } from './MedicalDataDisplay';
 

--- a/src/shared/utils/__tests__/memberPhotos.test.js
+++ b/src/shared/utils/__tests__/memberPhotos.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { buildMemberPhotoUrl } from '../memberPhotos.js';
+
+describe('buildMemberPhotoUrl', () => {
+  it('builds a 125x125 URL by default', () => {
+    const url = buildMemberPhotoUrl(1234567, 'abc-guid');
+    expect(url).toBe(
+      'https://www.onlinescoutmanager.co.uk/sites/onlinescoutmanager.co.uk/public/member_photos/1234000/1234567/abc-guid/125x125_0.jpg',
+    );
+  });
+
+  it('builds a 250x250 URL when requested', () => {
+    const url = buildMemberPhotoUrl(1234567, 'abc-guid', '250x250');
+    expect(url).toBe(
+      'https://www.onlinescoutmanager.co.uk/sites/onlinescoutmanager.co.uk/public/member_photos/1234000/1234567/abc-guid/250x250_0.jpg',
+    );
+  });
+
+  it('derives the photoStart bucket from the first 4 characters of scoutid', () => {
+    const url = buildMemberPhotoUrl(9876543, 'guid');
+    expect(url).toContain('/9876000/9876543/guid/');
+  });
+
+  it('accepts scoutid as a string', () => {
+    const url = buildMemberPhotoUrl('1234567', 'abc-guid');
+    expect(url).toContain('/1234000/1234567/abc-guid/');
+  });
+
+  it('returns null when scoutid is missing', () => {
+    expect(buildMemberPhotoUrl(null, 'abc-guid')).toBeNull();
+    expect(buildMemberPhotoUrl(undefined, 'abc-guid')).toBeNull();
+  });
+
+  it('returns null when photoGuid is missing', () => {
+    expect(buildMemberPhotoUrl(1234567, null)).toBeNull();
+    expect(buildMemberPhotoUrl(1234567, undefined)).toBeNull();
+    expect(buildMemberPhotoUrl(1234567, '')).toBeNull();
+  });
+});

--- a/src/shared/utils/memberPhotos.js
+++ b/src/shared/utils/memberPhotos.js
@@ -1,0 +1,30 @@
+/**
+ * @file memberPhotos — builds client-side URLs for OSM's public, unauthenticated
+ *   member photo CDN. No API call or auth token is required to fetch these
+ *   images; the URL is derived entirely from the scoutid and the member's
+ *   photo_guid (both already present on member records returned by OSM).
+ */
+
+const MEMBER_PHOTO_BASE_URL =
+  'https://www.onlinescoutmanager.co.uk/sites/onlinescoutmanager.co.uk/public/member_photos';
+
+/**
+ * Build the OSM CDN URL for a member's profile photo.
+ *
+ * OSM buckets photos into directories keyed by the first 4 characters of the
+ * scoutid followed by '000' (a 7-character directory bucket), e.g. scoutid
+ * `1234567` lives under `1234000/1234567/{photo_guid}/`.
+ *
+ * @param {number|string|null|undefined} scoutid - Member's OSM scout id
+ * @param {string|null|undefined} photoGuid - Member's photo_guid from OSM
+ * @param {'125x125'|'250x250'} [size='125x125'] - Pixel dimensions variant to request
+ * @returns {string|null} The photo URL, or `null` if scoutid/photoGuid is missing
+ */
+export function buildMemberPhotoUrl(scoutid, photoGuid, size = '125x125') {
+  if (!scoutid || !photoGuid) return null;
+
+  const scoutIdStr = String(scoutid);
+  const photoStart = `${scoutIdStr.slice(0, 4)}000`;
+
+  return `${MEMBER_PHOTO_BASE_URL}/${photoStart}/${scoutIdStr}/${photoGuid}/${size}_0.jpg`;
+}


### PR DESCRIPTION
## Summary

Brings OSM member photos into the Sections page and adds the tools needed to review photo consent at a glance.

### How photos work (patrolplanner approach)
Researched the neighbouring `patrolplanner` repo: OSM member photos are served from a **public, unauthenticated CDN path** built entirely client-side from data we already cache:

```
https://www.onlinescoutmanager.co.uk/sites/onlinescoutmanager.co.uk/public/member_photos/{first4OfScoutid+000}/{scoutid}/{photo_guid}/125x125_0.jpg
```

`photo_guid` already flows through `getMembersGrid` → SQLite/IndexedDB → member records, so **no backend changes were needed**.

### Changes
- **`MemberAvatar`** (`shared/components/ui`): circular photo avatar with lazy loading and an initials fallback (matching the existing `MemberDetailModal` convention) when `photo_guid` is missing or the image 404s. Sizes sm/md/lg (lg uses the 250x250 variant).
- **`buildMemberPhotoUrl`** (`shared/utils/memberPhotos.js`): URL construction helper.
- **Sections members table** (`SectionsList.jsx`):
  - **Photos** toggle in the Data row — photo column is **off by default** so it doesn't take up room.
  - **No Photo Consent** filter — shows only members whose `photographs` consent is not an explicit `Yes` (covers `No`, blank, and missing). Turning it on auto-enables the photo column so you can immediately see who these members are.
  - **Hide Adults** filter — excludes `person_type === 'Leaders'` (Young Leaders and Young People stay visible).
  - Member count header and empty state track the filtered list.

### Testing
- 19 new unit tests (URL builder, avatar render/fallbacks, consent predicate)
- Full suite: **629 passed, 13 skipped, 0 failures**
- `npm run lint`: 0 errors (18 pre-existing warnings, unchanged from main)
- `npm run build`: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ggpcDKLfmEg6A8WhTXSkq