### PR TITLE
feat: add Photo Consent gallery page with big photos and names

### DIFF
--- a/src/features/sections/components/PhotoConsentGalleryMasonry.jsx
+++ b/src/features/sections/components/PhotoConsentGalleryMasonry.jsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from 'react';
+import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
+
+const RESPONSIVE_BREAKPOINTS = {
+  LARGE: 1024,
+  MEDIUM: 768,
+};
+
+const COLUMN_COUNTS = {
+  LARGE: 3,
+  MEDIUM: 2,
+  BASE: 1,
+};
+
+const GRID_COLUMNS_PER_CARD = 3;
+
+const HEIGHT_ESTIMATES = {
+  HEADER: 64,
+  PHOTO_ROW: 140,
+};
+
+/**
+ * Estimate a section card's rendered height (header + photo grid rows) so
+ * cards can be distributed into masonry columns without a layout pass.
+ *
+ * @param {{members: Array}} section
+ * @returns {number} Estimated height in pixels.
+ */
+function estimateCardHeight(section) {
+  const rows = Math.ceil(section.members.length / GRID_COLUMNS_PER_CARD) || 1;
+  return HEIGHT_ESTIMATES.HEADER + rows * HEIGHT_ESTIMATES.PHOTO_ROW;
+}
+
+/**
+ * @returns {number} The masonry column count for the current viewport width.
+ */
+function getColumnCount() {
+  if (typeof window === 'undefined') return COLUMN_COUNTS.BASE;
+  const width = window.innerWidth;
+  if (width >= RESPONSIVE_BREAKPOINTS.LARGE) return COLUMN_COUNTS.LARGE;
+  if (width >= RESPONSIVE_BREAKPOINTS.MEDIUM) return COLUMN_COUNTS.MEDIUM;
+  return COLUMN_COUNTS.BASE;
+}
+
+/**
+ * Photo Consent Gallery Masonry
+ *
+ * Arranges one card per section into flex-masonry columns, using the same
+ * shortest-column distribution approach as the attendance brick cards (see
+ * shared/components/ui/SectionCardsFlexMasonry.jsx). Unlike the attendance
+ * cards, each card renders a photo-first grid — a large avatar and name only,
+ * with no age/patrol/medical data — so social media volunteers can instantly
+ * see who must not appear in photos.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Array<{sectionid: (string|number), sectionname: string, members: Array<Object>}>} props.sections
+ *   Section groups, as produced by groupNoConsentMembersBySection.
+ * @returns {JSX.Element}
+ */
+function PhotoConsentGalleryMasonry({ sections }) {
+  const columns = useMemo(() => {
+    const columnCount = getColumnCount();
+    const columns = Array.from({ length: columnCount }, () => ({ cards: [], height: 0 }));
+
+    sections.forEach((section) => {
+      const shortestColumn = columns.reduce(
+        (min, col) => (col.height < min.height ? col : min),
+        columns[0],
+      );
+      shortestColumn.cards.push(section);
+      shortestColumn.height += estimateCardHeight(section);
+    });
+
+    return columns;
+  }, [sections]);
+
+  return (
+    <div
+      className="flex gap-4 w-full"
+      role="region"
+      aria-label="Photo consent gallery cards in masonry layout"
+    >
+      {columns.map((column, columnIndex) => (
+        <div
+          key={columnIndex}
+          className="flex-1 flex flex-col gap-4"
+          style={{ minHeight: 0 }}
+        >
+          {column.cards.map((section) => {
+            const sectionKey = section.sectionid ?? section.sectionname;
+            return (
+              <div
+                key={sectionKey}
+                className="bg-white border border-gray-200 rounded-lg overflow-hidden"
+                role="article"
+                aria-labelledby={`photo-consent-section-${sectionKey}`}
+              >
+                <div className="px-5 py-4 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+                  <h4
+                    id={`photo-consent-section-${sectionKey}`}
+                    className="text-lg font-semibold text-gray-900"
+                  >
+                    {section.sectionname}
+                  </h4>
+                  <span className="text-sm text-gray-600">
+                    {section.members.length} member{section.members.length === 1 ? '' : 's'}
+                  </span>
+                </div>
+                <div className="p-4 grid grid-cols-3 sm:grid-cols-4 gap-4">
+                  {section.members.map((member) => (
+                    <div key={member.scoutid} className="flex flex-col items-center text-center gap-2">
+                      <MemberAvatar member={member} size="xl" />
+                      <span className="text-sm text-gray-900">
+                        {member.firstname} {member.lastname}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default PhotoConsentGalleryMasonry;

--- a/src/features/sections/components/PhotoConsentPage.jsx
+++ b/src/features/sections/components/PhotoConsentPage.jsx
@@ -93,8 +93,8 @@ function PhotoConsentPage() {
   };
 
   const noConsentSections = useMemo(
-    () => groupNoConsentMembersBySection(members, { hideAdults }),
-    [members, hideAdults],
+    () => groupNoConsentMembersBySection(members, { hideAdults, sections: selectedSections }),
+    [members, hideAdults, selectedSections],
   );
 
   const sortedSections = useMemo(

--- a/src/features/sections/components/PhotoConsentPage.jsx
+++ b/src/features/sections/components/PhotoConsentPage.jsx
@@ -1,0 +1,205 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
+import MainNavigation from '../../../shared/components/layout/MainNavigation.jsx';
+import databaseService from '../../../shared/services/storage/database.js';
+import { getListOfMembers } from '../../../shared/services/api/api/members.js';
+import { getToken } from '../../../shared/services/auth/tokenService.js';
+import { notifyError } from '../../../shared/utils/notifications.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+import { groupNoConsentMembersBySection } from '../utils/photoConsentGallery.js';
+import PhotoConsentGalleryMasonry from './PhotoConsentGalleryMasonry.jsx';
+
+/**
+ * Photo Consent Gallery
+ *
+ * A dedicated page for whoever is handling social media to instantly see
+ * which members must not appear in photos. Shows only members whose
+ * photographs consent is not an explicit 'Yes' (i.e. 'No', blank, or
+ * missing), grouped into one masonry card per section, with a large photo
+ * and name only — no age, patrol, or medical data.
+ *
+ * @component
+ * @returns {JSX.Element}
+ */
+function PhotoConsentPage() {
+  const navigate = useNavigate();
+  const [sections, setSections] = useState([]);
+  const [selectedSections, setSelectedSections] = useState([]);
+  const [sectionsLoading, setSectionsLoading] = useState(true);
+  const [sectionsError, setSectionsError] = useState(null);
+
+  const [members, setMembers] = useState([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [hideAdults, setHideAdults] = useState(false);
+
+  useEffect(() => {
+    const loadSections = async () => {
+      try {
+        setSectionsLoading(true);
+        setSectionsError(null);
+        const sectionsData = await databaseService.getSections();
+        setSections(sectionsData || []);
+      } catch (err) {
+        logger.error('Failed to load sections from cache', {
+          error: err.message,
+        }, LOG_CATEGORIES.ERROR);
+        setSectionsError(err.message);
+        setSections([]);
+      } finally {
+        setSectionsLoading(false);
+      }
+    };
+
+    loadSections();
+  }, []);
+
+  useEffect(() => {
+    const loadMembers = async () => {
+      if (selectedSections.length === 0) {
+        setMembers([]);
+        return;
+      }
+
+      try {
+        setMembersLoading(true);
+        const token = getToken();
+        const membersData = await getListOfMembers(selectedSections, token);
+        setMembers(membersData || []);
+      } catch (error) {
+        logger.error('Failed to load members', { error }, LOG_CATEGORIES.API);
+        notifyError('Failed to load members. Please check your connection and try again.');
+        setMembers([]);
+      } finally {
+        setMembersLoading(false);
+      }
+    };
+
+    loadMembers();
+  }, [selectedSections]);
+
+  const handleNavigateToSectionMovements = () => {
+    navigate('/movers');
+  };
+
+  const handleSectionToggle = (section) => {
+    setSelectedSections((prev) => {
+      const isSelected = prev.some((s) => s.sectionid === section.sectionid);
+      if (isSelected) {
+        return prev.filter((s) => s.sectionid !== section.sectionid);
+      }
+      return [...prev, section];
+    });
+  };
+
+  const noConsentSections = useMemo(
+    () => groupNoConsentMembersBySection(members, { hideAdults }),
+    [members, hideAdults],
+  );
+
+  const sortedSections = useMemo(
+    () => sections.slice().sort((a, b) => (a.sectionname || '').localeCompare(b.sectionname || '')),
+    [sections],
+  );
+
+  if (sectionsLoading) {
+    return <LoadingScreen message="Loading sections..." />;
+  }
+
+  if (sectionsError) {
+    return (
+      <div className="p-6">
+        <div className="max-w-4xl mx-auto">
+          <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+            <div className="text-scout-red">
+              <h2 className="text-lg font-semibold mb-2">Error Loading Sections</h2>
+              <p>{sectionsError}</p>
+              <button
+                onClick={() => navigate('/sections')}
+                className="mt-4 px-4 py-2 bg-scout-blue text-white rounded hover:bg-scout-blue-dark"
+              >
+                Back to Sections
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <MainNavigation onNavigateToSectionMovements={handleNavigateToSectionMovements} />
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+        <div className="mb-6">
+          <h2 className="text-2xl font-bold text-gray-900">Photo Consent Gallery</h2>
+          <p className="text-gray-600 mt-1">
+            Members without photo consent — do not publish photos of these members.
+          </p>
+        </div>
+
+        <div className="space-y-3 mb-6 p-3 bg-gray-50 rounded border-b border-gray-200">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Sections:
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {sortedSections.map((section) => {
+                const isSelected = selectedSections.some((s) => s.sectionid === section.sectionid);
+                return (
+                  <button
+                    key={section.sectionid}
+                    onClick={() => handleSectionToggle(section)}
+                    className={`px-3 py-1 rounded-md text-sm font-medium border transition-colors ${
+                      isSelected
+                        ? 'bg-scout-blue text-white border-scout-blue'
+                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                    }`}
+                    type="button"
+                  >
+                    {section.sectionname}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Filter:
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => setHideAdults((prev) => !prev)}
+                className={`px-3 py-1 rounded-md text-sm font-medium border transition-colors ${
+                  hideAdults
+                    ? 'bg-scout-blue text-white border-scout-blue'
+                    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                }`}
+                type="button"
+              >
+                Hide Adults
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {membersLoading ? (
+          <LoadingScreen message="Loading members..." />
+        ) : selectedSections.length === 0 ? (
+          <div className="bg-white rounded-lg border border-gray-200 p-8 text-center">
+            <p className="text-gray-500">Select a section above to see who must not appear in photos.</p>
+          </div>
+        ) : noConsentSections.length === 0 ? (
+          <div className="bg-white rounded-lg border border-gray-200 p-8 text-center">
+            <p className="text-gray-500">Everyone in the selected sections has given photo consent.</p>
+          </div>
+        ) : (
+          <PhotoConsentGalleryMasonry sections={noConsentSections} />
+        )}
+      </div>
+    </>
+  );
+}
+
+export default PhotoConsentPage;

--- a/src/features/sections/components/PhotoConsentPage.jsx
+++ b/src/features/sections/components/PhotoConsentPage.jsx
@@ -55,6 +55,8 @@ function PhotoConsentPage() {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+
     const loadMembers = async () => {
       if (selectedSections.length === 0) {
         setMembers([]);
@@ -65,17 +67,27 @@ function PhotoConsentPage() {
         setMembersLoading(true);
         const token = getToken();
         const membersData = await getListOfMembers(selectedSections, token);
-        setMembers(membersData || []);
+        if (!cancelled) {
+          setMembers(membersData || []);
+        }
       } catch (error) {
-        logger.error('Failed to load members', { error }, LOG_CATEGORIES.API);
-        notifyError('Failed to load members. Please check your connection and try again.');
-        setMembers([]);
+        if (!cancelled) {
+          logger.error('Failed to load members', { error }, LOG_CATEGORIES.API);
+          notifyError('Failed to load members. Please check your connection and try again.');
+          setMembers([]);
+        }
       } finally {
-        setMembersLoading(false);
+        if (!cancelled) {
+          setMembersLoading(false);
+        }
       }
     };
 
     loadMembers();
+
+    return () => {
+      cancelled = true;
+    };
   }, [selectedSections]);
 
   const handleNavigateToSectionMovements = () => {

--- a/src/features/sections/components/SectionsList.jsx
+++ b/src/features/sections/components/SectionsList.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getListOfMembers } from '../../../shared/services/api/api/members.js';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import { MemberDetailModal, MedicalDataPill } from '../../../shared/components/ui/index.js';
@@ -6,24 +7,10 @@ import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
 import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
 import { formatMedicalDataForDisplay } from '../../../shared/utils/medicalDataUtils.js';
 import { calculateAge } from '../../../shared/utils/ageUtils.js';
-import { groupContactInfo } from '../../../shared/utils/contactGroups.js';
+import { groupContactInfo, isNotPhotoConsentYes } from '../../../shared/utils/contactGroups.js';
 import { notifyError, notifySuccess, notifyWarning } from '../../../shared/utils/notifications.js';
 import { resolveSectionName } from '../../../shared/utils/memberUtils.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
-
-/**
- * Determines whether a member's photographs consent is anything other than
- * an explicit 'Yes' (i.e. 'No', empty, or missing all count as "not Yes").
- * Checks both `photographs` and `Photographs` keys, case-insensitively.
- *
- * @param {Object} [consents] - The `memberData.consents` map.
- * @returns {boolean} True when the member should be surfaced by the
- *   "No Photo Consent" filter.
- */
-export function isNotPhotoConsentYes(consents) {
-  const value = consents?.photographs ?? consents?.Photographs;
-  return String(value ?? '').trim().toLowerCase() !== 'yes';
-}
 
 function SectionsList({
   sections,
@@ -77,6 +64,7 @@ function SectionsList({
 
 // Members Table Content - Integrated into main card
 function MembersTableContent({ sections, onSectionToggle, allSections, loadingSection }) {
+  const navigate = useNavigate();
   const [members, setMembers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [selectedMember, setSelectedMember] = useState(null);
@@ -360,11 +348,11 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
       {/* Header with Export Button */}
       <div className="flex items-center justify-between mb-4">
         <h4 className="text-lg font-medium text-gray-900">Members ({visibleMembers.length})</h4>
-        {members.length > 0 && (
+        <div className="flex items-center gap-2">
           <button
-            onClick={exportToCSV}
+            onClick={() => navigate('/photo-consent')}
             type="button"
-            className="inline-flex items-center justify-center rounded-md font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed border-2 border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-gray-300 px-4 py-2 text-base"
+            className="inline-flex items-center justify-center rounded-md font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed bg-scout-blue text-white hover:bg-scout-blue-dark focus:ring-scout-blue px-4 py-2 text-base"
           >
             <svg
               className="w-4 h-4 mr-2"
@@ -375,11 +363,32 @@ function MembersTableContent({ sections, onSectionToggle, allSections, loadingSe
               strokeLinejoin="round"
               strokeWidth={2}
             >
-              <path d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              <path d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
+              <path d="M12 17a4 4 0 100-8 4 4 0 000 8z" />
             </svg>
-            Export CSV
+            Photo Consent Gallery
           </button>
-        )}
+          {members.length > 0 && (
+            <button
+              onClick={exportToCSV}
+              type="button"
+              className="inline-flex items-center justify-center rounded-md font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed border-2 border-gray-300 text-gray-700 hover:bg-gray-50 focus:ring-gray-300 px-4 py-2 text-base"
+            >
+              <svg
+                className="w-4 h-4 mr-2"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              >
+                <path d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Export CSV
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Filter Section */}

--- a/src/features/sections/components/index.js
+++ b/src/features/sections/components/index.js
@@ -3,3 +3,5 @@ export { default as SectionsPage } from './SectionsPage.jsx';
 export { default as SectionsList } from './SectionsList.jsx';
 export { default as SectionFilter } from './SectionFilter.jsx';
 export { default as SectionCardsFlexMasonry } from './SectionCardsFlexMasonry.jsx';
+export { default as PhotoConsentPage } from './PhotoConsentPage.jsx';
+export { default as PhotoConsentGalleryMasonry } from './PhotoConsentGalleryMasonry.jsx';

--- a/src/features/sections/utils/__tests__/photoConsentGallery.test.js
+++ b/src/features/sections/utils/__tests__/photoConsentGallery.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { groupNoConsentMembersBySection } from '../photoConsentGallery.js';
+
+const member = (overrides = {}) => ({
+  scoutid: 1,
+  firstname: 'Jane',
+  lastname: 'Doe',
+  sectionid: 100,
+  sectionname: 'Beavers',
+  person_type: 'Young People',
+  'consents__photographs': 'No',
+  ...overrides,
+});
+
+describe('groupNoConsentMembersBySection', () => {
+  it('excludes members with explicit Yes photo consent', () => {
+    const members = [member({ 'consents__photographs': 'Yes' })];
+    expect(groupNoConsentMembersBySection(members)).toEqual([]);
+  });
+
+  it('includes members with No, blank, or missing photo consent', () => {
+    const members = [
+      member({ scoutid: 1, 'consents__photographs': 'No' }),
+      member({ scoutid: 2, 'consents__photographs': '' }),
+      member({ scoutid: 3, consents__photographs: undefined }),
+    ];
+    const result = groupNoConsentMembersBySection(members);
+    expect(result).toHaveLength(1);
+    expect(result[0].members).toHaveLength(3);
+  });
+
+  it('groups matching members by section', () => {
+    const members = [
+      member({ scoutid: 1, sectionid: 100, sectionname: 'Beavers' }),
+      member({ scoutid: 2, sectionid: 200, sectionname: 'Cubs' }),
+    ];
+    const result = groupNoConsentMembersBySection(members);
+    expect(result.map((s) => s.sectionname)).toEqual(['Beavers', 'Cubs']);
+    expect(result[0].members).toHaveLength(1);
+    expect(result[1].members).toHaveLength(1);
+  });
+
+  it('omits sections with no matching members', () => {
+    const members = [
+      member({ scoutid: 1, sectionid: 100, sectionname: 'Beavers', 'consents__photographs': 'Yes' }),
+      member({ scoutid: 2, sectionid: 200, sectionname: 'Cubs', 'consents__photographs': 'No' }),
+    ];
+    const result = groupNoConsentMembersBySection(members);
+    expect(result.map((s) => s.sectionname)).toEqual(['Cubs']);
+  });
+
+  it('excludes adults (person_type Leaders) when hideAdults is true', () => {
+    const members = [
+      member({ scoutid: 1, person_type: 'Young People' }),
+      member({ scoutid: 2, person_type: 'Leaders' }),
+    ];
+    const result = groupNoConsentMembersBySection(members, { hideAdults: true });
+    expect(result[0].members).toHaveLength(1);
+    expect(result[0].members[0].scoutid).toBe(1);
+  });
+
+  it('includes adults when hideAdults is false (default)', () => {
+    const members = [
+      member({ scoutid: 1, person_type: 'Young People' }),
+      member({ scoutid: 2, person_type: 'Leaders' }),
+    ];
+    const result = groupNoConsentMembersBySection(members);
+    expect(result[0].members).toHaveLength(2);
+  });
+
+  it('sorts members within a section alphabetically by name', () => {
+    const members = [
+      member({ scoutid: 1, firstname: 'Zack', lastname: 'Zebra' }),
+      member({ scoutid: 2, firstname: 'Amy', lastname: 'Ant' }),
+    ];
+    const result = groupNoConsentMembersBySection(members);
+    expect(result[0].members.map((m) => m.firstname)).toEqual(['Amy', 'Zack']);
+  });
+
+  it('returns an empty array for no members', () => {
+    expect(groupNoConsentMembersBySection([])).toEqual([]);
+    expect(groupNoConsentMembersBySection(undefined)).toEqual([]);
+  });
+});

--- a/src/features/sections/utils/__tests__/photoConsentGallery.test.js
+++ b/src/features/sections/utils/__tests__/photoConsentGallery.test.js
@@ -77,6 +77,20 @@ describe('groupNoConsentMembersBySection', () => {
     expect(result[0].members.map((m) => m.firstname)).toEqual(['Amy', 'Zack']);
   });
 
+  it('prefers the section rows sectionname over member fields for card titles', () => {
+    const members = [member({ section: 'cubs', sectionname: undefined })];
+    const result = groupNoConsentMembersBySection(members, {
+      sections: [{ sectionid: 100, sectionname: 'Monday Cubs' }],
+    });
+    expect(result[0].sectionname).toBe('Monday Cubs');
+  });
+
+  it('falls back to member.sectionname over the section type when no section rows given', () => {
+    const members = [member({ section: 'cubs', sectionname: 'Monday Cubs' })];
+    const result = groupNoConsentMembersBySection(members);
+    expect(result[0].sectionname).toBe('Monday Cubs');
+  });
+
   it('returns an empty array for no members', () => {
     expect(groupNoConsentMembersBySection([])).toEqual([]);
     expect(groupNoConsentMembersBySection(undefined)).toEqual([]);

--- a/src/features/sections/utils/photoConsentGallery.js
+++ b/src/features/sections/utils/photoConsentGallery.js
@@ -59,7 +59,9 @@ export function groupNoConsentMembersBySection(members, { hideAdults = false, se
     const sectionName = sectionNamesById.get(String(member.sectionid))
       || member.sectionname
       || resolveSectionName(member);
-    const sectionKey = member.sectionid ?? sectionName;
+    const sectionKey = member.sectionid !== null && member.sectionid !== undefined
+      ? String(member.sectionid)
+      : sectionName;
 
     if (!sectionsById.has(sectionKey)) {
       sectionsById.set(sectionKey, {

--- a/src/features/sections/utils/photoConsentGallery.js
+++ b/src/features/sections/utils/photoConsentGallery.js
@@ -36,19 +36,29 @@ function memberLacksPhotoConsent(member) {
  *   currently selected sections.
  * @param {Object} [options]
  * @param {boolean} [options.hideAdults=false] - Exclude person_type === 'Leaders'.
+ * @param {Array<Object>} [options.sections] - Section rows (sectionid, sectionname)
+ *   used to resolve display names; member.section only holds the section type
+ *   (e.g. 'cubs'), not the section's actual name.
  * @returns {Array<{sectionid: string|number|undefined, sectionname: string, members: Array<Object>}>}
  *   One entry per section that has at least one matching member, sorted
  *   alphabetically by section name; members within each section are sorted
  *   alphabetically by first then last name.
  */
-export function groupNoConsentMembersBySection(members, { hideAdults = false } = {}) {
+export function groupNoConsentMembersBySection(members, { hideAdults = false, sections = [] } = {}) {
   const sectionsById = new Map();
+  const sectionNamesById = new Map(
+    (sections || [])
+      .filter((s) => s?.sectionid !== null && s?.sectionid !== undefined && s?.sectionname)
+      .map((s) => [String(s.sectionid), s.sectionname]),
+  );
 
   for (const member of members || []) {
     if (hideAdults && member.person_type === 'Leaders') continue;
     if (!memberLacksPhotoConsent(member)) continue;
 
-    const sectionName = resolveSectionName(member);
+    const sectionName = sectionNamesById.get(String(member.sectionid))
+      || member.sectionname
+      || resolveSectionName(member);
     const sectionKey = member.sectionid ?? sectionName;
 
     if (!sectionsById.has(sectionKey)) {
@@ -61,9 +71,9 @@ export function groupNoConsentMembersBySection(members, { hideAdults = false } =
     sectionsById.get(sectionKey).members.push(member);
   }
 
-  const sections = Array.from(sectionsById.values());
+  const grouped = Array.from(sectionsById.values());
 
-  for (const section of sections) {
+  for (const section of grouped) {
     section.members.sort((a, b) => {
       const aName = `${a.firstname || ''} ${a.lastname || ''}`.trim();
       const bName = `${b.firstname || ''} ${b.lastname || ''}`.trim();
@@ -71,7 +81,7 @@ export function groupNoConsentMembersBySection(members, { hideAdults = false } =
     });
   }
 
-  sections.sort((a, b) => a.sectionname.localeCompare(b.sectionname));
+  grouped.sort((a, b) => a.sectionname.localeCompare(b.sectionname));
 
-  return sections;
+  return grouped;
 }

--- a/src/features/sections/utils/photoConsentGallery.js
+++ b/src/features/sections/utils/photoConsentGallery.js
@@ -1,0 +1,77 @@
+/**
+ * @file photoConsentGallery — builds the section-grouped member lists for the
+ *   Photo Consent gallery page (features/sections/components/PhotoConsentPage.jsx).
+ *
+ * Filters members down to those whose photographs consent is not an explicit
+ * 'Yes' (see isNotPhotoConsentYes in shared/utils/contactGroups.js), optionally
+ * excludes adults (person_type === 'Leaders'), then groups the matches into
+ * one bucket per section — mirroring the section-card shape rendered by the
+ * attendance masonry (sectionid, sectionname, members).
+ *
+ * Pure function — no React, no DB/API access — so it can be unit tested
+ * directly against member fixtures.
+ */
+
+import { groupContactInfo, isNotPhotoConsentYes } from '../../../shared/utils/contactGroups.js';
+import { resolveSectionName } from '../../../shared/utils/memberUtils.js';
+
+/**
+ * @param {Object} member - A member record as returned by getListOfMembers.
+ * @returns {boolean} true when the member's merged permissions+consents
+ *   photographs field is anything other than an explicit 'Yes'.
+ */
+function memberLacksPhotoConsent(member) {
+  const contactGroups = groupContactInfo(member);
+  const consents = {
+    ...(contactGroups.permissions || {}),
+    ...(contactGroups.consents || {}),
+  };
+  return isNotPhotoConsentYes(consents);
+}
+
+/**
+ * Groups members without photo consent into one card per section.
+ *
+ * @param {Array<Object>} members - Members loaded via getListOfMembers for the
+ *   currently selected sections.
+ * @param {Object} [options]
+ * @param {boolean} [options.hideAdults=false] - Exclude person_type === 'Leaders'.
+ * @returns {Array<{sectionid: string|number|undefined, sectionname: string, members: Array<Object>}>}
+ *   One entry per section that has at least one matching member, sorted
+ *   alphabetically by section name; members within each section are sorted
+ *   alphabetically by first then last name.
+ */
+export function groupNoConsentMembersBySection(members, { hideAdults = false } = {}) {
+  const sectionsById = new Map();
+
+  for (const member of members || []) {
+    if (hideAdults && member.person_type === 'Leaders') continue;
+    if (!memberLacksPhotoConsent(member)) continue;
+
+    const sectionName = resolveSectionName(member);
+    const sectionKey = member.sectionid ?? sectionName;
+
+    if (!sectionsById.has(sectionKey)) {
+      sectionsById.set(sectionKey, {
+        sectionid: member.sectionid,
+        sectionname: sectionName,
+        members: [],
+      });
+    }
+    sectionsById.get(sectionKey).members.push(member);
+  }
+
+  const sections = Array.from(sectionsById.values());
+
+  for (const section of sections) {
+    section.members.sort((a, b) => {
+      const aName = `${a.firstname || ''} ${a.lastname || ''}`.trim();
+      const bName = `${b.firstname || ''} ${b.lastname || ''}`.trim();
+      return aName.localeCompare(bName);
+    });
+  }
+
+  sections.sort((a, b) => a.sectionname.localeCompare(b.sectionname));
+
+  return sections;
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -5,16 +5,17 @@ import LoadingScreen from '../shared/components/LoadingScreen.jsx';
 import ResponsiveLayout from '../shared/components/layout/ResponsiveLayout.jsx';
 import TokenExpiredDialog from '../shared/components/TokenExpiredDialog.jsx';
 import { useAuth } from '../features/auth/hooks';
+import { lazyWithRetry } from '../shared/utils/lazyWithRetry.js';
 
 // URL-based routing is now the only routing system
 
 // Lazy load main feature modules for better performance
-const MoversPage = React.lazy(() => import('../features/movements/components').then(module => ({ default: module.MoversPage })));
-const SectionsPage = React.lazy(() => import('../features/sections/components').then(module => ({ default: module.SectionsPage })));
-const PhotoConsentPage = React.lazy(() => import('../features/sections/components').then(module => ({ default: module.PhotoConsentPage })));
-const YoungLeadersPage = React.lazy(() => import('../features/young-leaders/components').then(module => ({ default: module.YoungLeadersPage })));
-const EventsRouter = React.lazy(() => import('../features/events/components').then(module => ({ default: module.EventsRouter })));
-const DataClearPage = React.lazy(() => import('../features/admin/components').then(module => ({ default: module.DataClearPage })));
+const MoversPage = lazyWithRetry(() => import('../features/movements/components').then(module => ({ default: module.MoversPage })));
+const SectionsPage = lazyWithRetry(() => import('../features/sections/components').then(module => ({ default: module.SectionsPage })));
+const PhotoConsentPage = lazyWithRetry(() => import('../features/sections/components').then(module => ({ default: module.PhotoConsentPage })));
+const YoungLeadersPage = lazyWithRetry(() => import('../features/young-leaders/components').then(module => ({ default: module.YoungLeadersPage })));
+const EventsRouter = lazyWithRetry(() => import('../features/events/components').then(module => ({ default: module.EventsRouter })));
+const DataClearPage = lazyWithRetry(() => import('../features/admin/components').then(module => ({ default: module.DataClearPage })));
 
 // Import route guards (keep synchronous for security)
 import { RouteGuard } from '../shared/components/guards';

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -6,6 +6,7 @@ import ResponsiveLayout from '../shared/components/layout/ResponsiveLayout.jsx';
 import TokenExpiredDialog from '../shared/components/TokenExpiredDialog.jsx';
 import { useAuth } from '../features/auth/hooks';
 import { lazyWithRetry } from '../shared/utils/lazyWithRetry.js';
+import ErrorBoundary from '../shared/components/ErrorBoundary.jsx';
 
 // URL-based routing is now the only routing system
 
@@ -72,63 +73,65 @@ function AppContent() {
         lastSyncTime={lastSyncTime}
         isRefreshing={false}
       >
-        <Suspense fallback={<LoadingScreen message="Loading application..." />}>
-          <Routes>
-            {/* Main application sections */}
-            <Route 
-              path="/movers" 
-              element={
-                <RouteGuard authLevel="none">
-                  <MoversPage />
-                </RouteGuard>
-              } 
-            />
-            <Route
-              path="/sections"
-              element={
-                <RouteGuard authLevel="none">
-                  <SectionsPage />
-                </RouteGuard>
-              }
-            />
-            <Route
-              path="/photo-consent"
-              element={
-                <RouteGuard authLevel="none">
-                  <PhotoConsentPage />
-                </RouteGuard>
-              }
-            />
-            <Route
-              path="/young-leaders"
-              element={
-                <RouteGuard authLevel="none">
-                  <YoungLeadersPage />
-                </RouteGuard>
-              }
-            />
-            <Route
-              path="/events/*"
-              element={
-                <RouteGuard authLevel="none">
-                  <EventsRouter />
-                </RouteGuard>
-              }
-            />
-            <Route
-              path="/clear"
-              element={
-                <RouteGuard authLevel="none">
-                  <DataClearPage />
-                </RouteGuard>
-              }
-            />
+        <ErrorBoundary>
+          <Suspense fallback={<LoadingScreen message="Loading application..." />}>
+            <Routes>
+              {/* Main application sections */}
+              <Route 
+                path="/movers" 
+                element={
+                  <RouteGuard authLevel="none">
+                    <MoversPage />
+                  </RouteGuard>
+                } 
+              />
+              <Route
+                path="/sections"
+                element={
+                  <RouteGuard authLevel="none">
+                    <SectionsPage />
+                  </RouteGuard>
+                }
+              />
+              <Route
+                path="/photo-consent"
+                element={
+                  <RouteGuard authLevel="none">
+                    <PhotoConsentPage />
+                  </RouteGuard>
+                }
+              />
+              <Route
+                path="/young-leaders"
+                element={
+                  <RouteGuard authLevel="none">
+                    <YoungLeadersPage />
+                  </RouteGuard>
+                }
+              />
+              <Route
+                path="/events/*"
+                element={
+                  <RouteGuard authLevel="none">
+                    <EventsRouter />
+                  </RouteGuard>
+                }
+              />
+              <Route
+                path="/clear"
+                element={
+                  <RouteGuard authLevel="none">
+                    <DataClearPage />
+                  </RouteGuard>
+                }
+              />
 
-            {/* Legacy route redirects */}
-            <Route path="/dashboard" element={<Navigate to="/events" replace />} />
-            <Route path="/" element={<Navigate to={`/events${window.location.search}`} replace />} />
-          </Routes>
-        </Suspense>
+              {/* Legacy route redirects */}
+              <Route path="/dashboard" element={<Navigate to="/events" replace />} />
+              <Route path="/" element={<Navigate to={`/events${window.location.search}`} replace />} />
+            </Routes>
+          </Suspense>
+        </ErrorBoundary>
       </ResponsiveLayout>
 
       {/* Token expiration dialog */}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -11,6 +11,7 @@ import { useAuth } from '../features/auth/hooks';
 // Lazy load main feature modules for better performance
 const MoversPage = React.lazy(() => import('../features/movements/components').then(module => ({ default: module.MoversPage })));
 const SectionsPage = React.lazy(() => import('../features/sections/components').then(module => ({ default: module.SectionsPage })));
+const PhotoConsentPage = React.lazy(() => import('../features/sections/components').then(module => ({ default: module.PhotoConsentPage })));
 const YoungLeadersPage = React.lazy(() => import('../features/young-leaders/components').then(module => ({ default: module.YoungLeadersPage })));
 const EventsRouter = React.lazy(() => import('../features/events/components').then(module => ({ default: module.EventsRouter })));
 const DataClearPage = React.lazy(() => import('../features/admin/components').then(module => ({ default: module.DataClearPage })));
@@ -86,6 +87,14 @@ function AppContent() {
               element={
                 <RouteGuard authLevel="none">
                   <SectionsPage />
+                </RouteGuard>
+              }
+            />
+            <Route
+              path="/photo-consent"
+              element={
+                <RouteGuard authLevel="none">
+                  <PhotoConsentPage />
                 </RouteGuard>
               }
             />

--- a/src/shared/components/ui/MemberAvatar.jsx
+++ b/src/shared/components/ui/MemberAvatar.jsx
@@ -5,12 +5,14 @@ const SIZE_CLASSES = {
   sm: 'h-8 w-8 text-xs',
   md: 'h-12 w-12 text-sm',
   lg: 'h-24 w-24 text-2xl',
+  xl: 'h-32 w-32 text-3xl',
 };
 
 const PHOTO_PIXEL_SIZE = {
   sm: '125x125',
   md: '125x125',
   lg: '250x250',
+  xl: '250x250',
 };
 
 /**
@@ -67,7 +69,7 @@ function getDisplayName(member) {
  * @component
  * @param {Object} props - Component props
  * @param {Object} props.member - Member data (scoutid, photo_guid, firstname/lastname or name)
- * @param {'sm'|'md'|'lg'} [props.size='sm'] - Avatar size: sm for table rows, md, lg for larger profile views
+ * @param {'sm'|'md'|'lg'|'xl'} [props.size='sm'] - Avatar size: sm for table rows, md, lg for larger profile views, xl for photo-first galleries
  * @param {string} [props.className] - Additional classes merged onto the avatar element
  * @returns {JSX.Element} Circular photo or initials fallback
  *

--- a/src/shared/components/ui/__tests__/MemberAvatar.test.jsx
+++ b/src/shared/components/ui/__tests__/MemberAvatar.test.jsx
@@ -51,7 +51,7 @@ describe('MemberAvatar', () => {
     expect(screen.getByText('JD')).toBeInTheDocument();
   });
 
-  it('applies the correct size classes for sm, md, and lg', () => {
+  it('applies the correct size classes for sm, md, lg, and xl', () => {
     const member = { scoutid: 1234567, photo_guid: null, firstname: 'Jane', lastname: 'Doe' };
 
     const { rerender } = render(<MemberAvatar member={member} size="sm" />);
@@ -62,5 +62,16 @@ describe('MemberAvatar', () => {
 
     rerender(<MemberAvatar member={member} size="lg" />);
     expect(screen.getByText('JD')).toHaveClass('h-24', 'w-24');
+
+    rerender(<MemberAvatar member={member} size="xl" />);
+    expect(screen.getByText('JD')).toHaveClass('h-32', 'w-32');
+  });
+
+  it('uses the 250x250 variant for size xl', () => {
+    const member = { scoutid: 1234567, photo_guid: 'abc-guid', firstname: 'Jane', lastname: 'Doe' };
+    render(<MemberAvatar member={member} size="xl" />);
+
+    const img = screen.getByRole('img', { name: /jane doe/i });
+    expect(img).toHaveAttribute('src', expect.stringContaining('250x250_0.jpg'));
   });
 });

--- a/src/shared/utils/__tests__/contactGroups.test.js
+++ b/src/shared/utils/__tests__/contactGroups.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isNotPhotoConsentYes } from '../SectionsList.jsx';
+import { isNotPhotoConsentYes } from '../contactGroups.js';
 
 describe('isNotPhotoConsentYes', () => {
   it('returns false when photographs consent is Yes', () => {

--- a/src/shared/utils/__tests__/lazyWithRetry.test.js
+++ b/src/shared/utils/__tests__/lazyWithRetry.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadModuleWithReload } from '../lazyWithRetry.js';
+
+describe('loadModuleWithReload', () => {
+  const reloadMock = vi.fn();
+  let originalLocation;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.getItem.mockReturnValue(null);
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, reload: reloadMock },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('returns the module when import succeeds', async () => {
+    const module = { default: () => null };
+    const result = await loadModuleWithReload(() => Promise.resolve(module));
+    expect(result).toBe(module);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads the page once when import fails', async () => {
+    const importFn = vi.fn(() => Promise.reject(new TypeError('Importing a module script failed.')));
+    const pending = loadModuleWithReload(importFn);
+    await vi.waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('lazy_chunk_reload_attempted', 'true');
+    void pending;
+  });
+
+  it('rethrows when import fails after a reload was already attempted', async () => {
+    sessionStorage.getItem.mockReturnValue('true');
+    const error = new TypeError('Importing a module script failed.');
+    await expect(loadModuleWithReload(() => Promise.reject(error))).rejects.toThrow(error);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the reload flag after a successful import', async () => {
+    await loadModuleWithReload(() => Promise.resolve({ default: () => null }));
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('lazy_chunk_reload_attempted');
+  });
+});

--- a/src/shared/utils/contactGroups.js
+++ b/src/shared/utils/contactGroups.js
@@ -37,3 +37,17 @@ export function groupContactInfo(member) {
 
   return groups;
 }
+
+/**
+ * Determines whether a member's photographs consent is anything other than
+ * an explicit 'Yes' (i.e. 'No', empty, or missing all count as "not Yes").
+ * Checks both `photographs` and `Photographs` keys, case-insensitively.
+ *
+ * @param {Object} [consents] - The `memberData.consents` map.
+ * @returns {boolean} True when the member should be surfaced by the
+ *   "No Photo Consent" filter.
+ */
+export function isNotPhotoConsentYes(consents) {
+  const value = consents?.photographs ?? consents?.Photographs;
+  return String(value ?? '').trim().toLowerCase() !== 'yes';
+}

--- a/src/shared/utils/lazyWithRetry.js
+++ b/src/shared/utils/lazyWithRetry.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const RELOAD_FLAG = 'lazy_chunk_reload_attempted';
+
+/**
+ * Loads a lazy module, reloading the page once if the chunk fails to import.
+ *
+ * Hashed chunk filenames change on every deploy, so a tab opened before a
+ * deploy can request a chunk that no longer exists ("Importing a module
+ * script failed" in Safari), unmounting the app to a blank page. Reloading
+ * fetches the current index.html and matching chunks. A sessionStorage flag
+ * prevents a reload loop when the import failure is not deploy-related.
+ *
+ * @param {Function} importFn - The dynamic import function for the module.
+ * @returns {Promise<Object>} The imported module.
+ * @throws {Error} The original import error when a reload was already attempted.
+ */
+export async function loadModuleWithReload(importFn) {
+  try {
+    const module = await importFn();
+    sessionStorage.removeItem(RELOAD_FLAG);
+    return module;
+  } catch (error) {
+    if (!sessionStorage.getItem(RELOAD_FLAG)) {
+      sessionStorage.setItem(RELOAD_FLAG, 'true');
+      window.location.reload();
+      return new Promise(() => {});
+    }
+    throw error;
+  }
+}
+
+/**
+ * Drop-in replacement for React.lazy that recovers from stale-chunk import
+ * failures after a deploy by reloading the page once.
+ *
+ * @param {Function} importFn - Dynamic import returning a module with a default export.
+ * @returns {React.LazyExoticComponent} Lazy component with reload recovery.
+ *
+ * @example
+ * const EventsRouter = lazyWithRetry(() =>
+ *   import('../features/events/components').then(m => ({ default: m.EventsRouter })));
+ */
+export function lazyWithRetry(importFn) {
+  return React.lazy(() => loadModuleWithReload(importFn));
+}


### PR DESCRIPTION
## Summary

Follow-up to #208 for the social-media use case: a dedicated gallery so whoever runs social channels can instantly see **who must not appear in published photos**.

### What's new
- **`/photo-consent` page** — masonry section cards (same brick-card style as the attendance view). Each card = one selected section, containing a responsive grid of **big photos (new `xl` avatar, 250x250 OSM variant) with first + last name only** — no other details.
- Shows only members whose photographs consent is **not an explicit Yes** (No, blank, or missing), with a "do not publish photos of these members" subtitle.
- Section pill toggles (cards rearrange dynamically per selection) + **Hide Adults** toggle.
- Entry point: **"Photo Consent Gallery" button** on the Sections page members header.

### Refactors
- `isNotPhotoConsentYes` moved from `SectionsList.jsx` to `shared/utils/contactGroups.js` (also removes a react-refresh lint warning); tests moved accordingly.
- Pure `groupNoConsentMembersBySection(members, { hideAdults })` helper — filtering/grouping/sorting fully unit tested.
- `MemberAvatar` gains `xl` size (h-32 w-32).

### Testing
- Full suite: **638 passed, 13 skipped, 0 failures** (8 new grouping tests, extended avatar tests)
- Lint: no new warnings; build: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ggpcDKLfmEg6A8WhTXSkq