### PR TITLE
feat: water rota encoding core (permit holder session planning)

### DIFF
--- a/docs/features/water-rota.md
+++ b/docs/features/water-rota.md
@@ -1,0 +1,57 @@
+# Water Session Permit Rota
+
+Plan and staff regular on-water sessions across sections (e.g. Cubs Tuesday, Scouts Friday)
+over a summer date range. Section leaders see per-session cover status; permit holders sign
+up (confirmed or backup) and see their week at a glance.
+
+Full design plan: agreed 2026-07-10 (see PR description). This document tracks the storage
+design and open spike questions.
+
+## Storage design
+
+One OSM FlexiRecord per calendar year — `Viking Water Rota <year>` — created in a
+leader-chosen **host section** (usually Adults; it must contain all permit holders).
+Rows are host-section members. Two column kinds:
+
+- `RotaConfig` — whole-plan config JSON (date range, per-section defaults). Each plan
+  editor writes the full config to **their own row**; readers take the last-writer-wins
+  winner across rows by `(v, at)`.
+- `S_<yyyymmdd>_<sectionid>` — one column per session. Column name is the session
+  identity (immutable, matching OSM's lack of column rename/delete). A cell holds the
+  row member's signup (`s`: `"I"` in / `"B"` backup, `sat` timestamp) plus an optional
+  session-metadata candidate (`m`: activity, times, expected kids `k`, permits needed
+  `p`, notes `n`, not-on-water flag `c`), merged LWW across the column.
+
+Key property: **each user only ever writes their own row**, so signups can never
+conflict across users; only metadata needs LWW resolution. Encoding/merging lives in
+`src/features/water-rota/services/rotaEncoding.js` (pure, clock-free, zod-validated).
+
+Sessions are generated from each section's OSM programme meetings (dates + times), with
+a manual weekly-slot fallback for sections whose programme is empty
+(`src/features/water-rota/utils/rotaDates.js`).
+
+## Spike questions (verify against live OSM before PR 3 ships)
+
+Record findings here as they are confirmed:
+
+1. **Column count** — is a record with ~40 custom columns (a full summer + config) fine
+   in OSM's UI and API? Fallback if not: one record per term (~13 columns), encoding
+   unchanged.
+2. **Cell size** — confirm a ~4KB cell value survives `update-flexi-record` round-trips
+   so session notes are safe. Cells are designed to stay under 1KB.
+3. **Cross-term persistence** — confirm cell values persist when the host section's term
+   changes (values should be per-member, term only selects the roster). Fallback: record
+   per term.
+4. **Programme endpoint shape** — exact query params and response fields of
+   `GET /ext/programme/` for our sections (the public OSM API spec is anonymized).
+   Confirm `starttime`/`endtime` presence; fall back to per-section preset times if
+   absent.
+5. **Permissions key** — the exact `section.permissions` key/threshold that indicates
+   flexi-record write access (used to gate plan editing and signup).
+
+## Deferred beyond v1
+
+- Ratio-aware cover by permit type + permit registry with expiry dates (the versioned
+  `m` object extends without column changes).
+- Notifications when a session is short or a holder withdraws.
+- Auto-promotion of backups; safety-boat / first-aider role tracking; export/print.

--- a/src/features/water-rota/index.js
+++ b/src/features/water-rota/index.js
@@ -1,0 +1,2 @@
+export * from './services';
+export * from './utils';

--- a/src/features/water-rota/services/__tests__/rotaEncoding.test.js
+++ b/src/features/water-rota/services/__tests__/rotaEncoding.test.js
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ROTA_CONFIG_COLUMN,
+  SIGNUP_STATUS,
+  buildSessionColumnName,
+  encodeConfig,
+  encodeSessionMeta,
+  encodeSignup,
+  mergeLwwConfig,
+  mergeSessionColumn,
+  parseSessionCell,
+  parseSessionColumnName,
+} from '../rotaEncoding.js';
+
+const META = {
+  v: 1,
+  at: '2026-07-01T10:00:00Z',
+  by: 'Simon Clark',
+  act: 'Kayaking',
+  st: '18:15',
+  en: '19:30',
+  k: 24,
+  p: 3,
+  c: 0,
+};
+
+const CONFIG = {
+  v: 1,
+  at: '2026-06-01T09:00:00Z',
+  by: 'Simon Clark',
+  cfg: {
+    start: '2026-06-01',
+    end: '2026-08-31',
+    sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
+  },
+};
+
+describe('session column names', () => {
+  it('round-trips date and section id', () => {
+    const name = buildSessionColumnName('2026-07-14', '49097');
+    expect(name).toBe('S_20260714_49097');
+    expect(parseSessionColumnName(name)).toEqual({ date: '2026-07-14', sectionId: '49097' });
+  });
+
+  it('rejects non-session columns', () => {
+    expect(parseSessionColumnName(ROTA_CONFIG_COLUMN)).toBeNull();
+    expect(parseSessionColumnName('S_2026714_49097')).toBeNull();
+    expect(parseSessionColumnName('DOB')).toBeNull();
+    expect(parseSessionColumnName(undefined)).toBeNull();
+  });
+});
+
+describe('parseSessionCell', () => {
+  it('treats empty, corrupt, and non-object values as empty cells', () => {
+    expect(parseSessionCell('')).toBeNull();
+    expect(parseSessionCell(null)).toBeNull();
+    expect(parseSessionCell('not json')).toBeNull();
+    expect(parseSessionCell('[1,2]')).toBeNull();
+    expect(parseSessionCell('"just a string"')).toBeNull();
+  });
+
+  it('rejects cells with invalid signup status', () => {
+    expect(parseSessionCell(JSON.stringify({ s: 'X' }))).toBeNull();
+  });
+
+  it('keeps unknown fields for forward compatibility', () => {
+    const raw = JSON.stringify({ s: 'I', sat: '2026-07-01T10:00:00Z', future: 'field' });
+    expect(parseSessionCell(raw)).toMatchObject({ s: 'I', future: 'field' });
+  });
+});
+
+describe('mergeLwwConfig', () => {
+  it('returns null when no rows have valid config', () => {
+    expect(mergeLwwConfig([])).toBeNull();
+    expect(mergeLwwConfig([null, '', 'garbage'])).toBeNull();
+  });
+
+  it('picks the highest version regardless of row order', () => {
+    const v1 = JSON.stringify(CONFIG);
+    const v2 = JSON.stringify({ ...CONFIG, v: 2, at: '2026-05-01T00:00:00Z', by: 'Other Leader' });
+    expect(mergeLwwConfig([v2, v1]).v).toBe(2);
+    expect(mergeLwwConfig([v1, v2]).v).toBe(2);
+  });
+
+  it('breaks version ties by timestamp', () => {
+    const older = JSON.stringify({ ...CONFIG, at: '2026-06-01T09:00:00Z', by: 'Older' });
+    const newer = JSON.stringify({ ...CONFIG, at: '2026-06-01T09:00:01Z', by: 'Newer' });
+    expect(mergeLwwConfig([older, newer]).by).toBe('Newer');
+    expect(mergeLwwConfig([newer, older]).by).toBe('Newer');
+  });
+
+  it('ignores corrupt rows while merging valid ones', () => {
+    expect(mergeLwwConfig(['{bad', JSON.stringify(CONFIG)]).v).toBe(1);
+  });
+});
+
+describe('mergeSessionColumn', () => {
+  it('collects signups and the winning metadata across rows', () => {
+    const rows = [
+      {
+        scoutid: 1,
+        name: 'Alice',
+        value: JSON.stringify({ s: 'I', sat: '2026-07-02T10:00:00Z', m: META }),
+      },
+      {
+        scoutid: 2,
+        name: 'Bob',
+        value: JSON.stringify({
+          s: 'B',
+          sat: '2026-07-01T10:00:00Z',
+          m: { ...META, v: 2, at: '2026-07-03T10:00:00Z', act: 'Rafting' },
+        }),
+      },
+      { scoutid: 3, name: 'Cara', value: '' },
+    ];
+
+    const { meta, signups } = mergeSessionColumn(rows);
+    expect(meta.v).toBe(2);
+    expect(meta.act).toBe('Rafting');
+    expect(signups).toEqual([
+      { scoutid: '2', name: 'Bob', status: 'B', at: '2026-07-01T10:00:00Z' },
+      { scoutid: '1', name: 'Alice', status: 'I', at: '2026-07-02T10:00:00Z' },
+    ]);
+  });
+
+  it('returns null meta and no signups for an untouched column', () => {
+    expect(mergeSessionColumn([{ scoutid: 1, name: 'Alice', value: null }])).toEqual({
+      meta: null,
+      signups: [],
+    });
+  });
+});
+
+describe('encodeSignup', () => {
+  it('writes signup into an empty cell', () => {
+    const raw = encodeSignup('', SIGNUP_STATUS.IN, '2026-07-02T10:00:00Z');
+    expect(JSON.parse(raw)).toEqual({ s: 'I', sat: '2026-07-02T10:00:00Z' });
+  });
+
+  it('preserves an existing metadata candidate when signing up', () => {
+    const existing = JSON.stringify({ m: META });
+    const raw = encodeSignup(existing, SIGNUP_STATUS.BACKUP, '2026-07-02T10:00:00Z');
+    expect(JSON.parse(raw)).toEqual({ s: 'B', sat: '2026-07-02T10:00:00Z', m: META });
+  });
+
+  it('withdrawing clears signup but keeps metadata', () => {
+    const existing = JSON.stringify({ s: 'I', sat: '2026-07-02T10:00:00Z', m: META });
+    const raw = encodeSignup(existing, null, '2026-07-03T10:00:00Z');
+    expect(JSON.parse(raw)).toEqual({ m: META });
+  });
+
+  it('withdrawing from a signup-only cell empties it', () => {
+    const existing = JSON.stringify({ s: 'I', sat: '2026-07-02T10:00:00Z' });
+    expect(encodeSignup(existing, null, '2026-07-03T10:00:00Z')).toBe('');
+  });
+
+  it('overwrites a corrupt cell rather than propagating it', () => {
+    const raw = encodeSignup('{corrupt', SIGNUP_STATUS.IN, '2026-07-02T10:00:00Z');
+    expect(JSON.parse(raw)).toEqual({ s: 'I', sat: '2026-07-02T10:00:00Z' });
+  });
+});
+
+describe('encodeSessionMeta', () => {
+  it('preserves the editor\'s own signup when writing metadata', () => {
+    const existing = JSON.stringify({ s: 'I', sat: '2026-07-02T10:00:00Z' });
+    const raw = encodeSessionMeta(existing, { ...META, v: 2 });
+    const cell = JSON.parse(raw);
+    expect(cell.s).toBe('I');
+    expect(cell.m.v).toBe(2);
+  });
+
+  it('rejects invalid metadata instead of storing it', () => {
+    expect(() => encodeSessionMeta('', { ...META, st: '6pm' })).toThrow();
+    expect(() => encodeSessionMeta('', { ...META, k: -1 })).toThrow();
+  });
+});
+
+describe('encodeConfig', () => {
+  it('round-trips through mergeLwwConfig', () => {
+    const raw = encodeConfig(CONFIG);
+    expect(mergeLwwConfig([raw])).toEqual(CONFIG);
+  });
+
+  it('rejects config without sections', () => {
+    expect(() => encodeConfig({ ...CONFIG, cfg: { start: '2026-06-01', end: '2026-08-31' } })).toThrow();
+  });
+});

--- a/src/features/water-rota/services/__tests__/vikingWaterRotaValidation.test.js
+++ b/src/features/water-rota/services/__tests__/vikingWaterRotaValidation.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateWaterRotaStructure } from '../vikingWaterRotaValidation.js';
+import { parseRotaRecordYear, buildRotaRecordName } from '../rotaTemplates.js';
+
+describe('validateWaterRotaStructure', () => {
+  it('accepts a structure with RotaConfig and session columns, ignoring strays', () => {
+    const structure = {
+      fieldMapping: {
+        f_1: { name: 'RotaConfig', type: 'text' },
+        f_2: { name: 'S_20260714_49097', type: 'text' },
+        f_3: { name: 'S_20260602_49097', type: 'text' },
+        f_4: { name: 'SomeStrayColumn', type: 'text' },
+      },
+    };
+
+    const result = validateWaterRotaStructure(structure);
+    expect(result.isValid).toBe(true);
+    expect(result.configFieldId).toBe('f_1');
+    expect(result.sessionColumns).toEqual([
+      { fieldId: 'f_3', date: '2026-06-02', sectionId: '49097' },
+      { fieldId: 'f_2', date: '2026-07-14', sectionId: '49097' },
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('fails without a RotaConfig column', () => {
+    const result = validateWaterRotaStructure({
+      fieldMapping: { f_1: { name: 'S_20260714_49097', type: 'text' } },
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0]).toContain('RotaConfig');
+  });
+
+  it('fails safely on a missing structure', () => {
+    expect(validateWaterRotaStructure(null).isValid).toBe(false);
+    expect(validateWaterRotaStructure({}).isValid).toBe(false);
+  });
+});
+
+describe('rota record naming', () => {
+  it('round-trips the year', () => {
+    expect(parseRotaRecordYear(buildRotaRecordName(2026))).toBe(2026);
+  });
+
+  it('rejects other record names', () => {
+    expect(parseRotaRecordYear('Viking Event Mgmt')).toBeNull();
+    expect(parseRotaRecordYear('Viking Water Rota')).toBeNull();
+    expect(parseRotaRecordYear(null)).toBeNull();
+  });
+});

--- a/src/features/water-rota/services/index.js
+++ b/src/features/water-rota/services/index.js
@@ -1,0 +1,3 @@
+export * from './rotaEncoding.js';
+export * from './rotaTemplates.js';
+export * from './vikingWaterRotaValidation.js';

--- a/src/features/water-rota/services/rotaEncoding.js
+++ b/src/features/water-rota/services/rotaEncoding.js
@@ -1,0 +1,284 @@
+/**
+ * Pure encoding/decoding for the Water Rota FlexiRecord.
+ *
+ * Layout: one FlexiRecord per year in a host section. Rows are host-section
+ * members; each permit holder only ever writes their own row's cells, so
+ * signups never conflict across users. Two column kinds:
+ *
+ * - "RotaConfig": whole-plan config JSON. Every plan editor writes the full
+ *   config to their own row; readers take the last-writer-wins (LWW) winner
+ *   across all rows by (v, at).
+ * - "S_<yyyymmdd>_<sectionid>": one column per session. A cell holds the row
+ *   member's signup (s/sat) plus an optional session-metadata candidate (m);
+ *   readers take the LWW winner of m across the column.
+ *
+ * All functions here are pure: no network, no storage, no clock reads —
+ * timestamps are supplied by callers so merges stay deterministic and testable.
+ *
+ * @module rotaEncoding
+ */
+
+import { z } from 'zod';
+
+/**
+ * Column name holding whole-plan config.
+ * @type {string}
+ */
+export const ROTA_CONFIG_COLUMN = 'RotaConfig';
+
+/**
+ * Signup status codes stored in session cells.
+ * @type {{IN: string, BACKUP: string}}
+ */
+export const SIGNUP_STATUS = { IN: 'I', BACKUP: 'B' };
+
+const timeSchema = z.string().regex(/^\d{2}:\d{2}$/);
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const isoInstantSchema = z.string().min(1);
+
+const sectionDefaultsSchema = z
+  .object({
+    sid: z.string().min(1),
+    sname: z.string(),
+    act: z.string(),
+    st: timeSchema,
+    en: timeSchema,
+  })
+  .passthrough();
+
+const rotaConfigSchema = z
+  .object({
+    v: z.number().int().nonnegative(),
+    at: isoInstantSchema,
+    by: z.string(),
+    cfg: z
+      .object({
+        start: isoDateSchema,
+        end: isoDateSchema,
+        termId: z.string().optional(),
+        sections: z.array(sectionDefaultsSchema),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const sessionMetaSchema = z
+  .object({
+    v: z.number().int().nonnegative(),
+    at: isoInstantSchema,
+    by: z.string(),
+    act: z.string(),
+    st: timeSchema,
+    en: timeSchema,
+    k: z.number().int().nonnegative(),
+    p: z.number().int().nonnegative(),
+    n: z.string().optional(),
+    c: z.union([z.literal(0), z.literal(1)]),
+  })
+  .passthrough();
+
+const sessionCellSchema = z
+  .object({
+    s: z.enum([SIGNUP_STATUS.IN, SIGNUP_STATUS.BACKUP]).optional(),
+    sat: isoInstantSchema.optional(),
+    m: sessionMetaSchema.optional(),
+  })
+  .passthrough();
+
+/**
+ * Build the column name identifying a session.
+ *
+ * @param {string} dateISO - Session date as yyyy-mm-dd
+ * @param {string|number} sectionId - OSM section id
+ * @returns {string} Column name, e.g. "S_20260714_49097"
+ */
+export function buildSessionColumnName(dateISO, sectionId) {
+  const compact = String(dateISO).replaceAll('-', '');
+  return `S_${compact}_${sectionId}`;
+}
+
+/**
+ * Parse a session column name back into its identity.
+ *
+ * @param {string} columnName - FlexiRecord column name
+ * @returns {{date: string, sectionId: string}|null} Session identity, or null for non-session columns
+ */
+export function parseSessionColumnName(columnName) {
+  const match = /^S_(\d{4})(\d{2})(\d{2})_(\d+)$/.exec(String(columnName ?? ''));
+  if (!match) {
+    return null;
+  }
+  return { date: `${match[1]}-${match[2]}-${match[3]}`, sectionId: match[4] };
+}
+
+/**
+ * Parse a raw cell string into a validated session cell object.
+ * Unparseable or invalid cells are treated as empty — the encoding is
+ * self-healing rather than propagating corrupt data.
+ *
+ * @param {string|null|undefined} raw - Raw FlexiRecord cell value
+ * @returns {Object|null} Validated cell object, or null when empty/invalid
+ */
+export function parseSessionCell(raw) {
+  const parsed = parseJson(raw);
+  if (!parsed) {
+    return null;
+  }
+  const result = sessionCellSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Parse a raw RotaConfig cell string into a validated config candidate.
+ *
+ * @param {string|null|undefined} raw - Raw FlexiRecord cell value
+ * @returns {Object|null} Validated config candidate, or null when empty/invalid
+ */
+export function parseConfigCell(raw) {
+  const parsed = parseJson(raw);
+  if (!parsed) {
+    return null;
+  }
+  const result = rotaConfigSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Merge the RotaConfig column across all rows, returning the LWW winner.
+ *
+ * @param {Array<string|null|undefined>} cellValues - Raw RotaConfig values from every row
+ * @returns {Object|null} Winning config candidate ({v, at, by, cfg}), or null when none valid
+ */
+export function mergeLwwConfig(cellValues) {
+  return (cellValues ?? [])
+    .map(parseConfigCell)
+    .filter(Boolean)
+    .reduce((winner, candidate) => (isNewer(candidate, winner) ? candidate : winner), null);
+}
+
+/**
+ * Merge one session column across all rows into display-ready data.
+ *
+ * @param {Array<{scoutid: string|number, name: string, value: string|null|undefined}>} rows - One entry per host-section member row
+ * @returns {{meta: Object|null, signups: Array<{scoutid: string, name: string, status: string, at: string|null}>}} LWW-winning metadata and all signups
+ */
+export function mergeSessionColumn(rows) {
+  let meta = null;
+  const signups = [];
+
+  for (const row of rows ?? []) {
+    const cell = parseSessionCell(row.value);
+    if (!cell) {
+      continue;
+    }
+    if (cell.m && isNewer(cell.m, meta)) {
+      meta = cell.m;
+    }
+    if (cell.s) {
+      signups.push({
+        scoutid: String(row.scoutid),
+        name: row.name,
+        status: cell.s,
+        at: cell.sat ?? null,
+      });
+    }
+  }
+
+  signups.sort((a, b) => String(a.at ?? '').localeCompare(String(b.at ?? '')));
+  return { meta, signups };
+}
+
+/**
+ * Encode a signup change into the member's own cell, preserving any session
+ * metadata candidate (and unknown future fields) already stored there.
+ *
+ * @param {string|null|undefined} existingRaw - The member's current raw cell value
+ * @param {string|null} status - SIGNUP_STATUS.IN, SIGNUP_STATUS.BACKUP, or null to withdraw
+ * @param {string} at - ISO timestamp of the change (caller-supplied)
+ * @returns {string} New raw cell value ('' when the cell becomes empty)
+ */
+export function encodeSignup(existingRaw, status, at) {
+  const cell = parseSessionCell(existingRaw) ?? {};
+  if (status === null) {
+    delete cell.s;
+    delete cell.sat;
+  } else {
+    cell.s = status;
+    cell.sat = at;
+  }
+  return isEmptyCell(cell) ? '' : JSON.stringify(cell);
+}
+
+/**
+ * Encode a session-metadata update into the editor's own cell, preserving
+ * their signup (and unknown future fields). The caller supplies the bumped
+ * version and timestamp so concurrent edits resolve by LWW.
+ *
+ * @param {string|null|undefined} existingRaw - The editor's current raw cell value
+ * @param {Object} meta - Full metadata candidate ({v, at, by, act, st, en, k, p, n?, c})
+ * @returns {string} New raw cell value
+ */
+export function encodeSessionMeta(existingRaw, meta) {
+  const validated = sessionMetaSchema.parse(meta);
+  const cell = parseSessionCell(existingRaw) ?? {};
+  cell.m = validated;
+  return JSON.stringify(cell);
+}
+
+/**
+ * Encode a whole-plan config candidate for the editor's own RotaConfig cell.
+ *
+ * @param {Object} candidate - Full candidate ({v, at, by, cfg})
+ * @returns {string} New raw cell value
+ */
+export function encodeConfig(candidate) {
+  return JSON.stringify(rotaConfigSchema.parse(candidate));
+}
+
+/**
+ * Compare two versioned candidates ({v, at}) for LWW ordering.
+ *
+ * @param {Object|null} candidate - New candidate
+ * @param {Object|null} incumbent - Current winner
+ * @returns {boolean} True when candidate should replace incumbent
+ */
+function isNewer(candidate, incumbent) {
+  if (!candidate) {
+    return false;
+  }
+  if (!incumbent) {
+    return true;
+  }
+  if (candidate.v !== incumbent.v) {
+    return candidate.v > incumbent.v;
+  }
+  return String(candidate.at).localeCompare(String(incumbent.at)) > 0;
+}
+
+/**
+ * Leniently parse a JSON object from a raw cell string.
+ *
+ * @param {string|null|undefined} raw - Raw cell value
+ * @returns {Object|null} Parsed object, or null for empty/invalid/non-object values
+ */
+function parseJson(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Determine whether a cell object carries no data worth storing.
+ *
+ * @param {Object} cell - Session cell object
+ * @returns {boolean} True when the cell should be stored as an empty string
+ */
+function isEmptyCell(cell) {
+  return Object.keys(cell).length === 0;
+}

--- a/src/features/water-rota/services/rotaTemplates.js
+++ b/src/features/water-rota/services/rotaTemplates.js
@@ -1,0 +1,63 @@
+/**
+ * Presets and naming for the Water Session Permit Rota.
+ *
+ * The rota is stored in one OSM FlexiRecord per calendar year, discovered by
+ * name prefix so every leader's device finds it without local configuration.
+ *
+ * @module rotaTemplates
+ */
+
+/**
+ * Name prefix shared by every yearly rota FlexiRecord.
+ * @type {string}
+ */
+export const ROTA_RECORD_NAME_PREFIX = 'Viking Water Rota';
+
+/**
+ * Activity presets offered as one-tap chips in session editing.
+ * Free-text activities are also allowed; these are just the common ones.
+ * @type {string[]}
+ */
+export const ACTIVITY_PRESETS = [
+  'Kayaking',
+  'Canoeing',
+  'Paddleboarding',
+  'Bell boats',
+  'Rafting',
+  'Sailing',
+];
+
+/**
+ * Fallback session times used when a section has no programme times and the
+ * planner has not yet set per-section defaults.
+ * @type {{start: string, end: string}}
+ */
+export const DEFAULT_SESSION_TIMES = { start: '18:30', end: '20:00' };
+
+/**
+ * Options forwarded to createFlexiRecord so the rota record starts with only
+ * our custom columns (no OSM auto DOB/Age/Patrol columns).
+ * @type {{dob: string, age: string, patrol: string, type: string}}
+ */
+export const ROTA_CREATE_OPTIONS = { dob: '0', age: '0', patrol: '0', type: 'none' };
+
+/**
+ * Build the exact FlexiRecord name for a rota year.
+ *
+ * @param {number} year - Four-digit calendar year (e.g. 2026)
+ * @returns {string} Record name, e.g. "Viking Water Rota 2026"
+ */
+export function buildRotaRecordName(year) {
+  return `${ROTA_RECORD_NAME_PREFIX} ${year}`;
+}
+
+/**
+ * Extract the year from a rota FlexiRecord name.
+ *
+ * @param {string} name - FlexiRecord name
+ * @returns {number|null} Four-digit year, or null when the name is not a rota record
+ */
+export function parseRotaRecordYear(name) {
+  const match = /^Viking Water Rota (\d{4})$/.exec(String(name ?? '').trim());
+  return match ? Number(match[1]) : null;
+}

--- a/src/features/water-rota/services/vikingWaterRotaValidation.js
+++ b/src/features/water-rota/services/vikingWaterRotaValidation.js
@@ -1,0 +1,55 @@
+/**
+ * Structure validation for a "Viking Water Rota <year>" FlexiRecord.
+ *
+ * Pure sibling of vikingEventMgmtValidation: it takes an already-fetched
+ * structure (fieldMapping) rather than fetching, because rota discovery and
+ * loading are owned by rotaService. Unknown columns are ignored — aborted
+ * setups can leave stray columns and columns can never be deleted in OSM.
+ *
+ * @module vikingWaterRotaValidation
+ */
+
+import { ROTA_CONFIG_COLUMN, parseSessionColumnName } from './rotaEncoding.js';
+
+/**
+ * Validate a rota FlexiRecord structure.
+ *
+ * @param {Object|null} structure - FlexiRecord structure with a fieldMapping of {fieldId: {name, type}}
+ * @returns {{isValid: boolean, hasConfigColumn: boolean, sessionColumns: Array<{fieldId: string, date: string, sectionId: string}>, configFieldId: string|null, errors: string[]}} Validation result
+ */
+export function validateWaterRotaStructure(structure) {
+  const result = {
+    isValid: false,
+    hasConfigColumn: false,
+    sessionColumns: [],
+    configFieldId: null,
+    errors: [],
+  };
+
+  const fieldMapping = structure?.fieldMapping;
+  if (!fieldMapping || typeof fieldMapping !== 'object') {
+    result.errors.push('Rota FlexiRecord structure has no field mapping');
+    return result;
+  }
+
+  for (const [fieldId, field] of Object.entries(fieldMapping)) {
+    if (field?.name === ROTA_CONFIG_COLUMN) {
+      result.hasConfigColumn = true;
+      result.configFieldId = fieldId;
+      continue;
+    }
+    const session = parseSessionColumnName(field?.name);
+    if (session) {
+      result.sessionColumns.push({ fieldId, ...session });
+    }
+  }
+
+  result.sessionColumns.sort((a, b) => a.date.localeCompare(b.date));
+
+  if (!result.hasConfigColumn) {
+    result.errors.push(`Missing required column: ${ROTA_CONFIG_COLUMN}`);
+  }
+
+  result.isValid = result.hasConfigColumn;
+  return result;
+}

--- a/src/features/water-rota/utils/__tests__/rotaDates.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaDates.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bucketSessionsByWeek,
+  expandWeeklySlot,
+  generateSessionsFromProgramme,
+  groupByHorizon,
+  startOfIsoWeek,
+} from '../rotaDates.js';
+
+const CUBS = { sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' };
+const RANGE = { start: '2026-06-01', end: '2026-08-31' };
+
+describe('generateSessionsFromProgramme', () => {
+  it('creates one session per meeting inside the range, programme times winning', () => {
+    const meetings = [
+      { date: '2026-06-02', startTime: '18:00', endTime: '19:15', title: 'Water night 1' },
+      { date: '2026-06-09', startTime: null, endTime: null, title: 'Water night 2' },
+      { date: '2026-05-26', startTime: '18:00', endTime: '19:15', title: 'Before range' },
+      { date: '2026-09-01', startTime: '18:00', endTime: '19:15', title: 'After range' },
+    ];
+
+    const sessions = generateSessionsFromProgramme(meetings, CUBS, RANGE);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]).toMatchObject({
+      date: '2026-06-02',
+      startTime: '18:00',
+      endTime: '19:15',
+      title: 'Water night 1',
+    });
+    expect(sessions[1]).toMatchObject({ date: '2026-06-09', startTime: '18:15', endTime: '19:30' });
+  });
+
+  it('collapses duplicate meeting dates to the first meeting', () => {
+    const meetings = [
+      { date: '2026-06-02', startTime: '18:00', endTime: '19:00', title: 'First' },
+      { date: '2026-06-02', startTime: '20:00', endTime: '21:00', title: 'Second' },
+    ];
+    const sessions = generateSessionsFromProgramme(meetings, CUBS, RANGE);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].title).toBe('First');
+  });
+
+  it('handles an empty programme', () => {
+    expect(generateSessionsFromProgramme([], CUBS, RANGE)).toEqual([]);
+    expect(generateSessionsFromProgramme(undefined, CUBS, RANGE)).toEqual([]);
+  });
+});
+
+describe('expandWeeklySlot', () => {
+  it('produces the slot weekday for every week in the range', () => {
+    const slot = { weekday: 2, ...CUBS };
+    const sessions = expandWeeklySlot(slot, { start: '2026-06-01', end: '2026-06-30' });
+    expect(sessions.map((s) => s.date)).toEqual([
+      '2026-06-02',
+      '2026-06-09',
+      '2026-06-16',
+      '2026-06-23',
+      '2026-06-30',
+    ]);
+    expect(new Set(sessions.map((s) => new Date(s.date).getDay()))).toEqual(new Set([2]));
+  });
+
+  it('starts on the range start when it falls on the slot weekday', () => {
+    const slot = { weekday: 1, ...CUBS };
+    const sessions = expandWeeklySlot(slot, { start: '2026-06-01', end: '2026-06-15' });
+    expect(sessions.map((s) => s.date)).toEqual(['2026-06-01', '2026-06-08', '2026-06-15']);
+  });
+
+  it('spans the October DST change without skipping or duplicating weeks', () => {
+    const slot = { weekday: 7, ...CUBS };
+    const sessions = expandWeeklySlot(slot, { start: '2026-10-19', end: '2026-11-02' });
+    expect(sessions.map((s) => s.date)).toEqual(['2026-10-25', '2026-11-01']);
+  });
+});
+
+describe('bucketSessionsByWeek', () => {
+  it('groups by Monday-start weeks in ascending order', () => {
+    const sessions = [
+      { date: '2026-06-12' },
+      { date: '2026-06-02' },
+      { date: '2026-06-05' },
+    ];
+    const weeks = bucketSessionsByWeek(sessions);
+    expect(weeks.map((w) => w.weekStart)).toEqual(['2026-06-01', '2026-06-08']);
+    expect(weeks[0].sessions.map((s) => s.date)).toEqual(['2026-06-02', '2026-06-05']);
+  });
+});
+
+describe('groupByHorizon', () => {
+  it('buckets by this week, next week, later, and past', () => {
+    const sessions = [
+      { date: '2026-07-08' },
+      { date: '2026-07-10' },
+      { date: '2026-07-14' },
+      { date: '2026-07-21' },
+      { date: '2026-07-06' },
+    ];
+    const buckets = groupByHorizon(sessions, '2026-07-10');
+    expect(buckets.past.map((s) => s.date)).toEqual(['2026-07-06', '2026-07-08']);
+    expect(buckets.thisWeek.map((s) => s.date)).toEqual(['2026-07-10']);
+    expect(buckets.nextWeek.map((s) => s.date)).toEqual(['2026-07-14']);
+    expect(buckets.later.map((s) => s.date)).toEqual(['2026-07-21']);
+  });
+});
+
+describe('startOfIsoWeek', () => {
+  it('returns the Monday of the containing week', () => {
+    expect(startOfIsoWeek('2026-07-10')).toBe('2026-07-06');
+    expect(startOfIsoWeek('2026-07-06')).toBe('2026-07-06');
+    expect(startOfIsoWeek('2026-07-12')).toBe('2026-07-06');
+  });
+});

--- a/src/features/water-rota/utils/index.js
+++ b/src/features/water-rota/utils/index.js
@@ -1,0 +1,1 @@
+export * from './rotaDates.js';

--- a/src/features/water-rota/utils/rotaDates.js
+++ b/src/features/water-rota/utils/rotaDates.js
@@ -1,0 +1,181 @@
+/**
+ * Pure date utilities for the Water Rota: session generation from programme
+ * meetings (or weekly slot fallback) and week bucketing for display.
+ *
+ * All functions take and return ISO yyyy-mm-dd date strings and are
+ * clock-free — callers supply "today" where relevant.
+ *
+ * @module rotaDates
+ */
+
+import { addDays, format, parseISO, startOfWeek } from 'date-fns';
+
+/**
+ * Session descriptor produced by generation, consumed by setup/board code.
+ *
+ * @typedef {Object} SessionDescriptor
+ * @property {string} date - Session date (yyyy-mm-dd)
+ * @property {string} sectionId - OSM section id
+ * @property {string} sectionName - Display name of the section
+ * @property {string} startTime - HH:mm
+ * @property {string} endTime - HH:mm
+ * @property {string} activity - Default activity for the session
+ * @property {string|null} title - Programme meeting title when derived from the programme
+ */
+
+/**
+ * Generate session descriptors from a section's programme meetings.
+ * One session per meeting date inside the range; duplicate dates collapse to
+ * the first meeting. Programme times win; section defaults fill gaps.
+ *
+ * @param {Array<{date: string, startTime: string|null, endTime: string|null, title: string|null}>} meetings - Normalized programme meetings
+ * @param {{sid: string, sname: string, act: string, st: string, en: string}} section - Per-section defaults from RotaConfig
+ * @param {{start: string, end: string}} range - Inclusive rota date range
+ * @returns {SessionDescriptor[]} Sessions sorted by date
+ */
+export function generateSessionsFromProgramme(meetings, section, range) {
+  const seen = new Set();
+  const sessions = [];
+
+  for (const meeting of meetings ?? []) {
+    const date = meeting.date;
+    if (!isWithinRange(date, range) || seen.has(date)) {
+      continue;
+    }
+    seen.add(date);
+    sessions.push({
+      date,
+      sectionId: section.sid,
+      sectionName: section.sname,
+      startTime: meeting.startTime || section.st,
+      endTime: meeting.endTime || section.en,
+      activity: section.act,
+      title: meeting.title ?? null,
+    });
+  }
+
+  return sessions.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Generate session descriptors from a weekly slot — the fallback when a
+ * section's programme is empty. Produces one session on the slot's weekday
+ * for every week in the range.
+ *
+ * @param {{weekday: number, sid: string, sname: string, st: string, en: string, act: string}} slot - Weekly slot (weekday: 1=Monday..7=Sunday)
+ * @param {{start: string, end: string}} range - Inclusive rota date range
+ * @returns {SessionDescriptor[]} Sessions sorted by date
+ */
+export function expandWeeklySlot(slot, range) {
+  const sessions = [];
+  let cursor = firstWeekdayOnOrAfter(range.start, slot.weekday);
+
+  while (isWithinRange(cursor, range)) {
+    sessions.push({
+      date: cursor,
+      sectionId: slot.sid,
+      sectionName: slot.sname,
+      startTime: slot.st,
+      endTime: slot.en,
+      activity: slot.act,
+      title: null,
+    });
+    cursor = format(addDays(parseISO(cursor), 7), 'yyyy-MM-dd');
+  }
+
+  return sessions;
+}
+
+/**
+ * Group sessions into calendar weeks (Monday start) for the board list and
+ * overview strip.
+ *
+ * @param {Array<{date: string}>} sessions - Any objects carrying a session date
+ * @returns {Array<{weekStart: string, sessions: Array}>} Weeks sorted ascending, sessions within a week sorted by date
+ */
+export function bucketSessionsByWeek(sessions) {
+  const byWeek = new Map();
+
+  for (const session of sessions ?? []) {
+    const weekStart = startOfIsoWeek(session.date);
+    if (!byWeek.has(weekStart)) {
+      byWeek.set(weekStart, []);
+    }
+    byWeek.get(weekStart).push(session);
+  }
+
+  return [...byWeek.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([weekStart, weekSessions]) => ({
+      weekStart,
+      sessions: weekSessions.sort((a, b) => a.date.localeCompare(b.date)),
+    }));
+}
+
+/**
+ * Bucket a member's commitments into display horizons.
+ *
+ * @param {Array<{date: string}>} sessions - Sessions the member is committed to
+ * @param {string} todayISO - Today's date (yyyy-mm-dd), caller-supplied
+ * @returns {{thisWeek: Array, nextWeek: Array, later: Array, past: Array}} Horizon buckets, each sorted by date
+ */
+export function groupByHorizon(sessions, todayISO) {
+  const thisWeekStart = startOfIsoWeek(todayISO);
+  const nextWeekStart = format(addDays(parseISO(thisWeekStart), 7), 'yyyy-MM-dd');
+  const laterStart = format(addDays(parseISO(thisWeekStart), 14), 'yyyy-MM-dd');
+
+  const buckets = { thisWeek: [], nextWeek: [], later: [], past: [] };
+
+  for (const session of sessions ?? []) {
+    if (session.date < todayISO) {
+      buckets.past.push(session);
+    } else if (session.date < nextWeekStart) {
+      buckets.thisWeek.push(session);
+    } else if (session.date < laterStart) {
+      buckets.nextWeek.push(session);
+    } else {
+      buckets.later.push(session);
+    }
+  }
+
+  for (const bucket of Object.values(buckets)) {
+    bucket.sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  return buckets;
+}
+
+/**
+ * Monday of the calendar week containing a date.
+ *
+ * @param {string} dateISO - Date (yyyy-mm-dd)
+ * @returns {string} Week-start Monday (yyyy-mm-dd)
+ */
+export function startOfIsoWeek(dateISO) {
+  return format(startOfWeek(parseISO(dateISO), { weekStartsOn: 1 }), 'yyyy-MM-dd');
+}
+
+/**
+ * First occurrence of a weekday on or after a date.
+ *
+ * @param {string} dateISO - Starting date (yyyy-mm-dd)
+ * @param {number} weekday - 1=Monday..7=Sunday
+ * @returns {string} Date of the first matching weekday (yyyy-mm-dd)
+ */
+function firstWeekdayOnOrAfter(dateISO, weekday) {
+  const start = parseISO(dateISO);
+  const startWeekday = ((start.getDay() + 6) % 7) + 1;
+  const offset = (weekday - startWeekday + 7) % 7;
+  return format(addDays(start, offset), 'yyyy-MM-dd');
+}
+
+/**
+ * Inclusive range check on ISO date strings.
+ *
+ * @param {string} dateISO - Date to test (yyyy-mm-dd)
+ * @param {{start: string, end: string}} range - Inclusive range
+ * @returns {boolean} True when the date falls inside the range
+ */
+function isWithinRange(dateISO, range) {
+  return typeof dateISO === 'string' && dateISO >= range.start && dateISO <= range.end;
+}


### PR DESCRIPTION
## Summary

First PR of the **Water Session Permit Rota** feature: leaders plan regular on-water sessions across sections over a summer date range; permit holders sign up (confirmed/backup); section leaders get at-a-glance cover status.

This PR ships the pure foundation — no UI, no network:

- **Storage design** (documented in `docs/features/water-rota.md`): one OSM FlexiRecord per year in a host section, one column per session (`S_<yyyymmdd>_<sectionid>`), plus a `RotaConfig` column. Each user only writes their own row, so signups can never conflict; session metadata uses last-writer-wins `(v, at)` merging across rows.
- `rotaEncoding.js` — zod-validated cell schemas, column naming, LWW merges, own-cell-preserving signup/metadata encoding. Corrupt cells self-heal. Unknown fields pass through for forward compatibility (v2 ratio rules).
- `rotaDates.js` — session generation from OSM programme meetings (with weekly-slot fallback), Monday-week bucketing, commitment horizons. Clock-free.
- `rotaTemplates.js` — record naming (`Viking Water Rota <year>`), activity presets.
- `vikingWaterRotaValidation.js` — structure validation mirroring the existing flexi validators; stray columns ignored (columns can't be deleted in OSM).

## Test plan

- 34 new Vitest tests: LWW merge ordering + tie-breaks, encode/parse round-trips, withdraw-preserves-metadata, DST-spanning slot expansion, corrupt-cell handling.
- `npm run lint` ✅ (0 errors) · `npm run test:run` ✅ (712 passed) · `npm run build` ✅

## Follow-ups (planned PRs)

Backend `/get-programme` proxy → rota load/write services → board UI → signups + My week → session editing + setup wizard → polish. Live-OSM spike questions (column count, cell size, cross-term persistence) tracked in the feature doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR