### PR TITLE
feat: rota signups, identity resolution, and My week view

### DIFF
--- a/src/features/water-rota/components/IdentityPickerModal.jsx
+++ b/src/features/water-rota/components/IdentityPickerModal.jsx
@@ -1,0 +1,71 @@
+import React, { useMemo, useState } from 'react';
+import Modal from '../../../shared/components/ui/Modal.jsx';
+import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
+
+/**
+ * Asks the user which host-section member row is theirs when the automatic
+ * full-name match fails or is ambiguous. Searchable; choice persists per
+ * rota record via useRotaIdentity.
+ *
+ * @param {Object} props
+ * @param {boolean} props.isOpen - Whether the modal is shown
+ * @param {Array<{scoutid: string, name: string}>} props.members - Host-section member rows
+ * @param {Function} props.onChoose - Called with the chosen scoutid
+ * @param {Function} props.onClose - Dismiss without choosing
+ * @returns {JSX.Element} Identity picker modal
+ */
+function IdentityPickerModal({ isOpen, members, onChoose, onClose }) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const sorted = [...(members ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+    return needle
+      ? sorted.filter((member) => member.name.toLowerCase().includes(needle))
+      : sorted;
+  }, [members, query]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="sm">
+      <Modal.Header>
+        <Modal.Title>Who are you?</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p className="text-sm text-gray-600">
+          Pick your name so signups go against the right person. You&apos;ll only
+          need to do this once.
+        </p>
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search names…"
+          className="mt-3 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-scout-blue focus:outline-none focus:ring-1 focus:ring-scout-blue"
+          aria-label="Search members"
+        />
+        <ul className="mt-3 max-h-64 overflow-y-auto divide-y divide-gray-100">
+          {filtered.map((member) => (
+            <li key={member.scoutid}>
+              <button
+                type="button"
+                onClick={() => onChoose(member.scoutid)}
+                className="w-full flex items-center gap-3 px-2 py-2.5 text-left hover:bg-gray-50 rounded-md"
+              >
+                <MemberAvatar member={{ name: member.name }} size="sm" />
+                <span className="text-sm font-medium text-gray-800">{member.name}</span>
+              </button>
+            </li>
+          ))}
+          {filtered.length === 0 && (
+            <li className="px-2 py-4 text-sm text-gray-500 text-center">
+              No matching names. If you&apos;re not listed, ask your admin to add you
+              to the rota&apos;s host section in OSM.
+            </li>
+          )}
+        </ul>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+export default IdentityPickerModal;

--- a/src/features/water-rota/components/MyCommitmentsPage.jsx
+++ b/src/features/water-rota/components/MyCommitmentsPage.jsx
@@ -1,0 +1,179 @@
+import React, { useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+import ConfirmModal from '../../../shared/components/ui/ConfirmModal.jsx';
+import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
+import { useWaterRota } from '../hooks/useWaterRota.js';
+import { useRotaIdentity } from '../hooks/useRotaIdentity.js';
+import { useRotaSignup } from '../hooks/useRotaSignup.js';
+import {
+  myStatusFor,
+  resolveAllSessions,
+  withdrawalNeedsConfirm,
+} from '../utils/rotaDisplay.js';
+import { groupByHorizon } from '../utils/rotaDates.js';
+import SessionCard from './SessionCard.jsx';
+import IdentityPickerModal from './IdentityPickerModal.jsx';
+
+const BUCKET_LABELS = [
+  ['thisWeek', 'This week'],
+  ['nextWeek', 'Next week'],
+  ['later', 'Later'],
+];
+
+/**
+ * A permit holder's week: every upcoming session they are confirmed or
+ * backup for, bucketed into this week / next week / later, with inline
+ * withdraw.
+ *
+ * @returns {JSX.Element} My commitments page
+ */
+function MyCommitmentsPage() {
+  const { loading, rota, error, refresh } = useWaterRota();
+  const identityState = useRotaIdentity(rota);
+  const { identity, needsPicker, choose } = identityState;
+  const { setSignup, pendingFieldId } = useRotaSignup(rota, identity, refresh);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [confirmChange, setConfirmChange] = useState(null);
+
+  const mySessions = useMemo(() => {
+    if (!rota || !identity) {
+      return [];
+    }
+    return resolveAllSessions(rota).filter(
+      (session) => !session.cancelled && myStatusFor(session, identity.scoutid) !== null,
+    );
+  }, [rota, identity]);
+
+  const buckets = useMemo(
+    () => groupByHorizon(mySessions, format(new Date(), 'yyyy-MM-dd')),
+    [mySessions],
+  );
+
+  const upcomingSoon = buckets.thisWeek.length + buckets.nextWeek.length;
+
+  const handleSignupChange = (session, newStatus) => {
+    const currentStatus = myStatusFor(session, identity.scoutid);
+    if (withdrawalNeedsConfirm(session, currentStatus, newStatus)) {
+      setConfirmChange({ session, newStatus });
+      return;
+    }
+    setSignup(session.fieldId, newStatus);
+  };
+
+  if (loading) {
+    return <LoadingScreen message="Loading your sessions..." />;
+  }
+
+  if (error || !rota) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-12 text-center text-sm text-gray-500">
+        {error ? `Couldn't load the rota: ${error.message}` : 'No water rota set up yet.'}
+        <div className="mt-3">
+          <Link to="/water-rota" className="text-scout-blue font-medium">
+            Go to the board
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!identity) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-16 text-center">
+        <h2 className="text-lg font-semibold text-gray-900">Who are you?</h2>
+        <p className="mt-2 text-sm text-gray-500">
+          Pick your name to see your sessions and sign up.
+        </p>
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="mt-5 px-5 py-2.5 rounded-md bg-scout-blue text-white text-sm font-semibold hover:bg-scout-blue-dark"
+        >
+          Pick my name
+        </button>
+        <IdentityPickerModal
+          isOpen={pickerOpen}
+          members={rota.members}
+          onChoose={(scoutid) => {
+            choose(scoutid);
+            setPickerOpen(false);
+          }}
+          onClose={() => setPickerOpen(false)}
+        />
+        {!needsPicker && (
+          <p className="mt-4 text-xs text-gray-400">
+            Your name couldn&apos;t be matched automatically.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-4">
+      <h1 className="text-lg font-semibold text-gray-900">My sessions</h1>
+      <p className="mt-1 text-sm text-gray-600">
+        {upcomingSoon === 0
+          ? 'Nothing in the next two weeks.'
+          : `You're covering ${upcomingSoon} session${upcomingSoon === 1 ? '' : 's'} in the next two weeks.`}
+      </p>
+
+      {mySessions.length === 0 ? (
+        <div className="mt-10 text-center">
+          <p className="text-sm text-gray-500">
+            You haven&apos;t signed up to any sessions yet.
+          </p>
+          <Link
+            to="/water-rota"
+            className="mt-3 inline-block px-5 py-2.5 rounded-md bg-scout-blue text-white text-sm font-semibold hover:bg-scout-blue-dark"
+          >
+            See who needs cover
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-6 pb-12">
+          {BUCKET_LABELS.map(([key, label]) =>
+            buckets[key].length === 0 ? null : (
+              <section key={key} aria-label={label}>
+                <h2 className="text-sm font-semibold text-gray-500 py-1.5">{label}</h2>
+                <div className="space-y-2">
+                  {buckets[key].map((session) => (
+                    <SessionCard
+                      key={session.fieldId}
+                      session={session}
+                      myStatus={myStatusFor(session, identity.scoutid)}
+                      onSignupChange={handleSignupChange}
+                      signupPending={pendingFieldId === session.fieldId}
+                    />
+                  ))}
+                </div>
+              </section>
+            ),
+          )}
+        </div>
+      )}
+
+      <ConfirmModal
+        isOpen={Boolean(confirmChange)}
+        title="Leave this session short?"
+        message={
+          confirmChange
+            ? `This session needs ${confirmChange.session.needed} permit holder${confirmChange.session.needed === 1 ? '' : 's'} and losing you leaves ${confirmChange.session.confirmed.length - 1} confirmed. Withdraw anyway?`
+            : ''
+        }
+        confirmText="Withdraw"
+        cancelText="Stay signed up"
+        confirmVariant="warning"
+        onConfirm={() => {
+          setSignup(confirmChange.session.fieldId, confirmChange.newStatus);
+          setConfirmChange(null);
+        }}
+        onCancel={() => setConfirmChange(null)}
+      />
+    </div>
+  );
+}
+
+export default MyCommitmentsPage;

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -2,12 +2,20 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { format, parseISO } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
 import SectionFilter from '../../../shared/components/ui/SectionFilter.jsx';
+import ConfirmModal from '../../../shared/components/ui/ConfirmModal.jsx';
 import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
 import { useWaterRota } from '../hooks/useWaterRota.js';
-import { resolveAllSessions } from '../utils/rotaDisplay.js';
+import { useRotaIdentity } from '../hooks/useRotaIdentity.js';
+import { useRotaSignup } from '../hooks/useRotaSignup.js';
+import {
+  myStatusFor,
+  resolveAllSessions,
+  withdrawalNeedsConfirm,
+} from '../utils/rotaDisplay.js';
 import { bucketSessionsByWeek, startOfIsoWeek } from '../utils/rotaDates.js';
 import SessionCard from './SessionCard.jsx';
 import TermOverviewStrip from './TermOverviewStrip.jsx';
+import IdentityPickerModal from './IdentityPickerModal.jsx';
 
 const FILTERS_STORAGE_KEY = 'viking_water_rota_section_filters';
 
@@ -26,9 +34,9 @@ function readStoredFilters() {
 }
 
 /**
- * The rota board: term overview strip plus a week-bucketed session list.
- * Auto-scrolls to the current week on load. Renders empty/error/first-run
- * states when there is no rota for the year.
+ * The rota board: term overview strip plus a week-bucketed session list
+ * with one-tap signups. Auto-scrolls to the current week on load. Renders
+ * empty/error/first-run states when there is no rota for the year.
  *
  * @param {Object} props
  * @param {Function} [props.onSelectSession] - Called with a session view when a card is tapped
@@ -37,7 +45,13 @@ function readStoredFilters() {
 function RotaBoardPage({ onSelectSession }) {
   const navigate = useNavigate();
   const { loading, rota, error, refresh, year } = useWaterRota();
+  const identityState = useRotaIdentity(rota);
+  const { identity, needsPicker, choose } = identityState;
+  const { setSignup, pendingFieldId } = useRotaSignup(rota, identity, refresh);
+
   const [sectionFilters, setSectionFilters] = useState(readStoredFilters);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [confirmChange, setConfirmChange] = useState(null);
   const weekRefs = useRef(new Map());
   const didAutoScroll = useRef(false);
 
@@ -80,6 +94,19 @@ function RotaBoardPage({ onSelectSession }) {
 
   const scrollToWeek = (weekStart) => {
     weekRefs.current.get(weekStart)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const handleSignupChange = (session, newStatus) => {
+    if (!identity) {
+      setPickerOpen(true);
+      return;
+    }
+    const currentStatus = myStatusFor(session, identity.scoutid);
+    if (withdrawalNeedsConfirm(session, currentStatus, newStatus)) {
+      setConfirmChange({ session, newStatus });
+      return;
+    }
+    setSignup(session.fieldId, newStatus);
   };
 
   if (loading) {
@@ -137,6 +164,17 @@ function RotaBoardPage({ onSelectSession }) {
         </button>
       </div>
 
+      {needsPicker && (
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="mt-3 w-full rounded-lg border border-scout-orange bg-scout-orange/10 px-4 py-2.5 text-left text-sm text-gray-800"
+        >
+          <span className="font-medium">Who are you?</span> Tap to pick your name so you
+          can sign up to sessions.
+        </button>
+      )}
+
       {filterSections.length > 1 && (
         <div className="mt-3">
           <SectionFilter
@@ -183,13 +221,49 @@ function RotaBoardPage({ onSelectSession }) {
               </h2>
               <div className="space-y-2">
                 {weekSessions.map((session) => (
-                  <SessionCard key={session.fieldId} session={session} onSelect={onSelectSession} />
+                  <SessionCard
+                    key={session.fieldId}
+                    session={session}
+                    onSelect={onSelectSession}
+                    myStatus={identity ? myStatusFor(session, identity.scoutid) : null}
+                    onSignupChange={handleSignupChange}
+                    signupDisabled={!identity && !needsPicker}
+                    signupPending={pendingFieldId === session.fieldId}
+                  />
                 ))}
               </div>
             </section>
           ))}
         </div>
       )}
+
+      <IdentityPickerModal
+        isOpen={pickerOpen}
+        members={rota.members}
+        onChoose={(scoutid) => {
+          choose(scoutid);
+          setPickerOpen(false);
+        }}
+        onClose={() => setPickerOpen(false)}
+      />
+
+      <ConfirmModal
+        isOpen={Boolean(confirmChange)}
+        title="Leave this session short?"
+        message={
+          confirmChange
+            ? `This session needs ${confirmChange.session.needed} permit holder${confirmChange.session.needed === 1 ? '' : 's'} and losing you leaves ${confirmChange.session.confirmed.length - 1} confirmed. Withdraw anyway?`
+            : ''
+        }
+        confirmText="Withdraw"
+        cancelText="Stay signed up"
+        confirmVariant="warning"
+        onConfirm={() => {
+          setSignup(confirmChange.session.fieldId, confirmChange.newStatus);
+          setConfirmChange(null);
+        }}
+        onCancel={() => setConfirmChange(null)}
+      />
     </div>
   );
 }

--- a/src/features/water-rota/components/SessionCard.jsx
+++ b/src/features/water-rota/components/SessionCard.jsx
@@ -2,20 +2,33 @@ import React from 'react';
 import { format, parseISO } from 'date-fns';
 import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
 import { coverStatusBgClass, sectionChipClass, COVER_STATUS } from '../utils/rotaDisplay.js';
+import SignupButtons from './SignupButtons.jsx';
 
 const MAX_AVATARS = 4;
 
 /**
  * One session on the rota board: cover-status rail, section chip, date and
- * times, activity, expected young people, and the permit-holder cover line
- * with an overlapping avatar cluster (backups get a dashed ring).
+ * times, activity, expected young people, the permit-holder cover line with
+ * an overlapping avatar cluster (backups get a dashed ring), and — when a
+ * signup handler is provided — one-tap signup pills.
  *
  * @param {Object} props
  * @param {import('../utils/rotaDisplay.js').SessionView} props.session - Resolved session view model
- * @param {Function} [props.onSelect] - Called with the session when the card is tapped
+ * @param {Function} [props.onSelect] - Called with the session when the card body is tapped
+ * @param {string|null} [props.myStatus] - Current user's signup for this session ('I', 'B', or null)
+ * @param {Function} [props.onSignupChange] - Called with (session, newStatus); omitting hides the pills
+ * @param {boolean} [props.signupDisabled] - Disable the pills (offline / identity unresolved)
+ * @param {boolean} [props.signupPending] - A signup write is in flight for this session
  * @returns {JSX.Element} Session card
  */
-function SessionCard({ session, onSelect }) {
+function SessionCard({
+  session,
+  onSelect,
+  myStatus = null,
+  onSignupChange,
+  signupDisabled = false,
+  signupPending = false,
+}) {
   const {
     date,
     sectionName,
@@ -34,19 +47,22 @@ function SessionCard({ session, onSelect }) {
   const people = [...confirmed, ...backups];
   const overflow = people.length - MAX_AVATARS;
   const timeLabel = startTime && endTime ? `${startTime}–${endTime}` : startTime || '';
+  const showSignup = Boolean(onSignupChange) && !cancelled;
 
   return (
-    <button
-      type="button"
-      onClick={() => onSelect?.(session)}
+    <div
       data-testid={`session-${session.fieldId}`}
-      className={`relative w-full text-left bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden focus:outline-none focus:ring-2 focus:ring-scout-blue ${
+      className={`relative bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden ${
         cancelled ? 'opacity-60' : ''
       }`}
     >
       <span className={`absolute inset-y-0 left-0 w-1.5 ${coverStatusBgClass(status)}`} aria-hidden="true" />
 
-      <span className="block pl-4 pr-3 py-3">
+      <button
+        type="button"
+        onClick={() => onSelect?.(session)}
+        className="block w-full text-left pl-4 pr-3 pt-3 pb-2 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-scout-blue"
+      >
         <span className="flex items-center gap-2 flex-wrap">
           <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${sectionChipClass(sectionName)}`}>
             {sectionName}
@@ -114,8 +130,19 @@ function SessionCard({ session, onSelect }) {
             )}
           </span>
         )}
-      </span>
-    </button>
+      </button>
+
+      {showSignup && (
+        <div className="pl-4 pr-3 pb-3">
+          <SignupButtons
+            myStatus={myStatus}
+            disabled={signupDisabled || signupPending}
+            pending={signupPending}
+            onChange={(newStatus) => onSignupChange(session, newStatus)}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/features/water-rota/components/SignupButtons.jsx
+++ b/src/features/water-rota/components/SignupButtons.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { SIGNUP_STATUS } from '../services/rotaEncoding.js';
+
+/**
+ * One-tap signup pills for a session: "I'm in" and "Backup". Tapping the
+ * active pill withdraws. Parent decides whether a withdrawal needs
+ * confirmation before calling onChange.
+ *
+ * @param {Object} props
+ * @param {string|null} props.myStatus - Current signup ('I', 'B', or null)
+ * @param {boolean} [props.disabled] - Disable both pills (offline / no identity / pending)
+ * @param {boolean} [props.pending] - Show the in-flight state
+ * @param {Function} props.onChange - Called with the requested status ('I', 'B', or null to withdraw)
+ * @returns {JSX.Element} Signup pill row
+ */
+function SignupButtons({ myStatus, disabled = false, pending = false, onChange }) {
+  const isIn = myStatus === SIGNUP_STATUS.IN;
+  const isBackup = myStatus === SIGNUP_STATUS.BACKUP;
+
+  const base =
+    'flex-1 py-1.5 px-3 rounded-full text-sm font-medium border transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+
+  return (
+    <div className={`flex gap-2 ${pending ? 'animate-pulse' : ''}`} data-testid="signup-buttons">
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={isIn}
+        onClick={() => onChange(isIn ? null : SIGNUP_STATUS.IN)}
+        className={`${base} ${
+          isIn
+            ? 'bg-scout-blue border-scout-blue text-white'
+            : 'bg-white border-gray-300 text-gray-700 hover:border-scout-blue hover:text-scout-blue'
+        }`}
+      >
+        {isIn ? '✓ I\'m in' : 'I\'m in'}
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={isBackup}
+        onClick={() => onChange(isBackup ? null : SIGNUP_STATUS.BACKUP)}
+        className={`${base} ${
+          isBackup
+            ? 'bg-gray-700 border-gray-700 text-white'
+            : 'bg-white border-gray-300 text-gray-700 hover:border-gray-500'
+        }`}
+      >
+        {isBackup ? '✓ Backup' : 'Backup'}
+      </button>
+    </div>
+  );
+}
+
+export default SignupButtons;

--- a/src/features/water-rota/components/WaterRotaRouter.jsx
+++ b/src/features/water-rota/components/WaterRotaRouter.jsx
@@ -1,12 +1,47 @@
 import React from 'react';
-import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, NavLink, useNavigate } from 'react-router-dom';
 import MainNavigation from '../../../shared/components/layout/MainNavigation.jsx';
 import RotaBoardPage from './RotaBoardPage.jsx';
+import MyCommitmentsPage from './MyCommitmentsPage.jsx';
 
 /**
- * Nested router for the Water Rota feature. The board is the default view;
- * My-week and setup routes are added by their own PRs and unknown paths
- * fall back to the board.
+ * Segmented control switching between the board and the personal view.
+ *
+ * @returns {JSX.Element} Board | My week toggle
+ */
+function ViewSwitch() {
+  const base = 'flex-1 text-center py-1.5 rounded-md text-sm font-medium transition-colors';
+  return (
+    <div className="max-w-3xl mx-auto px-4 pt-3">
+      <div className="flex gap-1 rounded-lg bg-gray-100 p-1" role="tablist" aria-label="Rota views">
+        <NavLink
+          to="/water-rota"
+          end
+          role="tab"
+          className={({ isActive }) =>
+            `${base} ${isActive ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-800'}`
+          }
+        >
+          Board
+        </NavLink>
+        <NavLink
+          to="/water-rota/me"
+          role="tab"
+          className={({ isActive }) =>
+            `${base} ${isActive ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-800'}`
+          }
+        >
+          My week
+        </NavLink>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Nested router for the Water Rota feature: board (default) and My week,
+ * with unknown paths falling back to the board. The setup wizard route is
+ * added by its own PR.
  *
  * @returns {JSX.Element} Water rota routes under /water-rota
  */
@@ -16,8 +51,10 @@ function WaterRotaRouter() {
   return (
     <>
       <MainNavigation onNavigateToSectionMovements={() => navigate('/movers')} />
+      <ViewSwitch />
       <Routes>
         <Route index element={<RotaBoardPage />} />
+        <Route path="me" element={<MyCommitmentsPage />} />
         <Route path="*" element={<Navigate to="/water-rota" replace />} />
       </Routes>
     </>

--- a/src/features/water-rota/components/__tests__/SessionCard.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionCard.test.jsx
@@ -72,7 +72,7 @@ describe('SessionCard', () => {
     const session = makeSession();
     render(<SessionCard session={session} onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByTestId('session-f_2'));
+    fireEvent.click(screen.getByRole('button'));
     expect(onSelect).toHaveBeenCalledWith(session);
   });
 });

--- a/src/features/water-rota/components/__tests__/SignupButtons.test.jsx
+++ b/src/features/water-rota/components/__tests__/SignupButtons.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import SignupButtons from '../SignupButtons.jsx';
+import { SIGNUP_STATUS } from '../../services/rotaEncoding.js';
+
+describe('SignupButtons', () => {
+  it('requests IN when not signed up', () => {
+    const onChange = vi.fn();
+    render(<SignupButtons myStatus={null} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('I\'m in'));
+    expect(onChange).toHaveBeenCalledWith(SIGNUP_STATUS.IN);
+  });
+
+  it('tapping the active pill withdraws', () => {
+    const onChange = vi.fn();
+    render(<SignupButtons myStatus={SIGNUP_STATUS.IN} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('✓ I\'m in'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('switches between confirmed and backup', () => {
+    const onChange = vi.fn();
+    render(<SignupButtons myStatus={SIGNUP_STATUS.IN} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('Backup'));
+    expect(onChange).toHaveBeenCalledWith(SIGNUP_STATUS.BACKUP);
+  });
+
+  it('disables both pills when disabled', () => {
+    const onChange = vi.fn();
+    render(<SignupButtons myStatus={null} disabled onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('I\'m in'));
+    fireEvent.click(screen.getByText('Backup'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/water-rota/components/index.js
+++ b/src/features/water-rota/components/index.js
@@ -1,4 +1,7 @@
 export { default as WaterRotaRouter } from './WaterRotaRouter.jsx';
 export { default as RotaBoardPage } from './RotaBoardPage.jsx';
+export { default as MyCommitmentsPage } from './MyCommitmentsPage.jsx';
 export { default as SessionCard } from './SessionCard.jsx';
+export { default as SignupButtons } from './SignupButtons.jsx';
 export { default as TermOverviewStrip } from './TermOverviewStrip.jsx';
+export { default as IdentityPickerModal } from './IdentityPickerModal.jsx';

--- a/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../../shared/utils/storageUtils.js', () => ({
+  safeGetSessionItem: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/storage/indexedDBService.js', () => ({
+  IndexedDBService: {
+    get: vi.fn(),
+    STORES: { CACHE_DATA: 'cache_data' },
+  },
+}));
+
+import { safeGetSessionItem } from '../../../../shared/utils/storageUtils.js';
+import { IndexedDBService } from '../../../../shared/services/storage/indexedDBService.js';
+import { useRotaIdentity } from '../useRotaIdentity.js';
+
+const ROTA = {
+  recordId: 777,
+  members: [
+    { scoutid: '10', name: 'Simon Clark' },
+    { scoutid: '11', name: 'Alice Smith' },
+    { scoutid: '12', name: 'Alice Smith' },
+  ],
+};
+
+function Harness({ rota }) {
+  const { identity, needsPicker, resolving, choose } = useRotaIdentity(rota);
+  return (
+    <div>
+      <span data-testid="identity">{identity ? identity.name : 'none'}</span>
+      <span data-testid="picker">{String(needsPicker)}</span>
+      <span data-testid="resolving">{String(resolving)}</span>
+      <button onClick={() => choose('11')}>choose</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  IndexedDBService.get.mockResolvedValue(null);
+});
+
+describe('useRotaIdentity', () => {
+  it('auto-matches a unique full name from session user info', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
+
+    render(<Harness rota={ROTA} />);
+
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+    expect(screen.getByTestId('picker')).toHaveTextContent('false');
+    expect(localStorage.getItem('viking_rota_identity_777')).toBe('10');
+  });
+
+  it('asks for the picker when the name is ambiguous', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Alice', lastname: 'Smith' });
+
+    render(<Harness rota={ROTA} />);
+
+    await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
+    expect(screen.getByTestId('identity')).toHaveTextContent('none');
+  });
+
+  it('asks for the picker when no name source exists', async () => {
+    safeGetSessionItem.mockReturnValue({});
+    IndexedDBService.get.mockResolvedValue(null);
+
+    render(<Harness rota={ROTA} />);
+
+    await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
+  });
+
+  it('prefers a previously confirmed choice over name matching', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
+    localStorage.setItem('viking_rota_identity_777', '11');
+
+    render(<Harness rota={ROTA} />);
+
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
+  });
+
+  it('persists an explicit choice', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Alice', lastname: 'Smith' });
+
+    render(<Harness rota={ROTA} />);
+    await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
+
+    fireEvent.click(screen.getByText('choose'));
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
+    expect(localStorage.getItem('viking_rota_identity_777')).toBe('11');
+  });
+
+  it('falls back to cached startup globals for the name', async () => {
+    safeGetSessionItem.mockReturnValue({});
+    IndexedDBService.get.mockResolvedValue({ globals: { firstname: 'Simon', lastname: 'Clark' } });
+
+    render(<Harness rota={ROTA} />);
+
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+  });
+});

--- a/src/features/water-rota/hooks/index.js
+++ b/src/features/water-rota/hooks/index.js
@@ -1,1 +1,3 @@
 export * from './useWaterRota.js';
+export * from './useRotaIdentity.js';
+export * from './useRotaSignup.js';

--- a/src/features/water-rota/hooks/useRotaIdentity.js
+++ b/src/features/water-rota/hooks/useRotaIdentity.js
@@ -1,0 +1,122 @@
+/**
+ * Resolves which host-section member row belongs to the current user, so
+ * signups write to the right row.
+ *
+ * Resolution order: a previously confirmed choice (persisted per record) →
+ * unique full-name match against the rota members → otherwise the caller
+ * shows the identity picker. The chosen identity is stored per record id,
+ * so a new year's rota re-resolves.
+ *
+ * @module useRotaIdentity
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { safeGetSessionItem } from '../../../shared/utils/storageUtils.js';
+import { IndexedDBService } from '../../../shared/services/storage/indexedDBService.js';
+
+/**
+ * Best-effort current user full name from session auth info or cached
+ * startup data (same sources as the sign-in feature).
+ *
+ * @returns {Promise<string|null>} "First Last", or null when unknown
+ */
+export async function getCurrentUserName() {
+  const userInfo = safeGetSessionItem('user_info', {});
+  if (userInfo.firstname && userInfo.lastname) {
+    return `${userInfo.firstname} ${userInfo.lastname}`;
+  }
+
+  try {
+    const startupData = await IndexedDBService.get(IndexedDBService.STORES.CACHE_DATA, 'viking_startup_data');
+    const globals = startupData?.globals;
+    if (globals?.firstname && globals?.lastname) {
+      return `${globals.firstname} ${globals.lastname}`;
+    }
+  } catch {
+    /* fall through to null — caller shows the picker */
+  }
+  return null;
+}
+
+/**
+ * Storage key for the confirmed identity on one rota record.
+ *
+ * @param {string|number} recordId - FlexiRecord id
+ * @returns {string} localStorage key
+ */
+function identityStorageKey(recordId) {
+  return `viking_rota_identity_${recordId}`;
+}
+
+/**
+ * Resolve the current user's member row in the rota host section.
+ *
+ * @param {import('../services/rotaService.js').LoadedRota|null} rota - Loaded rota (null while loading)
+ * @returns {{identity: {scoutid: string, name: string}|null, needsPicker: boolean, resolving: boolean, choose: Function, clear: Function}} Identity state
+ */
+export function useRotaIdentity(rota) {
+  const [state, setState] = useState({ identity: null, needsPicker: false, resolving: true });
+
+  const members = useMemo(() => rota?.members ?? [], [rota]);
+  const recordId = rota?.recordId;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolve() {
+      if (!recordId || members.length === 0) {
+        setState({ identity: null, needsPicker: false, resolving: !recordId });
+        return;
+      }
+
+      const storedId = localStorage.getItem(identityStorageKey(recordId));
+      const stored = members.find((member) => member.scoutid === storedId);
+      if (stored) {
+        if (!cancelled) {
+          setState({ identity: stored, needsPicker: false, resolving: false });
+        }
+        return;
+      }
+
+      const fullName = await getCurrentUserName();
+      const matches = fullName
+        ? members.filter((member) => member.name.toLowerCase() === fullName.toLowerCase())
+        : [];
+
+      if (!cancelled) {
+        if (matches.length === 1) {
+          localStorage.setItem(identityStorageKey(recordId), matches[0].scoutid);
+          setState({ identity: matches[0], needsPicker: false, resolving: false });
+        } else {
+          setState({ identity: null, needsPicker: true, resolving: false });
+        }
+      }
+    }
+
+    resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, [recordId, members]);
+
+  const choose = useCallback(
+    (scoutid) => {
+      const member = members.find((entry) => entry.scoutid === String(scoutid));
+      if (!member || !recordId) {
+        return;
+      }
+      localStorage.setItem(identityStorageKey(recordId), member.scoutid);
+      setState({ identity: member, needsPicker: false, resolving: false });
+    },
+    [members, recordId],
+  );
+
+  const clear = useCallback(() => {
+    if (recordId) {
+      localStorage.removeItem(identityStorageKey(recordId));
+    }
+    setState({ identity: null, needsPicker: true, resolving: false });
+  }, [recordId]);
+
+  return { ...state, choose, clear };
+}

--- a/src/features/water-rota/hooks/useRotaSignup.js
+++ b/src/features/water-rota/hooks/useRotaSignup.js
@@ -1,0 +1,67 @@
+/**
+ * Signup writes for the rota board: wraps rotaService.writeSignup with
+ * per-session pending state, toasts, and a refresh after each write.
+ *
+ * @module useRotaSignup
+ */
+
+import { useCallback, useState } from 'react';
+import { getToken } from '../../../shared/services/auth/tokenService.js';
+import { notifyError, notifySuccess } from '../../../shared/utils/notifications.js';
+import { writeSignup } from '../services/rotaService.js';
+import { SIGNUP_STATUS } from '../services/rotaEncoding.js';
+
+/**
+ * Human label for a signup change, used in toasts.
+ *
+ * @param {string|null} status - New signup status
+ * @returns {string} Toast message
+ */
+function successMessage(status) {
+  if (status === SIGNUP_STATUS.IN) return 'You\'re in';
+  if (status === SIGNUP_STATUS.BACKUP) return 'Added to the backup list';
+  return 'Signup withdrawn';
+}
+
+/**
+ * Perform signup changes against a loaded rota.
+ *
+ * @param {import('../services/rotaService.js').LoadedRota|null} rota - Loaded rota
+ * @param {{scoutid: string}|null} identity - Resolved member identity
+ * @param {Function} refresh - Re-load the rota after a successful write
+ * @returns {{setSignup: Function, pendingFieldId: string|null}} Signup API
+ */
+export function useRotaSignup(rota, identity, refresh) {
+  const [pendingFieldId, setPendingFieldId] = useState(null);
+
+  const setSignup = useCallback(
+    async (fieldId, status) => {
+      if (!rota || !identity) {
+        return;
+      }
+      setPendingFieldId(fieldId);
+      try {
+        await writeSignup({
+          rota,
+          fieldId,
+          scoutid: identity.scoutid,
+          status,
+          token: getToken(),
+        });
+        notifySuccess(successMessage(status));
+        await refresh();
+      } catch (error) {
+        if (error?.code === 'WRITE_UNAVAILABLE') {
+          notifyError('You\'re offline — connect to change your signup.');
+        } else {
+          notifyError(`Signup failed: ${error.message}`);
+        }
+      } finally {
+        setPendingFieldId(null);
+      }
+    },
+    [rota, identity, refresh],
+  );
+
+  return { setSignup, pendingFieldId };
+}

--- a/src/features/water-rota/utils/__tests__/rotaDisplaySignup.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaDisplaySignup.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { myStatusFor, withdrawalNeedsConfirm } from '../rotaDisplay.js';
+
+function view({ confirmed = [], backups = [], needed = 3 } = {}) {
+  return {
+    confirmed: confirmed.map((id) => ({ scoutid: String(id), name: `P${id}`, status: 'I', at: null })),
+    backups: backups.map((id) => ({ scoutid: String(id), name: `P${id}`, status: 'B', at: null })),
+    needed,
+  };
+}
+
+describe('myStatusFor', () => {
+  it('finds the user in confirmed and backup lists', () => {
+    const session = view({ confirmed: [10], backups: [11] });
+    expect(myStatusFor(session, '10')).toBe('I');
+    expect(myStatusFor(session, 11)).toBe('B');
+    expect(myStatusFor(session, '12')).toBeNull();
+    expect(myStatusFor(session, null)).toBeNull();
+  });
+});
+
+describe('withdrawalNeedsConfirm', () => {
+  it('confirms when a confirmed holder leaving drops below the target', () => {
+    const session = view({ confirmed: [10, 11], needed: 2 });
+    expect(withdrawalNeedsConfirm(session, 'I', null)).toBe(true);
+    expect(withdrawalNeedsConfirm(session, 'I', 'B')).toBe(true);
+  });
+
+  it('does not confirm when cover survives the withdrawal', () => {
+    const session = view({ confirmed: [10, 11, 12], needed: 2 });
+    expect(withdrawalNeedsConfirm(session, 'I', null)).toBe(false);
+  });
+
+  it('never confirms backup withdrawals or new signups', () => {
+    const session = view({ confirmed: [10], backups: [11], needed: 2 });
+    expect(withdrawalNeedsConfirm(session, 'B', null)).toBe(false);
+    expect(withdrawalNeedsConfirm(session, null, 'I')).toBe(false);
+  });
+
+  it('never confirms when no target is set', () => {
+    const session = view({ confirmed: [10], needed: null });
+    expect(withdrawalNeedsConfirm(session, 'I', null)).toBe(false);
+  });
+});

--- a/src/features/water-rota/utils/rotaDisplay.js
+++ b/src/features/water-rota/utils/rotaDisplay.js
@@ -125,6 +125,47 @@ export function resolveAllSessions(rota) {
 }
 
 /**
+ * The current user's signup status on a resolved session.
+ *
+ * @param {SessionView} session - Resolved session view
+ * @param {string|null|undefined} scoutid - The user's member row id
+ * @returns {string|null} SIGNUP_STATUS value, or null when not signed up
+ */
+export function myStatusFor(session, scoutid) {
+  if (!scoutid) {
+    return null;
+  }
+  const id = String(scoutid);
+  if (session.confirmed.some((signup) => signup.scoutid === id)) {
+    return SIGNUP_STATUS.IN;
+  }
+  if (session.backups.some((signup) => signup.scoutid === id)) {
+    return SIGNUP_STATUS.BACKUP;
+  }
+  return null;
+}
+
+/**
+ * Whether withdrawing (or stepping down from confirmed) needs confirmation:
+ * true when the user is currently confirmed and losing them drops the
+ * session below its permit-holder target.
+ *
+ * @param {SessionView} session - Resolved session view
+ * @param {string|null} currentStatus - The user's current signup status
+ * @param {string|null} newStatus - The requested signup status
+ * @returns {boolean} True when the change warrants a confirm dialog
+ */
+export function withdrawalNeedsConfirm(session, currentStatus, newStatus) {
+  if (currentStatus !== SIGNUP_STATUS.IN || newStatus === SIGNUP_STATUS.IN) {
+    return false;
+  }
+  if (session.needed === null) {
+    return false;
+  }
+  return session.confirmed.length - 1 < session.needed;
+}
+
+/**
  * Tailwind classes for a section chip, matching the app's section colors.
  *
  * @param {string} sectionName - Section display name


### PR DESCRIPTION
## Summary

Fifth PR in the Water Rota stack (#211 → #212 → #213 → #214 → this). The rota becomes interactive:

- **One-tap signups** on every session card: `I'm in` / `Backup` pills, tap-again to withdraw. Withdrawing (or stepping down to backup) when that drops the session below its permit-holder target raises a confirm dialog first.
- **Identity resolution** — signups must write to the user's own member row, so `useRotaIdentity` resolves it: previously confirmed choice (persisted per record) → unique full-name match from session auth info or cached startup globals → searchable **IdentityPickerModal** (one-time). An amber banner prompts when the picker is needed.
- **My week** at `/water-rota/me` — a permit holder's commitments bucketed This week / Next week / Later with a "covering N sessions in the next two weeks" summary and inline withdraw; reachable via a Board | My week segmented control.
- Signup writes go through the PR 3 freshness-locked path; failures toast clearly (dedicated offline message).

## Test plan

- 15 new tests: identity precedence (stored > auto-match), ambiguous/missing names, startup-globals fallback, choice persistence, pill toggle semantics, withdrawal-confirm rule edges (backup withdrawals and unset targets never confirm).
- `npm run lint` ✅ (0 errors) · `npm run test:run` ✅ (765 passed) · `npm run build` ✅

**Stacked on #214.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR