### PR TITLE
ci: make the JSDoc documentation job advisory (non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
   # Documentation Quality Check
   documentation:
     runs-on: ubuntu-latest
+    # Advisory: the jsdoc CLI validator rejects valid modern JSDoc type syntax
+    # (import('…') references, arrow-function and optional-property types — 90+
+    # across the codebase) that eslint-plugin-jsdoc and editors/tsc accept. We
+    # keep those type-informative annotations rather than strip them, so this
+    # job must not fail the pipeline. Docs still generate for visibility.
+    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why
The `documentation` job has been **red on every release** (v2.18.x, v2.19.0) — but only because the `jsdoc` CLI validator (`docs:validate`) can't parse **valid modern JSDoc type syntax** the codebase uses:
- **73** `import('…')` type references (cross-file types your IDE/tsc resolve)
- arrow-function types (`() => Promise<T>`) and optional inline props (`resetTime?: number`)

**`npm run lint` (eslint-plugin-jsdoc) accepts all of these** — only the old jsdoc CLI rejects them. The job isn't a required check (that's why #219 merged), and `deploy` doesn't depend on it, so the deploy has always succeeded; the pipeline just reports a cosmetic "failure".

## Change
Mark the `documentation` job `continue-on-error: true` so it no longer fails the CI/CD Pipeline. Docs still generate for visibility. No app code changes, no annotations stripped (keeps the type info IDEs use).

CI-only. `patch` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)