### PR TITLE
feat: water rota load/write/setup services

### DIFF
--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { API: 'API', APP: 'APP', ERROR: 'ERROR', DATABASE: 'DATABASE' },
+}));
+
+vi.mock('../../../../shared/services/api/api/index.js', () => ({
+  getFlexiRecords: vi.fn(),
+  getFlexiStructure: vi.fn(),
+  getSingleFlexiRecord: vi.fn(),
+  updateFlexiRecord: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/storage/database.js', () => ({
+  default: {
+    getSections: vi.fn(),
+    getFlexiData: vi.fn(),
+    saveFlexiData: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../shared/services/storage/currentActiveTermsService.js', () => ({
+  CurrentActiveTermsService: { getCurrentActiveTerm: vi.fn() },
+}));
+
+import {
+  getFlexiRecords,
+  getFlexiStructure,
+  getSingleFlexiRecord,
+  updateFlexiRecord,
+} from '../../../../shared/services/api/api/index.js';
+import databaseService from '../../../../shared/services/storage/database.js';
+import { CurrentActiveTermsService } from '../../../../shared/services/storage/currentActiveTermsService.js';
+import {
+  discoverRotaRecord,
+  loadRota,
+  writeSignup,
+  writeSessionMeta,
+} from '../rotaService.js';
+import { SIGNUP_STATUS } from '../rotaEncoding.js';
+
+const HOST_SECTION = { sectionid: 900, sectionname: 'Adults', section: 'adults' };
+const OTHER_SECTION = { sectionid: 901, sectionname: 'Cubs', section: 'cubs' };
+const TOKEN = 'tok';
+
+const STRUCTURE = {
+  config: JSON.stringify([
+    { id: 'f_1', name: 'RotaConfig' },
+    { id: 'f_2', name: 'S_20260714_49097' },
+  ]),
+};
+
+const CONFIG_CELL = JSON.stringify({
+  v: 1,
+  at: '2026-06-01T09:00:00Z',
+  by: 'Simon Clark',
+  cfg: {
+    start: '2026-06-01',
+    end: '2026-08-31',
+    sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
+  },
+});
+
+const META = {
+  v: 1,
+  at: '2026-07-01T10:00:00Z',
+  by: 'Simon Clark',
+  act: 'Kayaking',
+  st: '18:15',
+  en: '19:30',
+  k: 24,
+  p: 3,
+  c: 0,
+};
+
+function gridWith(items) {
+  return { identifier: 'scoutid', items };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  databaseService.getSections.mockResolvedValue([OTHER_SECTION, HOST_SECTION]);
+  databaseService.getFlexiData.mockResolvedValue(null);
+  databaseService.saveFlexiData.mockResolvedValue(undefined);
+  CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: 'T1' });
+});
+
+describe('discoverRotaRecord', () => {
+  it('finds the rota record across the user sections', async () => {
+    getFlexiRecords.mockImplementation(async (sectionId) =>
+      sectionId === HOST_SECTION.sectionid
+        ? { items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] }
+        : { items: [{ name: 'Viking Event Mgmt', extraid: 1 }] },
+    );
+
+    const result = await discoverRotaRecord(2026, TOKEN);
+    expect(result).toEqual({ hostSection: HOST_SECTION, recordId: 777 });
+  });
+
+  it('returns null when no section has the record', async () => {
+    getFlexiRecords.mockResolvedValue({ items: [] });
+    expect(await discoverRotaRecord(2026, TOKEN)).toBeNull();
+  });
+
+  it('skips sections whose flexi list read fails', async () => {
+    getFlexiRecords.mockImplementation(async (sectionId) => {
+      if (sectionId === OTHER_SECTION.sectionid) {
+        throw new Error('boom');
+      }
+      return { items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] };
+    });
+
+    const result = await discoverRotaRecord(2026, TOKEN);
+    expect(result?.recordId).toBe(777);
+  });
+});
+
+describe('loadRota', () => {
+  beforeEach(() => {
+    getFlexiRecords.mockImplementation(async (sectionId) =>
+      sectionId === HOST_SECTION.sectionid
+        ? { items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] }
+        : { items: [] },
+    );
+    getFlexiStructure.mockResolvedValue(STRUCTURE);
+  });
+
+  it('decodes config, sessions, signups, and members from the grid', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      {
+        scoutid: 10,
+        firstname: 'Simon',
+        lastname: 'Clark',
+        f_1: CONFIG_CELL,
+        f_2: JSON.stringify({ s: 'I', sat: '2026-07-02T10:00:00Z', m: META }),
+      },
+      { scoutid: 11, firstname: 'Alice', lastname: 'Smith', f_1: '', f_2: '' },
+    ]));
+
+    const rota = await loadRota(2026, TOKEN);
+
+    expect(rota.recordId).toBe(777);
+    expect(rota.termId).toBe('T1');
+    expect(rota.config.cfg.start).toBe('2026-06-01');
+    expect(rota.sessions).toHaveLength(1);
+    expect(rota.sessions[0]).toMatchObject({
+      fieldId: 'f_2',
+      date: '2026-07-14',
+      sectionId: '49097',
+    });
+    expect(rota.sessions[0].meta.act).toBe('Kayaking');
+    expect(rota.sessions[0].signups).toEqual([
+      { scoutid: '10', name: 'Simon Clark', status: 'I', at: '2026-07-02T10:00:00Z' },
+    ]);
+    expect(rota.members).toEqual([
+      { scoutid: '10', name: 'Simon Clark' },
+      { scoutid: '11', name: 'Alice Smith' },
+    ]);
+    expect(databaseService.saveFlexiData).toHaveBeenCalledWith(777, 900, 'T1', expect.any(Array));
+  });
+
+  it('returns null when no rota record exists', async () => {
+    getFlexiRecords.mockResolvedValue({ items: [] });
+    expect(await loadRota(2026, TOKEN)).toBeNull();
+  });
+
+  it('throws when the record structure is missing RotaConfig', async () => {
+    getFlexiStructure.mockResolvedValue({
+      config: JSON.stringify([{ id: 'f_2', name: 'S_20260714_49097' }]),
+    });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([]));
+
+    await expect(loadRota(2026, TOKEN)).rejects.toThrow(/RotaConfig/);
+  });
+});
+
+describe('writeSignup', () => {
+  const rota = { hostSection: HOST_SECTION, recordId: 777, termId: 'T1' };
+
+  it('re-fetches live, preserves own metadata, writes one cell, patches cache', async () => {
+    const ownCell = JSON.stringify({ m: META });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_2: ownCell },
+    ]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+    databaseService.getFlexiData.mockResolvedValue({
+      items: [{ scoutid: 10, f_2: ownCell }],
+    });
+
+    await writeSignup({ rota, fieldId: 'f_2', scoutid: 10, status: SIGNUP_STATUS.IN, token: TOKEN });
+
+    expect(updateFlexiRecord).toHaveBeenCalledTimes(1);
+    const [sectionid, scoutid, recordId, columnid, value, termid, section] =
+      updateFlexiRecord.mock.calls[0];
+    expect([sectionid, scoutid, recordId, columnid, termid, section]).toEqual([
+      900, 10, 777, 'f_2', 'T1', 'adults',
+    ]);
+    const written = JSON.parse(value);
+    expect(written.s).toBe('I');
+    expect(written.m).toEqual(META);
+
+    const [, , , savedItems] = databaseService.saveFlexiData.mock.calls.at(-1);
+    expect(savedItems[0].f_2).toBe(value);
+  });
+
+  it('throws when the caller has no row in the host section', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 99, f_2: '' }]));
+
+    await expect(
+      writeSignup({ rota, fieldId: 'f_2', scoutid: 10, status: SIGNUP_STATUS.IN, token: TOKEN }),
+    ).rejects.toThrow(/member row/);
+    expect(updateFlexiRecord).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid statuses without touching the network', async () => {
+    await expect(
+      writeSignup({ rota, fieldId: 'f_2', scoutid: 10, status: 'X', token: TOKEN }),
+    ).rejects.toThrow(/Invalid signup status/);
+    expect(getSingleFlexiRecord).not.toHaveBeenCalled();
+  });
+
+  it('propagates write failures (offline / permission)', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_2: '' }]));
+    const offline = new Error('writeSignup: cannot send write - offline');
+    offline.code = 'WRITE_UNAVAILABLE';
+    updateFlexiRecord.mockRejectedValue(offline);
+
+    await expect(
+      writeSignup({ rota, fieldId: 'f_2', scoutid: 10, status: SIGNUP_STATUS.IN, token: TOKEN }),
+    ).rejects.toThrow(/offline/);
+  });
+
+  it('serializes concurrent writes through the lock', async () => {
+    const order = [];
+    getSingleFlexiRecord.mockImplementation(async () => {
+      order.push('fetch');
+      return gridWith([{ scoutid: 10, f_2: '' }]);
+    });
+    updateFlexiRecord.mockImplementation(async () => {
+      order.push('update');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return { ok: true };
+    });
+
+    await Promise.all([
+      writeSignup({ rota, fieldId: 'f_2', scoutid: 10, status: SIGNUP_STATUS.IN, token: TOKEN }),
+      writeSignup({ rota, fieldId: 'f_2', scoutid: 10, status: SIGNUP_STATUS.BACKUP, token: TOKEN }),
+    ]);
+
+    expect(order).toEqual(['fetch', 'update', 'fetch', 'update']);
+  });
+});
+
+describe('writeSessionMeta', () => {
+  const rota = { hostSection: HOST_SECTION, recordId: 777, termId: 'T1' };
+
+  it('bumps the version above the live column winner and preserves own signup', async () => {
+    const ownCell = JSON.stringify({ s: 'B', sat: '2026-07-01T08:00:00Z' });
+    const rivalCell = JSON.stringify({ m: { ...META, v: 5, by: 'Rival Leader' } });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, f_2: ownCell },
+      { scoutid: 11, f_2: rivalCell },
+    ]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeSessionMeta({
+      rota,
+      fieldId: 'f_2',
+      scoutid: 10,
+      by: 'Simon Clark',
+      fields: { act: 'Rafting', st: '18:00', en: '19:15', k: 20, p: 2, c: 0 },
+      token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.m.v).toBe(6);
+    expect(written.m.act).toBe('Rafting');
+    expect(written.m.by).toBe('Simon Clark');
+    expect(written.s).toBe('B');
+    expect(written.sat).toBe('2026-07-01T08:00:00Z');
+  });
+});

--- a/src/features/water-rota/services/__tests__/rotaSetupService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaSetupService.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { API: 'API', APP: 'APP', ERROR: 'ERROR' },
+}));
+
+vi.mock('../../../flexi-records/services/flexiRecordCreationService.js', () => ({
+  createOrCompleteFlexiRecord: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/api/api/index.js', () => ({
+  getFlexiRecords: vi.fn(),
+  getFlexiStructure: vi.fn(),
+  getSingleFlexiRecord: vi.fn(),
+  updateFlexiRecord: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/storage/database.js', () => ({
+  default: {
+    getSections: vi.fn(),
+    getFlexiData: vi.fn().mockResolvedValue(null),
+    saveFlexiData: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../shared/services/storage/currentActiveTermsService.js', () => ({
+  CurrentActiveTermsService: { getCurrentActiveTerm: vi.fn() },
+}));
+
+import { createOrCompleteFlexiRecord } from '../../../flexi-records/services/flexiRecordCreationService.js';
+import {
+  getFlexiStructure,
+  getSingleFlexiRecord,
+  updateFlexiRecord,
+} from '../../../../shared/services/api/api/index.js';
+import { createOrCompleteRota, diffSessions, writeRotaConfig } from '../rotaSetupService.js';
+
+const HOST_SECTION = { sectionid: 900, sectionname: 'Adults', section: 'adults' };
+
+const SESSIONS = [
+  { date: '2026-06-02', sectionId: '49097', sectionName: 'Cubs', startTime: '18:15', endTime: '19:30', activity: 'Kayaking', title: null },
+  { date: '2026-06-05', sectionId: '49099', sectionName: 'Scouts', startTime: '19:00', endTime: '20:30', activity: 'Bell boats', title: null },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createOrCompleteRota', () => {
+  it('builds a template with the config column plus one column per session', async () => {
+    createOrCompleteFlexiRecord.mockResolvedValue({ success: true, flexirecordid: 777 });
+
+    const result = await createOrCompleteRota({
+      hostSection: HOST_SECTION,
+      year: 2026,
+      termId: 'T1',
+      sessions: SESSIONS,
+      token: 'tok',
+    });
+
+    expect(result.flexirecordid).toBe(777);
+    const { section, template, termId } = createOrCompleteFlexiRecord.mock.calls[0][0];
+    expect(section).toBe(HOST_SECTION);
+    expect(termId).toBe('T1');
+    expect(template.name).toBe('Viking Water Rota 2026');
+    expect(template.fields).toEqual(['RotaConfig', 'S_20260602_49097', 'S_20260605_49099']);
+  });
+
+  it('surfaces partial failure results untouched so callers can retry', async () => {
+    const partial = { success: false, flexirecordid: 777, errors: [{ field: 'S_20260605_49099', error: 'boom' }] };
+    createOrCompleteFlexiRecord.mockResolvedValue(partial);
+
+    const result = await createOrCompleteRota({
+      hostSection: HOST_SECTION,
+      year: 2026,
+      termId: 'T1',
+      sessions: SESSIONS,
+      token: 'tok',
+    });
+
+    expect(result).toBe(partial);
+  });
+});
+
+describe('writeRotaConfig', () => {
+  it('resolves the RotaConfig field id and writes the LWW config candidate', async () => {
+    getFlexiStructure.mockResolvedValue({
+      config: JSON.stringify([{ id: 'f_9', name: 'RotaConfig' }]),
+    });
+    getSingleFlexiRecord.mockResolvedValue({
+      items: [{ scoutid: 10, f_9: '' }],
+    });
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    const cfg = {
+      start: '2026-06-01',
+      end: '2026-08-31',
+      sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
+    };
+
+    await writeRotaConfig({
+      hostSection: HOST_SECTION,
+      recordId: 777,
+      termId: 'T1',
+      scoutid: 10,
+      by: 'Simon Clark',
+      cfg,
+      token: 'tok',
+    });
+
+    expect(getFlexiStructure).toHaveBeenCalledWith(777, 900, 'T1', 'tok', true);
+    const [, , , columnid, value] = updateFlexiRecord.mock.calls[0];
+    expect(columnid).toBe('f_9');
+    const written = JSON.parse(value);
+    expect(written.v).toBe(1);
+    expect(written.cfg).toEqual(cfg);
+  });
+
+  it('throws when the record has no RotaConfig column', async () => {
+    getFlexiStructure.mockResolvedValue({
+      config: JSON.stringify([{ id: 'f_2', name: 'S_20260714_49097' }]),
+    });
+
+    await expect(
+      writeRotaConfig({
+        hostSection: HOST_SECTION,
+        recordId: 777,
+        termId: 'T1',
+        scoutid: 10,
+        by: 'Simon Clark',
+        cfg: { start: '2026-06-01', end: '2026-08-31', sections: [] },
+        token: 'tok',
+      }),
+    ).rejects.toThrow(/RotaConfig column not found/);
+  });
+});
+
+describe('diffSessions', () => {
+  const existing = [
+    { fieldId: 'f_2', date: '2026-06-02', sectionId: '49097' },
+    { fieldId: 'f_3', date: '2026-06-09', sectionId: '49097' },
+  ];
+
+  it('identifies new descriptors and orphaned columns', () => {
+    const descriptors = [
+      { date: '2026-06-02', sectionId: '49097' },
+      { date: '2026-06-16', sectionId: '49097' },
+    ];
+
+    const { toAdd, orphaned } = diffSessions(existing, descriptors);
+    expect(toAdd.map((d) => d.date)).toEqual(['2026-06-16']);
+    expect(orphaned.map((c) => c.date)).toEqual(['2026-06-09']);
+  });
+
+  it('returns empty diffs when everything matches', () => {
+    const descriptors = [
+      { date: '2026-06-02', sectionId: '49097' },
+      { date: '2026-06-09', sectionId: '49097' },
+    ];
+    expect(diffSessions(existing, descriptors)).toEqual({ toAdd: [], orphaned: [] });
+  });
+
+  it('handles empty inputs', () => {
+    expect(diffSessions([], [])).toEqual({ toAdd: [], orphaned: [] });
+    expect(diffSessions(undefined, undefined)).toEqual({ toAdd: [], orphaned: [] });
+  });
+});

--- a/src/features/water-rota/services/index.js
+++ b/src/features/water-rota/services/index.js
@@ -1,4 +1,6 @@
 export * from './programmeService.js';
 export * from './rotaEncoding.js';
+export * from './rotaService.js';
+export * from './rotaSetupService.js';
 export * from './rotaTemplates.js';
 export * from './vikingWaterRotaValidation.js';

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -1,0 +1,368 @@
+/**
+ * Water Rota data service: discovers the yearly rota FlexiRecord across the
+ * user's sections, loads and decodes it, and performs the three rota writes
+ * (signup, session metadata, plan config).
+ *
+ * Write discipline (PRD §5.4 freshness constraint): every write re-fetches
+ * the live grid, merges into the writer's OWN cell only (preserving whatever
+ * else that cell holds), sends a single updateFlexiRecord, then patches the
+ * local cache optimistically. Writes are serialized through a module-level
+ * promise-chain lock so two in-flight writes cannot interleave their
+ * read-merge-write cycles. Rota writes are online-only — offline attempts
+ * throw WRITE_UNAVAILABLE from the API layer.
+ *
+ * @module rotaService
+ */
+
+import {
+  getFlexiRecords,
+  getFlexiStructure,
+  getSingleFlexiRecord,
+  updateFlexiRecord,
+} from '../../../shared/services/api/api/index.js';
+import databaseService from '../../../shared/services/storage/database.js';
+import { CurrentActiveTermsService } from '../../../shared/services/storage/currentActiveTermsService.js';
+import { parseFlexiStructure } from '../../../shared/utils/flexiRecordTransforms.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+import {
+  ROTA_CONFIG_COLUMN,
+  SIGNUP_STATUS,
+  encodeConfig,
+  encodeSessionMeta,
+  encodeSignup,
+  mergeLwwConfig,
+  mergeSessionColumn,
+} from './rotaEncoding.js';
+import { buildRotaRecordName } from './rotaTemplates.js';
+import { validateWaterRotaStructure } from './vikingWaterRotaValidation.js';
+
+let writeLock = Promise.resolve();
+
+/**
+ * Serialize rota writes so concurrent read-merge-write cycles cannot
+ * interleave (same pattern as signInOutbox's withStoreLock).
+ *
+ * @param {Function} fn - Async operation to run under the lock
+ * @returns {Promise<*>} The operation's result
+ */
+function withWriteLock(fn) {
+  const run = writeLock.then(fn);
+  writeLock = run.then(() => undefined, () => undefined);
+  return run;
+}
+
+/**
+ * A loaded, decoded rota.
+ *
+ * @typedef {Object} LoadedRota
+ * @property {number} year - Rota calendar year
+ * @property {Object} hostSection - Section the record lives in ({sectionid, sectionname, section, ...})
+ * @property {string|number} recordId - FlexiRecord id (extraid)
+ * @property {string} termId - Term id used for grid reads
+ * @property {Object|null} config - LWW-winning plan config candidate ({v, at, by, cfg}), null before first config write
+ * @property {Array<Object>} sessions - Decoded sessions ({fieldId, date, sectionId, meta, signups})
+ * @property {Array<{scoutid: string, name: string}>} members - Host-section member rows
+ */
+
+/**
+ * Find the rota FlexiRecord for a year by scanning the user's sections.
+ *
+ * @param {number} year - Calendar year
+ * @param {string} token - OSM authentication token
+ * @returns {Promise<{hostSection: Object, recordId: string|number}|null>} Discovery result, or null when no rota exists
+ */
+export async function discoverRotaRecord(year, token) {
+  const recordName = buildRotaRecordName(year);
+  const sections = (await databaseService.getSections()) || [];
+
+  for (const section of sections) {
+    try {
+      const list = await getFlexiRecords(section.sectionid, token);
+      const match = (list?.items || []).find((record) => record.name === recordName);
+      if (match) {
+        return { hostSection: section, recordId: match.extraid };
+      }
+    } catch (error) {
+      logger.warn('Rota discovery: flexi list read failed for section', {
+        sectionId: section.sectionid,
+        error: error.message,
+      }, LOG_CATEGORIES.API);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the term id to use for rota grid reads on the host section.
+ *
+ * @param {string|number} hostSectionId - Host section id
+ * @returns {Promise<string|null>} Current active term id, or null when unknown
+ */
+export async function resolveRotaTermId(hostSectionId) {
+  try {
+    const term = await CurrentActiveTermsService.getCurrentActiveTerm(hostSectionId);
+    return term?.currentTermId ?? null;
+  } catch (error) {
+    logger.warn('Rota: current active term lookup failed', {
+      hostSectionId,
+      error: error.message,
+    }, LOG_CATEGORIES.ERROR);
+    return null;
+  }
+}
+
+/**
+ * Load and decode the rota for a year: discovery, structure validation,
+ * LWW config merge, and per-session column merges. Persists the fetched
+ * grid to the flexi cache so the board renders offline afterwards.
+ *
+ * @param {number} year - Calendar year
+ * @param {string} token - OSM authentication token
+ * @returns {Promise<LoadedRota|null>} Decoded rota, or null when none exists for the year
+ * @throws {Error} When the record exists but its structure is invalid or unreadable
+ */
+export async function loadRota(year, token) {
+  const discovery = await discoverRotaRecord(year, token);
+  if (!discovery) {
+    return null;
+  }
+
+  const { hostSection, recordId } = discovery;
+  const termId = await resolveRotaTermId(hostSection.sectionid);
+  if (!termId) {
+    throw new Error('No active term found for the rota host section');
+  }
+
+  const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token);
+  const structure = decodeStructure(structureData);
+  const check = validateWaterRotaStructure(structure);
+  if (!check.isValid) {
+    throw new Error(`Water rota record is invalid: ${check.errors.join('; ')}`);
+  }
+
+  const grid = await getSingleFlexiRecord(recordId, hostSection.sectionid, termId, token);
+  const items = Array.isArray(grid?.items) ? grid.items : [];
+
+  try {
+    await databaseService.saveFlexiData(recordId, hostSection.sectionid, termId, items);
+  } catch (error) {
+    logger.warn('Rota: caching grid for offline use failed', {
+      error: error.message,
+    }, LOG_CATEGORIES.ERROR);
+  }
+
+  const config = mergeLwwConfig(items.map((item) => item[check.configFieldId]));
+
+  const sessions = check.sessionColumns.map((column) => {
+    const { meta, signups } = mergeSessionColumn(
+      items.map((item) => ({
+        scoutid: item.scoutid,
+        name: memberName(item),
+        value: item[column.fieldId],
+      })),
+    );
+    return { ...column, meta, signups };
+  });
+
+  const members = items.map((item) => ({
+    scoutid: String(item.scoutid),
+    name: memberName(item),
+  }));
+
+  return { year, hostSection, recordId, termId, config, sessions, members };
+}
+
+/**
+ * Write the caller's signup for one session into their own row.
+ *
+ * @param {Object} params
+ * @param {LoadedRota} params.rota - Loaded rota (host section, record, term)
+ * @param {string} params.fieldId - Session column field id (f_N)
+ * @param {string|number} params.scoutid - The caller's member row id in the host section
+ * @param {string|null} params.status - SIGNUP_STATUS.IN, SIGNUP_STATUS.BACKUP, or null to withdraw
+ * @param {string} params.token - OSM authentication token
+ * @returns {Promise<void>}
+ */
+export async function writeSignup({ rota, fieldId, scoutid, status, token }) {
+  if (status !== null && !Object.values(SIGNUP_STATUS).includes(status)) {
+    throw new Error(`Invalid signup status: ${status}`);
+  }
+  await writeOwnCell({
+    rota,
+    fieldId,
+    scoutid,
+    token,
+    mutate: (ownRaw) => encodeSignup(ownRaw, status, new Date().toISOString()),
+  });
+}
+
+/**
+ * Write a session-metadata update into the editor's own row, bumping the
+ * LWW version above the current column winner read live inside the lock.
+ *
+ * @param {Object} params
+ * @param {LoadedRota} params.rota - Loaded rota
+ * @param {string} params.fieldId - Session column field id (f_N)
+ * @param {string|number} params.scoutid - The editor's member row id
+ * @param {string} params.by - Editor display name for the audit trail
+ * @param {{act: string, st: string, en: string, k: number, p: number, n?: string, c: 0|1}} params.fields - Full metadata fields
+ * @param {string} params.token - OSM authentication token
+ * @returns {Promise<void>}
+ */
+export async function writeSessionMeta({ rota, fieldId, scoutid, by, fields, token }) {
+  await writeOwnCell({
+    rota,
+    fieldId,
+    scoutid,
+    token,
+    mutate: (ownRaw, items) => {
+      const { meta: winner } = mergeSessionColumn(
+        items.map((item) => ({ scoutid: item.scoutid, name: '', value: item[fieldId] })),
+      );
+      const meta = {
+        ...fields,
+        v: (winner?.v ?? 0) + 1,
+        at: new Date().toISOString(),
+        by,
+      };
+      return encodeSessionMeta(ownRaw, meta);
+    },
+  });
+}
+
+/**
+ * Write a whole-plan config candidate into the editor's own RotaConfig cell,
+ * bumping the LWW version above the current winner read live inside the lock.
+ *
+ * @param {Object} params
+ * @param {LoadedRota} params.rota - Loaded rota
+ * @param {string} params.configFieldId - RotaConfig column field id (f_N)
+ * @param {string|number} params.scoutid - The editor's member row id
+ * @param {string} params.by - Editor display name
+ * @param {Object} params.cfg - Full plan config ({start, end, termId?, sections})
+ * @param {string} params.token - OSM authentication token
+ * @returns {Promise<void>}
+ */
+export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, token }) {
+  await writeOwnCell({
+    rota,
+    fieldId: configFieldId,
+    scoutid,
+    token,
+    mutate: (_ownRaw, items) => {
+      const winner = mergeLwwConfig(items.map((item) => item[configFieldId]));
+      return encodeConfig({
+        v: (winner?.v ?? 0) + 1,
+        at: new Date().toISOString(),
+        by,
+        cfg,
+      });
+    },
+  });
+}
+
+/**
+ * Shared write cycle: under the write lock, re-fetch the live grid, compute
+ * the caller's new own-cell value, send one updateFlexiRecord, then patch
+ * the local flexi cache so the UI reflects the write immediately.
+ *
+ * @param {Object} params
+ * @param {LoadedRota} params.rota - Loaded rota
+ * @param {string} params.fieldId - Column field id being written
+ * @param {string|number} params.scoutid - The caller's member row id
+ * @param {string} params.token - OSM authentication token
+ * @param {(ownRaw: string|undefined, items: Array<Object>) => string} params.mutate - Computes the new cell value from the fresh grid
+ * @returns {Promise<void>}
+ */
+async function writeOwnCell({ rota, fieldId, scoutid, token, mutate }) {
+  const { hostSection, recordId, termId } = rota;
+
+  await withWriteLock(async () => {
+    const fresh = await getSingleFlexiRecord(recordId, hostSection.sectionid, termId, token);
+    const items = Array.isArray(fresh?.items) ? fresh.items : [];
+    const ownRow = items.find((item) => String(item.scoutid) === String(scoutid));
+    if (!ownRow) {
+      throw new Error('Your member row was not found in the rota host section');
+    }
+
+    const newValue = mutate(ownRow[fieldId], items);
+
+    await updateFlexiRecord(
+      hostSection.sectionid,
+      scoutid,
+      recordId,
+      fieldId,
+      newValue,
+      termId,
+      hostSection.section,
+      token,
+    );
+
+    await patchLocalCache({ recordId, hostSection, termId, scoutid, fieldId, newValue });
+  });
+}
+
+/**
+ * Optimistically patch one cell in the locally cached grid (same pattern as
+ * signInOutbox.applyLocal). Failures are logged, never thrown — the write
+ * itself already succeeded.
+ *
+ * @param {Object} params
+ * @param {string|number} params.recordId - FlexiRecord id
+ * @param {Object} params.hostSection - Host section
+ * @param {string} params.termId - Term id
+ * @param {string|number} params.scoutid - Member row id
+ * @param {string} params.fieldId - Column field id
+ * @param {string} params.newValue - New raw cell value
+ * @returns {Promise<void>}
+ */
+async function patchLocalCache({ recordId, hostSection, termId, scoutid, fieldId, newValue }) {
+  try {
+    const cached = await databaseService.getFlexiData(recordId, hostSection.sectionid, termId);
+    const items = Array.isArray(cached?.items) ? [...cached.items] : [];
+    const idx = items.findIndex((item) => String(item.scoutid) === String(scoutid));
+    if (idx >= 0) {
+      items[idx] = { ...items[idx], [fieldId]: newValue };
+    } else {
+      items.push({ scoutid, [fieldId]: newValue });
+    }
+    await databaseService.saveFlexiData(recordId, hostSection.sectionid, termId, items);
+  } catch (error) {
+    logger.error('Rota: optimistic cache patch failed', {
+      error: error.message,
+      fieldId,
+    }, LOG_CATEGORIES.ERROR);
+  }
+}
+
+/**
+ * Normalize a raw structure response into the {fieldMapping} shape the
+ * validator consumes, reusing the shared flexi structure parser.
+ *
+ * @param {Object|null} structureData - Raw getFlexiStructure response
+ * @returns {{fieldMapping: Object}|null} Normalized structure, or null
+ */
+function decodeStructure(structureData) {
+  if (!structureData) {
+    return null;
+  }
+  const mapping = parseFlexiStructure(structureData);
+  const fieldMapping = {};
+  mapping.forEach((fieldInfo, fieldId) => {
+    fieldMapping[fieldId] = fieldInfo;
+  });
+  return { fieldMapping };
+}
+
+/**
+ * Display name for a grid row member.
+ *
+ * @param {Object} item - Grid row item
+ * @returns {string} "First Last" (best effort)
+ */
+function memberName(item) {
+  return [item.firstname, item.lastname].filter(Boolean).join(' ').trim();
+}
+
+export { ROTA_CONFIG_COLUMN };

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -1,0 +1,130 @@
+/**
+ * Water Rota setup: creates (or completes) the yearly rota FlexiRecord with
+ * one column per planned session, writes the initial plan config, and diffs
+ * an existing rota against freshly generated sessions for programme sync.
+ *
+ * Creation is resumable and idempotent — it reuses the flexi-records
+ * create-or-complete orchestrator, which only adds missing columns and
+ * returns per-column errors on partial failure. That matters here because
+ * OSM has no column delete: an aborted run must be completable, never
+ * duplicated.
+ *
+ * @module rotaSetupService
+ */
+
+import { createOrCompleteFlexiRecord } from '../../flexi-records/services/flexiRecordCreationService.js';
+import {
+  getFlexiStructure,
+} from '../../../shared/services/api/api/index.js';
+import { parseFlexiStructure } from '../../../shared/utils/flexiRecordTransforms.js';
+import {
+  ROTA_CONFIG_COLUMN,
+  buildSessionColumnName,
+  parseSessionColumnName,
+} from './rotaEncoding.js';
+import { ROTA_CREATE_OPTIONS, buildRotaRecordName } from './rotaTemplates.js';
+import { writeConfig } from './rotaService.js';
+
+/**
+ * Create or complete the rota record for a year on the host section.
+ *
+ * @param {Object} params
+ * @param {Object} params.hostSection - Host section ({sectionid, sectionname, section})
+ * @param {number} params.year - Calendar year the rota covers
+ * @param {string|number} params.termId - Term id for structure reads
+ * @param {import('../utils/rotaDates.js').SessionDescriptor[]} params.sessions - Sessions to create columns for
+ * @param {string} params.token - OSM authentication token
+ * @returns {Promise<import('../../flexi-records/services/flexiRecordCreationService.js').CreationResult>} Per-column result; success=false with errors on partial failure (safe to re-run)
+ */
+export async function createOrCompleteRota({ hostSection, year, termId, sessions, token }) {
+  const template = {
+    name: buildRotaRecordName(year),
+    fields: [
+      ROTA_CONFIG_COLUMN,
+      ...sessions.map((session) => buildSessionColumnName(session.date, session.sectionId)),
+    ],
+    createOptions: ROTA_CREATE_OPTIONS,
+  };
+
+  return createOrCompleteFlexiRecord({ section: hostSection, template, termId, token });
+}
+
+/**
+ * Write the initial (or updated) plan config after the record exists.
+ * Reads the structure fresh to resolve the RotaConfig column id, then
+ * delegates to the standard LWW config write.
+ *
+ * @param {Object} params
+ * @param {Object} params.hostSection - Host section
+ * @param {string|number} params.recordId - FlexiRecord id from creation
+ * @param {string|number} params.termId - Term id
+ * @param {string|number} params.scoutid - The editor's member row id in the host section
+ * @param {string} params.by - Editor display name
+ * @param {Object} params.cfg - Full plan config ({start, end, termId?, sections})
+ * @param {string} params.token - OSM authentication token
+ * @returns {Promise<void>}
+ * @throws {Error} When the RotaConfig column cannot be found
+ */
+export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, token }) {
+  const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, true);
+  const configFieldId = findConfigFieldId(structureData);
+  if (!configFieldId) {
+    throw new Error('RotaConfig column not found on the rota record');
+  }
+
+  await writeConfig({
+    rota: { hostSection, recordId, termId },
+    configFieldId,
+    scoutid,
+    by,
+    cfg,
+    token,
+  });
+}
+
+/**
+ * Diff generated session descriptors against the columns already on the
+ * record. Pure. Used both by setup re-entry and "Sync from programme".
+ *
+ * @param {Array<{fieldId: string, date: string, sectionId: string}>} existingColumns - Session columns from validateWaterRotaStructure
+ * @param {import('../utils/rotaDates.js').SessionDescriptor[]} descriptors - Freshly generated sessions
+ * @returns {{toAdd: Array, orphaned: Array}} Descriptors needing new columns, and existing columns with no matching descriptor (candidates to mark not-on-water)
+ */
+export function diffSessions(existingColumns, descriptors) {
+  const existingNames = new Set(
+    (existingColumns ?? []).map((column) => buildSessionColumnName(column.date, column.sectionId)),
+  );
+  const descriptorNames = new Set(
+    (descriptors ?? []).map((descriptor) => buildSessionColumnName(descriptor.date, descriptor.sectionId)),
+  );
+
+  const toAdd = (descriptors ?? []).filter(
+    (descriptor) => !existingNames.has(buildSessionColumnName(descriptor.date, descriptor.sectionId)),
+  );
+  const orphaned = (existingColumns ?? []).filter(
+    (column) => !descriptorNames.has(buildSessionColumnName(column.date, column.sectionId)),
+  );
+
+  return { toAdd, orphaned };
+}
+
+/**
+ * Resolve the RotaConfig column id from a raw structure response.
+ *
+ * @param {Object|null} structureData - Raw getFlexiStructure response
+ * @returns {string|null} Field id (f_N), or null when absent
+ */
+function findConfigFieldId(structureData) {
+  if (!structureData) {
+    return null;
+  }
+  const mapping = parseFlexiStructure(structureData);
+  for (const [fieldId, fieldInfo] of mapping.entries()) {
+    if (fieldInfo?.name === ROTA_CONFIG_COLUMN) {
+      return fieldId;
+    }
+  }
+  return null;
+}
+
+export { parseSessionColumnName };


### PR DESCRIPTION
## Summary

Third PR in the Water Rota stack (#211 → #212 → this). Implements the data layer between the FlexiRecord encoding and the upcoming UI:

- **`rotaService.js`** — discovers the yearly `Viking Water Rota <year>` record across the user's sections, loads and decodes it (structure validation, LWW config merge, per-session column merge, member list), and performs the three writes: signup, session metadata, plan config. Every write runs under a promise-chain lock (same pattern as `signInOutbox.withStoreLock`), re-fetches the live grid, merges **only the caller's own cell** (preserving signup when writing metadata and vice versa), sends one `updateFlexiRecord`, then optimistically patches the local flexi cache. Metadata/config writes bump the LWW version above the live winner read inside the lock — a concurrent edit from another device can't be silently overwritten with a stale version number.
- **`rotaSetupService.js`** — resumable record creation reusing `createOrCompleteFlexiRecord` (idempotent; only adds missing columns — essential since OSM has no column delete), initial config write, and pure `diffSessions` for "Sync from programme" (new meetings → columns to add; vanished meetings → suggest not-on-water).

## Test plan

- 19 new Vitest tests: discovery across sections (incl. failed section reads), full grid decode, own-row-missing and invalid-status guards, own-cell metadata preservation, LWW version bump over a rival's live edit, write-lock serialization (fetch/update ordering), offline write propagation, partial-failure passthrough, sync diffing.
- `npm run lint` ✅ (0 errors) · `npm run test:run` ✅ (736 passed) · `npm run build` ✅

**Stacked on #212** — merge in order #211 → #212 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR