### PR TITLE
feat: water rota board UI (read-only)

### DIFF
--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { format, parseISO } from 'date-fns';
+import { useNavigate } from 'react-router-dom';
+import SectionFilter from '../../../shared/components/ui/SectionFilter.jsx';
+import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
+import { useWaterRota } from '../hooks/useWaterRota.js';
+import { resolveAllSessions } from '../utils/rotaDisplay.js';
+import { bucketSessionsByWeek, startOfIsoWeek } from '../utils/rotaDates.js';
+import SessionCard from './SessionCard.jsx';
+import TermOverviewStrip from './TermOverviewStrip.jsx';
+
+const FILTERS_STORAGE_KEY = 'viking_water_rota_section_filters';
+
+/**
+ * Read persisted section filters, defaulting to everything visible.
+ *
+ * @returns {Object} Map of sectionId to boolean visibility
+ */
+function readStoredFilters() {
+  try {
+    const raw = localStorage.getItem(FILTERS_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * The rota board: term overview strip plus a week-bucketed session list.
+ * Auto-scrolls to the current week on load. Renders empty/error/first-run
+ * states when there is no rota for the year.
+ *
+ * @param {Object} props
+ * @param {Function} [props.onSelectSession] - Called with a session view when a card is tapped
+ * @returns {JSX.Element} Board page
+ */
+function RotaBoardPage({ onSelectSession }) {
+  const navigate = useNavigate();
+  const { loading, rota, error, refresh, year } = useWaterRota();
+  const [sectionFilters, setSectionFilters] = useState(readStoredFilters);
+  const weekRefs = useRef(new Map());
+  const didAutoScroll = useRef(false);
+
+  const sessions = useMemo(() => (rota ? resolveAllSessions(rota) : []), [rota]);
+
+  const filterSections = useMemo(
+    () =>
+      (rota?.config?.cfg?.sections ?? []).map((entry) => ({
+        sectionid: entry.sid,
+        sectionname: entry.sname,
+      })),
+    [rota],
+  );
+
+  const visibleSessions = useMemo(
+    () => sessions.filter((session) => sectionFilters[session.sectionId] !== false),
+    [sessions, sectionFilters],
+  );
+
+  const weeks = useMemo(() => bucketSessionsByWeek(visibleSessions), [visibleSessions]);
+  const currentWeekStart = startOfIsoWeek(format(new Date(), 'yyyy-MM-dd'));
+
+  useEffect(() => {
+    if (didAutoScroll.current || weeks.length === 0) {
+      return;
+    }
+    const target = weeks.find((week) => week.weekStart >= currentWeekStart) ?? weeks[weeks.length - 1];
+    weekRefs.current.get(target.weekStart)?.scrollIntoView({ block: 'start' });
+    didAutoScroll.current = true;
+  }, [weeks, currentWeekStart]);
+
+  const handleFiltersChange = (filters) => {
+    setSectionFilters(filters);
+    try {
+      localStorage.setItem(FILTERS_STORAGE_KEY, JSON.stringify(filters));
+    } catch {
+      /* non-fatal: filters just won't persist */
+    }
+  };
+
+  const scrollToWeek = (weekStart) => {
+    weekRefs.current.get(weekStart)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  if (loading) {
+    return <LoadingScreen message="Loading water rota..." />;
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-12 text-center">
+        <p className="text-gray-700 font-medium">Couldn&apos;t load the water rota</p>
+        <p className="mt-1 text-sm text-gray-500">{error.message}</p>
+        <button
+          type="button"
+          onClick={refresh}
+          className="mt-4 px-4 py-2 rounded-md bg-scout-blue text-white text-sm font-medium hover:bg-scout-blue-dark"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!rota) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-16 text-center">
+        <div className="text-5xl" aria-hidden="true">🛶</div>
+        <h2 className="mt-4 text-lg font-semibold text-gray-900">
+          No water rota for {year} yet
+        </h2>
+        <p className="mt-2 text-sm text-gray-500">
+          Set up this summer&apos;s on-water sessions from each section&apos;s programme, then
+          permit holders can sign up to cover them.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/water-rota/setup')}
+          className="mt-6 px-5 py-2.5 rounded-md bg-scout-blue text-white text-sm font-semibold hover:bg-scout-blue-dark"
+        >
+          Set up the rota
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-4">
+      <div className="flex items-center justify-between gap-2">
+        <h1 className="text-lg font-semibold text-gray-900">Water Rota {year}</h1>
+        <button
+          type="button"
+          onClick={refresh}
+          className="text-sm text-scout-blue hover:text-scout-blue-dark font-medium"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {filterSections.length > 1 && (
+        <div className="mt-3">
+          <SectionFilter
+            sections={filterSections}
+            sectionFilters={sectionFilters}
+            onFiltersChange={handleFiltersChange}
+          />
+        </div>
+      )}
+
+      <div className="mt-3 sticky top-0 z-10 bg-white/95 backdrop-blur rounded-lg">
+        <TermOverviewStrip
+          weeks={weeks}
+          currentWeekStart={currentWeekStart}
+          onSelectWeek={scrollToWeek}
+        />
+      </div>
+
+      {weeks.length === 0 ? (
+        <p className="mt-8 text-center text-sm text-gray-500">
+          No sessions match the current filters.
+        </p>
+      ) : (
+        <div className="mt-2 space-y-6 pb-12">
+          {weeks.map(({ weekStart, sessions: weekSessions }) => (
+            <section
+              key={weekStart}
+              ref={(node) => {
+                if (node) {
+                  weekRefs.current.set(weekStart, node);
+                } else {
+                  weekRefs.current.delete(weekStart);
+                }
+              }}
+              aria-label={`Week of ${format(parseISO(weekStart), 'd MMMM yyyy')}`}
+            >
+              <h2 className={`text-sm font-semibold py-1.5 ${
+                weekStart === currentWeekStart ? 'text-scout-blue' : 'text-gray-500'
+              }`}>
+                Week of {format(parseISO(weekStart), 'd MMMM')}
+                {weekStart === currentWeekStart && (
+                  <span className="ml-2 text-xs font-medium uppercase tracking-wide">this week</span>
+                )}
+              </h2>
+              <div className="space-y-2">
+                {weekSessions.map((session) => (
+                  <SessionCard key={session.fieldId} session={session} onSelect={onSelectSession} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default RotaBoardPage;

--- a/src/features/water-rota/components/SessionCard.jsx
+++ b/src/features/water-rota/components/SessionCard.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { format, parseISO } from 'date-fns';
+import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
+import { coverStatusBgClass, sectionChipClass, COVER_STATUS } from '../utils/rotaDisplay.js';
+
+const MAX_AVATARS = 4;
+
+/**
+ * One session on the rota board: cover-status rail, section chip, date and
+ * times, activity, expected young people, and the permit-holder cover line
+ * with an overlapping avatar cluster (backups get a dashed ring).
+ *
+ * @param {Object} props
+ * @param {import('../utils/rotaDisplay.js').SessionView} props.session - Resolved session view model
+ * @param {Function} [props.onSelect] - Called with the session when the card is tapped
+ * @returns {JSX.Element} Session card
+ */
+function SessionCard({ session, onSelect }) {
+  const {
+    date,
+    sectionName,
+    activity,
+    startTime,
+    endTime,
+    kids,
+    needed,
+    cancelled,
+    hasMeta,
+    confirmed,
+    backups,
+    status,
+  } = session;
+
+  const people = [...confirmed, ...backups];
+  const overflow = people.length - MAX_AVATARS;
+  const timeLabel = startTime && endTime ? `${startTime}–${endTime}` : startTime || '';
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(session)}
+      data-testid={`session-${session.fieldId}`}
+      className={`relative w-full text-left bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden focus:outline-none focus:ring-2 focus:ring-scout-blue ${
+        cancelled ? 'opacity-60' : ''
+      }`}
+    >
+      <span className={`absolute inset-y-0 left-0 w-1.5 ${coverStatusBgClass(status)}`} aria-hidden="true" />
+
+      <span className="block pl-4 pr-3 py-3">
+        <span className="flex items-center gap-2 flex-wrap">
+          <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${sectionChipClass(sectionName)}`}>
+            {sectionName}
+          </span>
+          <span className={`text-sm font-medium text-gray-900 ${cancelled ? 'line-through' : ''}`}>
+            {format(parseISO(date), 'EEE d MMM')}
+          </span>
+          {timeLabel && (
+            <span className="text-sm text-gray-500">{timeLabel}</span>
+          )}
+          {cancelled && (
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+              Not on water
+            </span>
+          )}
+        </span>
+
+        {!cancelled && (
+          <span className="mt-1 flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-800">
+              {activity || 'Activity not set'}
+            </span>
+            {kids !== null && (
+              <span className="text-xs text-gray-500">~{kids} YP</span>
+            )}
+          </span>
+        )}
+
+        {!cancelled && (
+          <span className="mt-2 flex items-center justify-between">
+            <span className="text-sm text-gray-700">
+              {status === COVER_STATUS.UNSET && !hasMeta ? (
+                <span className="text-gray-400 italic">Needs setting up</span>
+              ) : needed === null ? (
+                <span className="text-gray-400 italic">Permit holders not set</span>
+              ) : (
+                <>
+                  <span className="font-semibold">{confirmed.length}</span>
+                  {` of ${needed} permit holder${needed === 1 ? '' : 's'}`}
+                  {backups.length > 0 && (
+                    <span className="text-gray-500">{` · ${backups.length} backup${backups.length === 1 ? '' : 's'}`}</span>
+                  )}
+                </>
+              )}
+            </span>
+
+            {people.length > 0 && (
+              <span className="flex -space-x-2" aria-label={`Signed up: ${people.map((p) => p.name).join(', ')}`}>
+                {people.slice(0, MAX_AVATARS).map((person) => (
+                  <span
+                    key={person.scoutid}
+                    className={`inline-block rounded-full ring-2 ${
+                      person.status === 'B' ? 'ring-gray-400 ring-dashed' : 'ring-white'
+                    }`}
+                  >
+                    <MemberAvatar member={{ name: person.name }} size="sm" />
+                  </span>
+                ))}
+                {overflow > 0 && (
+                  <span className="h-8 w-8 rounded-full bg-gray-200 text-gray-700 text-xs font-medium flex items-center justify-center ring-2 ring-white">
+                    +{overflow}
+                  </span>
+                )}
+              </span>
+            )}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+export default SessionCard;

--- a/src/features/water-rota/components/TermOverviewStrip.jsx
+++ b/src/features/water-rota/components/TermOverviewStrip.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { format, parseISO } from 'date-fns';
+import { coverStatusBgClass } from '../utils/rotaDisplay.js';
+
+/**
+ * Horizontally scrollable term overview: one narrow column per week, one
+ * status dot per session. The whole-term "do I have enough cover" answer
+ * in a glance; tapping a week scrolls the board to it.
+ *
+ * @param {Object} props
+ * @param {Array<{weekStart: string, sessions: Array}>} props.weeks - Week buckets of resolved session views
+ * @param {string} props.currentWeekStart - Monday of the current week (yyyy-mm-dd)
+ * @param {Function} [props.onSelectWeek] - Called with a weekStart when tapped
+ * @returns {JSX.Element|null} Strip, or null with no weeks
+ */
+function TermOverviewStrip({ weeks, currentWeekStart, onSelectWeek }) {
+  if (!weeks || weeks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="overflow-x-auto pb-1" role="navigation" aria-label="Term overview">
+      <div className="flex gap-1.5 min-w-max px-1">
+        {weeks.map(({ weekStart, sessions }) => {
+          const isCurrent = weekStart === currentWeekStart;
+          return (
+            <button
+              key={weekStart}
+              type="button"
+              onClick={() => onSelectWeek?.(weekStart)}
+              aria-label={`Week of ${format(parseISO(weekStart), 'd MMMM')}`}
+              className={`flex flex-col items-center gap-1 px-2 py-1.5 rounded-lg border ${
+                isCurrent
+                  ? 'border-scout-blue bg-scout-blue/5'
+                  : 'border-transparent hover:bg-gray-100'
+              }`}
+            >
+              <span className={`text-[11px] font-medium whitespace-nowrap ${isCurrent ? 'text-scout-blue' : 'text-gray-500'}`}>
+                {format(parseISO(weekStart), 'd MMM')}
+              </span>
+              <span className="flex gap-1">
+                {sessions.map((session) => (
+                  <span
+                    key={session.fieldId}
+                    className={`h-2.5 w-2.5 rounded-full ${coverStatusBgClass(session.status)} ${
+                      session.cancelled ? 'opacity-40' : ''
+                    }`}
+                    aria-hidden="true"
+                  />
+                ))}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default TermOverviewStrip;

--- a/src/features/water-rota/components/WaterRotaRouter.jsx
+++ b/src/features/water-rota/components/WaterRotaRouter.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import MainNavigation from '../../../shared/components/layout/MainNavigation.jsx';
+import RotaBoardPage from './RotaBoardPage.jsx';
+
+/**
+ * Nested router for the Water Rota feature. The board is the default view;
+ * My-week and setup routes are added by their own PRs and unknown paths
+ * fall back to the board.
+ *
+ * @returns {JSX.Element} Water rota routes under /water-rota
+ */
+function WaterRotaRouter() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <MainNavigation onNavigateToSectionMovements={() => navigate('/movers')} />
+      <Routes>
+        <Route index element={<RotaBoardPage />} />
+        <Route path="*" element={<Navigate to="/water-rota" replace />} />
+      </Routes>
+    </>
+  );
+}
+
+export default WaterRotaRouter;

--- a/src/features/water-rota/components/__tests__/SessionCard.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionCard.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import SessionCard from '../SessionCard.jsx';
+import { COVER_STATUS } from '../../utils/rotaDisplay.js';
+
+function makeSession(overrides = {}) {
+  return {
+    fieldId: 'f_2',
+    date: '2026-07-14',
+    sectionId: '49097',
+    sectionName: 'Cubs',
+    activity: 'Kayaking',
+    startTime: '18:15',
+    endTime: '19:30',
+    kids: 24,
+    needed: 3,
+    notes: '',
+    cancelled: false,
+    hasMeta: true,
+    confirmed: [
+      { scoutid: '1', name: 'Alice Smith', status: 'I', at: null },
+      { scoutid: '2', name: 'Bob Jones', status: 'I', at: null },
+    ],
+    backups: [{ scoutid: '3', name: 'Cara Lee', status: 'B', at: null }],
+    status: COVER_STATUS.AT_RISK,
+    ...overrides,
+  };
+}
+
+describe('SessionCard', () => {
+  it('shows section, date, times, activity, kids, and cover counts', () => {
+    render(<SessionCard session={makeSession()} />);
+
+    expect(screen.getByText('Cubs')).toBeInTheDocument();
+    expect(screen.getByText('Tue 14 Jul')).toBeInTheDocument();
+    expect(screen.getByText('18:15–19:30')).toBeInTheDocument();
+    expect(screen.getByText('Kayaking')).toBeInTheDocument();
+    expect(screen.getByText('~24 YP')).toBeInTheDocument();
+    expect(screen.getByText('of 3 permit holders', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('· 1 backup', { exact: false })).toBeInTheDocument();
+  });
+
+  it('renders the not-on-water state without cover details', () => {
+    render(<SessionCard session={makeSession({ cancelled: true, status: COVER_STATUS.OFF })} />);
+
+    expect(screen.getByText('Not on water')).toBeInTheDocument();
+    expect(screen.queryByText('Kayaking')).not.toBeInTheDocument();
+    expect(screen.queryByText('of 3 permit holders', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('prompts setup when no metadata exists yet', () => {
+    render(
+      <SessionCard
+        session={makeSession({
+          hasMeta: false,
+          needed: null,
+          kids: null,
+          confirmed: [],
+          backups: [],
+          status: COVER_STATUS.UNSET,
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Needs setting up')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with the session when tapped', () => {
+    const onSelect = vi.fn();
+    const session = makeSession();
+    render(<SessionCard session={session} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId('session-f_2'));
+    expect(onSelect).toHaveBeenCalledWith(session);
+  });
+});

--- a/src/features/water-rota/components/index.js
+++ b/src/features/water-rota/components/index.js
@@ -1,0 +1,4 @@
+export { default as WaterRotaRouter } from './WaterRotaRouter.jsx';
+export { default as RotaBoardPage } from './RotaBoardPage.jsx';
+export { default as SessionCard } from './SessionCard.jsx';
+export { default as TermOverviewStrip } from './TermOverviewStrip.jsx';

--- a/src/features/water-rota/hooks/index.js
+++ b/src/features/water-rota/hooks/index.js
@@ -1,0 +1,1 @@
+export * from './useWaterRota.js';

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -1,0 +1,46 @@
+/**
+ * Loads and exposes the current year's water rota.
+ *
+ * Reads ride the flexi cache underneath loadRota, so a previously loaded
+ * board renders offline; refresh() re-runs discovery and the live grid
+ * fetch.
+ *
+ * @module useWaterRota
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { getToken } from '../../../shared/services/auth/tokenService.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+import { loadRota } from '../services/rotaService.js';
+
+/**
+ * Load the water rota for a year.
+ *
+ * @param {number} [year] - Calendar year; defaults to the current year
+ * @returns {{loading: boolean, rota: Object|null, error: Error|null, refresh: Function, year: number}} Rota state
+ */
+export function useWaterRota(year) {
+  const targetYear = year ?? new Date().getFullYear();
+  const [state, setState] = useState({ loading: true, rota: null, error: null });
+
+  const refresh = useCallback(async () => {
+    setState((previous) => ({ ...previous, loading: true, error: null }));
+    try {
+      const token = getToken();
+      const rota = await loadRota(targetYear, token);
+      setState({ loading: false, rota, error: null });
+    } catch (error) {
+      logger.error('Water rota load failed', {
+        year: targetYear,
+        error: error.message,
+      }, LOG_CATEGORIES.ERROR);
+      setState({ loading: false, rota: null, error });
+    }
+  }, [targetYear]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { ...state, refresh, year: targetYear };
+}

--- a/src/features/water-rota/index.js
+++ b/src/features/water-rota/index.js
@@ -1,2 +1,4 @@
+export * from './components';
+export * from './hooks';
 export * from './services';
 export * from './utils';

--- a/src/features/water-rota/utils/__tests__/rotaDisplay.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaDisplay.test.js
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COVER_STATUS,
+  coverStatus,
+  coverStatusBgClass,
+  resolveAllSessions,
+  resolveSessionView,
+  sectionChipClass,
+} from '../rotaDisplay.js';
+
+const META = {
+  v: 1,
+  at: '2026-07-01T10:00:00Z',
+  by: 'Simon Clark',
+  act: 'Kayaking',
+  st: '18:15',
+  en: '19:30',
+  k: 24,
+  p: 3,
+  c: 0,
+};
+
+const CONFIG = {
+  v: 1,
+  at: '2026-06-01T09:00:00Z',
+  by: 'Simon Clark',
+  cfg: {
+    start: '2026-06-01',
+    end: '2026-08-31',
+    sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
+  },
+};
+
+function signup(scoutid, status) {
+  return { scoutid: String(scoutid), name: `Person ${scoutid}`, status, at: null };
+}
+
+describe('coverStatus', () => {
+  it('covers the four cover states', () => {
+    expect(coverStatus({ confirmedCount: 3, backupCount: 0, needed: 3, cancelled: false })).toBe(COVER_STATUS.COVERED);
+    expect(coverStatus({ confirmedCount: 2, backupCount: 1, needed: 3, cancelled: false })).toBe(COVER_STATUS.AT_RISK);
+    expect(coverStatus({ confirmedCount: 1, backupCount: 1, needed: 3, cancelled: false })).toBe(COVER_STATUS.SHORT);
+    expect(coverStatus({ confirmedCount: 0, backupCount: 0, needed: 3, cancelled: true })).toBe(COVER_STATUS.OFF);
+  });
+
+  it('treats a missing target as unset (not short)', () => {
+    expect(coverStatus({ confirmedCount: 0, backupCount: 0, needed: null, cancelled: false })).toBe(COVER_STATUS.UNSET);
+  });
+
+  it('cancelled wins over everything', () => {
+    expect(coverStatus({ confirmedCount: 5, backupCount: 0, needed: 3, cancelled: true })).toBe(COVER_STATUS.OFF);
+  });
+
+  it('over-cover and zero-target sessions are covered', () => {
+    expect(coverStatus({ confirmedCount: 5, backupCount: 0, needed: 3, cancelled: false })).toBe(COVER_STATUS.COVERED);
+    expect(coverStatus({ confirmedCount: 0, backupCount: 0, needed: 0, cancelled: false })).toBe(COVER_STATUS.COVERED);
+  });
+});
+
+describe('resolveSessionView', () => {
+  const baseSession = {
+    fieldId: 'f_2',
+    date: '2026-07-14',
+    sectionId: '49097',
+    meta: META,
+    signups: [signup(1, 'I'), signup(2, 'B'), signup(3, 'I')],
+  };
+
+  it('resolves metadata, splits signups, and computes status', () => {
+    const view = resolveSessionView(baseSession, CONFIG);
+    expect(view.sectionName).toBe('Cubs');
+    expect(view.activity).toBe('Kayaking');
+    expect(view.kids).toBe(24);
+    expect(view.needed).toBe(3);
+    expect(view.confirmed).toHaveLength(2);
+    expect(view.backups).toHaveLength(1);
+    expect(view.status).toBe(COVER_STATUS.AT_RISK);
+    expect(view.hasMeta).toBe(true);
+  });
+
+  it('self-heals from config defaults when metadata is gone', () => {
+    const view = resolveSessionView({ ...baseSession, meta: null, signups: [] }, CONFIG);
+    expect(view.activity).toBe('Kayaking');
+    expect(view.startTime).toBe('18:15');
+    expect(view.needed).toBeNull();
+    expect(view.status).toBe(COVER_STATUS.UNSET);
+    expect(view.hasMeta).toBe(false);
+  });
+
+  it('survives a missing config entirely', () => {
+    const view = resolveSessionView({ ...baseSession, meta: null, signups: [] }, null);
+    expect(view.sectionName).toBe('Section 49097');
+    expect(view.activity).toBe('');
+    expect(view.status).toBe(COVER_STATUS.UNSET);
+  });
+
+  it('flags not-on-water sessions', () => {
+    const view = resolveSessionView({ ...baseSession, meta: { ...META, c: 1 } }, CONFIG);
+    expect(view.cancelled).toBe(true);
+    expect(view.status).toBe(COVER_STATUS.OFF);
+  });
+});
+
+describe('resolveAllSessions', () => {
+  it('sorts by date then section name', () => {
+    const rota = {
+      config: CONFIG,
+      sessions: [
+        { fieldId: 'f_3', date: '2026-07-21', sectionId: '49097', meta: null, signups: [] },
+        { fieldId: 'f_2', date: '2026-07-14', sectionId: '49097', meta: null, signups: [] },
+      ],
+    };
+    expect(resolveAllSessions(rota).map((s) => s.fieldId)).toEqual(['f_2', 'f_3']);
+  });
+});
+
+describe('style helpers', () => {
+  it('maps section names and statuses to classes', () => {
+    expect(sectionChipClass('Monday Cubs')).toContain('forest-green');
+    expect(sectionChipClass('Scouts')).toContain('navy');
+    expect(sectionChipClass('Unknown')).toContain('purple');
+    expect(coverStatusBgClass(COVER_STATUS.COVERED)).toBe('bg-scout-green');
+    expect(coverStatusBgClass(COVER_STATUS.AT_RISK)).toBe('bg-scout-orange');
+    expect(coverStatusBgClass(COVER_STATUS.SHORT)).toBe('bg-scout-red');
+    expect(coverStatusBgClass(COVER_STATUS.OFF)).toBe('bg-gray-300');
+  });
+});

--- a/src/features/water-rota/utils/rotaDisplay.js
+++ b/src/features/water-rota/utils/rotaDisplay.js
@@ -1,0 +1,164 @@
+/**
+ * Pure display logic for the Water Rota board: resolves decoded sessions
+ * into render-ready view models (with config-default self-healing) and
+ * computes cover status.
+ *
+ * @module rotaDisplay
+ */
+
+import { SIGNUP_STATUS } from '../services/rotaEncoding.js';
+
+/**
+ * Cover status values, from healthy to missing data.
+ * covered: confirmed >= needed. atRisk: confirmed short but backups close
+ * the gap. short: not enough even with backups. off: not on water this
+ * week. unset: nobody has set a permit-holder target yet.
+ *
+ * @type {{COVERED: string, AT_RISK: string, SHORT: string, OFF: string, UNSET: string}}
+ */
+export const COVER_STATUS = {
+  COVERED: 'covered',
+  AT_RISK: 'atRisk',
+  SHORT: 'short',
+  OFF: 'off',
+  UNSET: 'unset',
+};
+
+/**
+ * Compute the cover status for a session.
+ *
+ * @param {{confirmedCount: number, backupCount: number, needed: number|null, cancelled: boolean}} session - Resolved session counts
+ * @returns {string} One of COVER_STATUS
+ */
+export function coverStatus({ confirmedCount, backupCount, needed, cancelled }) {
+  if (cancelled) {
+    return COVER_STATUS.OFF;
+  }
+  if (needed === null || needed === undefined) {
+    return COVER_STATUS.UNSET;
+  }
+  if (confirmedCount >= needed) {
+    return COVER_STATUS.COVERED;
+  }
+  if (confirmedCount + backupCount >= needed) {
+    return COVER_STATUS.AT_RISK;
+  }
+  return COVER_STATUS.SHORT;
+}
+
+/**
+ * Render-ready session view model.
+ *
+ * @typedef {Object} SessionView
+ * @property {string} fieldId - Session column field id
+ * @property {string} date - yyyy-mm-dd
+ * @property {string} sectionId - OSM section id
+ * @property {string} sectionName - Display section name
+ * @property {string} activity - Activity name
+ * @property {string} startTime - HH:mm
+ * @property {string} endTime - HH:mm
+ * @property {number|null} kids - Expected young people, null when unset
+ * @property {number|null} needed - Permit holders needed, null when unset
+ * @property {string} notes - Session notes ('' when none)
+ * @property {boolean} cancelled - Not on water this week
+ * @property {boolean} hasMeta - False when showing config defaults only
+ * @property {Array} confirmed - Confirmed signups ({scoutid, name, status, at})
+ * @property {Array} backups - Backup signups
+ * @property {string} status - COVER_STATUS value
+ */
+
+/**
+ * Resolve a decoded session against plan config defaults. When no metadata
+ * candidate survives (e.g. the writer left the host section), the session
+ * self-heals from the config's per-section defaults.
+ *
+ * @param {{fieldId: string, date: string, sectionId: string, meta: Object|null, signups: Array}} session - Decoded session from loadRota
+ * @param {Object|null} config - LWW-winning config candidate ({cfg}) or null
+ * @returns {SessionView} Render-ready view model
+ */
+export function resolveSessionView(session, config) {
+  const sectionDefaults = (config?.cfg?.sections ?? []).find(
+    (entry) => String(entry.sid) === String(session.sectionId),
+  );
+  const meta = session.meta;
+
+  const confirmed = session.signups.filter((signup) => signup.status === SIGNUP_STATUS.IN);
+  const backups = session.signups.filter((signup) => signup.status === SIGNUP_STATUS.BACKUP);
+
+  const view = {
+    fieldId: session.fieldId,
+    date: session.date,
+    sectionId: session.sectionId,
+    sectionName: sectionDefaults?.sname ?? `Section ${session.sectionId}`,
+    activity: meta?.act ?? sectionDefaults?.act ?? '',
+    startTime: meta?.st ?? sectionDefaults?.st ?? '',
+    endTime: meta?.en ?? sectionDefaults?.en ?? '',
+    kids: meta?.k ?? null,
+    needed: meta?.p ?? null,
+    notes: meta?.n ?? '',
+    cancelled: meta?.c === 1,
+    hasMeta: Boolean(meta),
+    confirmed,
+    backups,
+  };
+
+  view.status = coverStatus({
+    confirmedCount: confirmed.length,
+    backupCount: backups.length,
+    needed: view.needed,
+    cancelled: view.cancelled,
+  });
+
+  return view;
+}
+
+/**
+ * Resolve every session in a loaded rota, sorted by date.
+ *
+ * @param {import('../services/rotaService.js').LoadedRota} rota - Loaded rota
+ * @returns {SessionView[]} View models sorted by date then section
+ */
+export function resolveAllSessions(rota) {
+  return (rota?.sessions ?? [])
+    .map((session) => resolveSessionView(session, rota.config))
+    .sort((a, b) => a.date.localeCompare(b.date) || a.sectionName.localeCompare(b.sectionName));
+}
+
+/**
+ * Tailwind classes for a section chip, matching the app's section colors.
+ *
+ * @param {string} sectionName - Section display name
+ * @returns {string} Chip background/text classes
+ */
+export function sectionChipClass(sectionName) {
+  const name = (sectionName ?? '').toLowerCase();
+  if (name.includes('earlyyears')) return 'bg-scout-red text-white';
+  if (name.includes('squirrel')) return 'bg-scout-red text-white';
+  if (name.includes('beaver')) return 'bg-scout-blue text-white';
+  if (name.includes('cub')) return 'bg-scout-forest-green text-white';
+  if (name.includes('scout')) return 'bg-scout-navy text-white';
+  if (name.includes('explorer')) return 'bg-scout-green text-white';
+  if (name.includes('adult')) return 'bg-scout-purple text-white';
+  return 'bg-scout-purple text-white';
+}
+
+/**
+ * Tailwind background class for a cover status (rail and strip dots).
+ *
+ * @param {string} status - COVER_STATUS value
+ * @returns {string} Background class
+ */
+export function coverStatusBgClass(status) {
+  switch (status) {
+  case COVER_STATUS.COVERED:
+    return 'bg-scout-green';
+  case COVER_STATUS.AT_RISK:
+    return 'bg-scout-orange';
+  case COVER_STATUS.SHORT:
+    return 'bg-scout-red';
+  case COVER_STATUS.OFF:
+    return 'bg-gray-300';
+  default:
+    return 'bg-gray-300';
+  }
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -16,6 +16,7 @@ const SectionsPage = lazyWithRetry(() => import('../features/sections/components
 const PhotoConsentPage = lazyWithRetry(() => import('../features/sections/components').then(module => ({ default: module.PhotoConsentPage })));
 const YoungLeadersPage = lazyWithRetry(() => import('../features/young-leaders/components').then(module => ({ default: module.YoungLeadersPage })));
 const EventsRouter = lazyWithRetry(() => import('../features/events/components').then(module => ({ default: module.EventsRouter })));
+const WaterRotaRouter = lazyWithRetry(() => import('../features/water-rota/components').then(module => ({ default: module.WaterRotaRouter })));
 const DataClearPage = lazyWithRetry(() => import('../features/admin/components').then(module => ({ default: module.DataClearPage })));
 
 // Internal component that uses auth and notifications
@@ -94,6 +95,7 @@ function AppContent() {
               <Route path="/photo-consent" element={<PhotoConsentPage />} />
               <Route path="/young-leaders" element={<YoungLeadersPage />} />
               <Route path="/events/*" element={<EventsRouter />} />
+              <Route path="/water-rota/*" element={<WaterRotaRouter />} />
               <Route path="/clear" element={<DataClearPage />} />
 
               {/* Legacy route redirects */}

--- a/src/shared/components/layout/MainNavigation.jsx
+++ b/src/shared/components/layout/MainNavigation.jsx
@@ -11,6 +11,7 @@ function MainNavigation({ onNavigateToSectionMovements }) {
     if (path.startsWith('/sections')) return 'sections';
     if (path.startsWith('/movers')) return 'movers';
     if (path.startsWith('/young-leaders')) return 'young-leaders';
+    if (path.startsWith('/water-rota')) return 'water-rota';
     return 'events'; // default
   };
 
@@ -71,6 +72,22 @@ function MainNavigation({ onNavigateToSectionMovements }) {
               aria-label="Switch to Young Leaders view"
             >
               🏅 Young Leaders
+            </Link>
+
+            {/* Water Rota Tab */}
+            <Link
+              to="/water-rota"
+              className={`py-3 px-1 border-b-2 font-medium text-sm whitespace-nowrap ${
+                currentPage === 'water-rota'
+                  ? 'border-scout-blue text-scout-blue'
+                  : 'border-transparent text-gray-600 hover:text-gray-900 hover:border-gray-300'
+              }`}
+              role="tab"
+              aria-selected={currentPage === 'water-rota'}
+              aria-controls="water-rota-panel"
+              aria-label="Switch to Water Rota view"
+            >
+              🛶 Rota
             </Link>
 
             {/* Movers Button */}


### PR DESCRIPTION
## Summary

Fourth PR in the Water Rota stack (#211 → #212 → #213 → this). The first visible piece: the read-only rota board at `/water-rota` with a 🛶 Rota nav tab.

**Design:** on a phone, a sessions×weeks grid doesn't work as a grid — so the board is a vertically scrolling list bucketed by week (sticky headers, auto-scroll to this week) topped by a horizontally scrollable **term overview strip**: one narrow column per week, one status dot per session. Green = covered, amber = covered only if backups step up, red = short, grey = not on water / target not set. That strip is the section leader's whole-term "do I have enough cover" answer in one glance, and tapping a week scrolls the list to it.

Each **SessionCard** carries a status rail, section chip (scout brand colors), date + editable-preset times, activity, expected YP, and "2 of 3 permit holders" with an overlapping avatar cluster (backups get a dashed ring). Cards are tappable (detail modal arrives in a later PR). Signup buttons arrive in the next PR.

`rotaDisplay.js` keeps all of this pure and tested: view-model resolution self-heals from config defaults when a session's metadata writer left the host section, and a missing permit-holder target renders as "needs setting up" rather than falsely red.

## Test plan

- 14 new tests: cover-status math (incl. unset vs short, cancelled precedence, zero-target), config self-healing, sort order, SessionCard render states (normal / not-on-water / needs-setup / tap).
- `npm run lint` ✅ (0 errors) · `npm run test:run` ✅ (750 passed) · `npm run build` ✅
- Visual QA once the stack lands: board renders from cache offline; empty state offers "Set up the rota".

**Stacked on #213.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR