### PR TITLE
feat: programme API wrapper + water-rota programme service

### DIFF
--- a/src/features/water-rota/services/__tests__/programmeService.test.js
+++ b/src/features/water-rota/services/__tests__/programmeService.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeProgrammeMeetings } from '../programmeService.js';
+
+describe('normalizeProgrammeMeetings', () => {
+  it('normalizes a typical OSM programme summary item', () => {
+    const meetings = normalizeProgrammeMeetings([
+      {
+        eveningid: '8785585',
+        title: '  Water night  ',
+        meetingdate: '2026-06-02',
+        starttime: '18:15:00',
+        endtime: '19:30:00',
+      },
+    ]);
+
+    expect(meetings).toEqual([
+      {
+        eveningid: '8785585',
+        title: 'Water night',
+        date: '2026-06-02',
+        startTime: '18:15',
+        endTime: '19:30',
+      },
+    ]);
+  });
+
+  it('tolerates missing time fields — summary payloads may omit them', () => {
+    const meetings = normalizeProgrammeMeetings([
+      { eveningid: 1, title: 'No times', meetingdate: '2026-06-09' },
+    ]);
+    expect(meetings[0].startTime).toBeNull();
+    expect(meetings[0].endTime).toBeNull();
+    expect(meetings[0].eveningid).toBe('1');
+  });
+
+  it('accepts UK dd/mm/yyyy dates and ISO dates with time suffixes', () => {
+    const meetings = normalizeProgrammeMeetings([
+      { meetingdate: '14/07/2026' },
+      { meetingdate: '2026-06-02 00:00:00' },
+    ]);
+    expect(meetings.map((m) => m.date)).toEqual(['2026-06-02', '2026-07-14']);
+  });
+
+  it('drops items without a parseable date and handles empty input', () => {
+    expect(normalizeProgrammeMeetings([{ title: 'No date' }, { meetingdate: 'soon' }])).toEqual([]);
+    expect(normalizeProgrammeMeetings(undefined)).toEqual([]);
+    expect(normalizeProgrammeMeetings(null)).toEqual([]);
+  });
+
+  it('normalizes blank titles to null and sorts by date', () => {
+    const meetings = normalizeProgrammeMeetings([
+      { meetingdate: '2026-06-16', title: '' },
+      { meetingdate: '2026-06-02', title: 'First' },
+    ]);
+    expect(meetings.map((m) => m.date)).toEqual(['2026-06-02', '2026-06-16']);
+    expect(meetings[0].title).toBe('First');
+    expect(meetings[1].title).toBeNull();
+  });
+});

--- a/src/features/water-rota/services/index.js
+++ b/src/features/water-rota/services/index.js
@@ -1,3 +1,4 @@
+export * from './programmeService.js';
 export * from './rotaEncoding.js';
 export * from './rotaTemplates.js';
 export * from './vikingWaterRotaValidation.js';

--- a/src/features/water-rota/services/programmeService.js
+++ b/src/features/water-rota/services/programmeService.js
@@ -1,0 +1,102 @@
+/**
+ * Programme meetings for the water rota: fetches a section's programme
+ * summary and normalizes it into the meeting shape consumed by
+ * generateSessionsFromProgramme.
+ *
+ * OSM's programme summary reliably carries meeting dates; start/end times
+ * are not guaranteed (the summary payload may omit them entirely), so both
+ * normalize to null and per-section defaults fill the gap downstream.
+ *
+ * @module programmeService
+ */
+
+import { getProgramme } from '../../../shared/services/api/api/index.js';
+
+/**
+ * Normalized programme meeting consumed by session generation.
+ *
+ * @typedef {Object} ProgrammeMeeting
+ * @property {string|null} eveningid - OSM programme entry id
+ * @property {string|null} title - Meeting title
+ * @property {string} date - Meeting date (yyyy-mm-dd)
+ * @property {string|null} startTime - HH:mm, or null when OSM omits it
+ * @property {string|null} endTime - HH:mm, or null when OSM omits it
+ */
+
+/**
+ * Fetch and normalize a section's programme meetings for a term.
+ *
+ * @param {number|string} sectionId - OSM section id
+ * @param {number|string} termId - OSM term id
+ * @param {string} token - OSM authentication token
+ * @returns {Promise<ProgrammeMeeting[]>} Meetings with parseable dates, sorted by date
+ */
+export async function fetchProgrammeMeetings(sectionId, termId, token) {
+  const programme = await getProgramme(sectionId, termId, token);
+  return normalizeProgrammeMeetings(programme?.items);
+}
+
+/**
+ * Normalize raw OSM programme summary items. Items without a parseable
+ * meeting date are dropped; times are normalized to HH:mm or null.
+ *
+ * @param {Array<Object>|null|undefined} items - Raw programme summary items
+ * @returns {ProgrammeMeeting[]} Normalized meetings sorted by date
+ */
+export function normalizeProgrammeMeetings(items) {
+  return (items ?? [])
+    .map((item) => {
+      const date = normalizeDate(item?.meetingdate);
+      if (!date) {
+        return null;
+      }
+      return {
+        eveningid: item.eveningid !== null && item.eveningid !== undefined ? String(item.eveningid) : null,
+        title: typeof item.title === 'string' && item.title.trim() !== '' ? item.title.trim() : null,
+        date,
+        startTime: normalizeTime(item.starttime),
+        endTime: normalizeTime(item.endtime),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Normalize an OSM date value to yyyy-mm-dd. Accepts ISO (yyyy-mm-dd,
+ * optionally with a time suffix) and UK (dd/mm/yyyy) forms.
+ *
+ * @param {*} value - Raw date value
+ * @returns {string|null} yyyy-mm-dd, or null when unparseable
+ */
+function normalizeDate(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const iso = /^(\d{4})-(\d{2})-(\d{2})/.exec(value.trim());
+  if (iso) {
+    return `${iso[1]}-${iso[2]}-${iso[3]}`;
+  }
+  const uk = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value.trim());
+  if (uk) {
+    return `${uk[3]}-${uk[2]}-${uk[1]}`;
+  }
+  return null;
+}
+
+/**
+ * Normalize an OSM time value to HH:mm. Accepts HH:mm and HH:mm:ss.
+ *
+ * @param {*} value - Raw time value
+ * @returns {string|null} HH:mm, or null when absent/unparseable
+ */
+function normalizeTime(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const match = /^(\d{1,2}):(\d{2})(?::\d{2})?$/.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  return `${match[1].padStart(2, '0')}:${match[2]}`;
+}

--- a/src/shared/services/api/api/index.js
+++ b/src/shared/services/api/api/index.js
@@ -38,6 +38,11 @@ export {
   getListOfMembers,
 } from './members.js';
 
+// Programme exports
+export {
+  getProgramme,
+} from './programme.js';
+
 // FlexiRecords exports
 export {
   getFlexiRecords,

--- a/src/shared/services/api/api/programme.js
+++ b/src/shared/services/api/api/programme.js
@@ -1,0 +1,63 @@
+/**
+ * Programme API service — proxies OSM's programme summary (meeting list)
+ * through the backend. Used by the water-rota feature to derive on-water
+ * session dates from each section's programme.
+ *
+ * @module programme
+ */
+
+import { osmRequest } from './base.js';
+import { safeGetItem } from '../../../utils/storageUtils.js';
+import { isDemoMode } from '../../../../config/demoMode.js';
+import IndexedDBService from '../../storage/indexedDBService.js';
+import logger, { LOG_CATEGORIES } from '../../utils/logger.js';
+
+const PROGRAMME_CACHE_TTL = 30 * 60 * 1000;
+
+/**
+ * Retrieves the programme summary (meeting list) for a section and term.
+ * Cached for 30 minutes — the programme changes rarely within a session.
+ * Cache hits and network responses share the same `{items}` shape (the
+ * cached copy additionally carries `_cacheTimestamp`), mirroring
+ * getStartupData.
+ *
+ * @param {number|string} sectionId - OSM section identifier
+ * @param {number|string} termId - OSM term identifier
+ * @param {string} token - OSM authentication token
+ * @returns {Promise<{items: Array<Object>}|null>} Programme meetings wrapper, or null when unavailable
+ * @throws {Error} When the request fails and no cached data is available
+ *
+ * @example
+ * const programme = await getProgramme(49097, '846925', userToken);
+ * const meetings = programme?.items ?? [];
+ */
+export async function getProgramme(sectionId, termId, token) {
+  const cacheKey = `viking_programme_${sectionId}_${termId}`;
+
+  if (isDemoMode()) {
+    return safeGetItem(`demo_${cacheKey}_offline`, null);
+  }
+
+  return osmRequest(
+    'getProgrammeSummary',
+    `/get-programme-summary?sectionid=${encodeURIComponent(sectionId)}&termid=${encodeURIComponent(termId)}`,
+    {
+      token,
+      ttl: PROGRAMME_CACHE_TTL,
+      cacheRead: () => IndexedDBService.get(IndexedDBService.STORES.CACHE_DATA, cacheKey),
+      transform: (data) => ({ items: (data && Array.isArray(data.items)) ? data.items : [] }),
+      cacheWrite: async (result) => {
+        const withTimestamp = { ...result, _cacheTimestamp: Date.now() };
+        const success = await IndexedDBService.set(
+          IndexedDBService.STORES.CACHE_DATA,
+          cacheKey,
+          withTimestamp,
+        );
+        if (!success) {
+          logger.error('Programme caching failed', { sectionId, termId }, LOG_CATEGORIES.ERROR);
+        }
+      },
+      emptyValue: null,
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Frontend half of the programme integration for the Water Rota (stacked on #211; backend endpoint: Walton-Viking-Scouts/VikingsEventMgmtAPI#51).

- `src/shared/services/api/api/programme.js` — `getProgramme(sectionId, termId, token)` via `osmRequest` with a 30-minute TTL cache in the CACHE_DATA store, following the `getStartupData` pattern (cache hits and network responses share the same `{items}` shape so the TTL fast-path is consistent).
- `src/features/water-rota/services/programmeService.js` — `fetchProgrammeMeetings` + `normalizeProgrammeMeetings`: tolerates missing `starttime`/`endtime` (OSM's summary payload may omit them — per-section defaults fill in downstream), accepts ISO and UK date forms, drops unparseable dates, trims/nulls blank titles.

## Test plan

- 5 new Vitest tests for normalization edge cases.
- `npm run lint` ✅ · `npm run test:run` ✅ (717 passed) · `npm run build` ✅

**Note:** base branch is `feature/water-rota-encoding` (stacked). Merge #211 first, then retarget/merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR