### PR TITLE
fix: restore web sign-in — primary login no longer stores a return path

### DIFF
--- a/src/features/auth/hooks/useAuth.jsx
+++ b/src/features/auth/hooks/useAuth.jsx
@@ -530,11 +530,14 @@ function useAuthLogic() {
     }
   }, [determineAuthState, consumeOAuthCallback]);
 
-  // Login function. Store the current path (incl. query) so the OAuth callback
-  // returns the user to where they started — e.g. a shared deep link opened
-  // logged-out — instead of dropping them on the default landing page.
+  // Login function.
+  // NOTE: primary login deliberately does NOT store a return path. Restoring it
+  // on the web callback runs a replaceState + popstate (consumeOAuthCallback,
+  // source==='url') that hangs the post-OAuth render on mobile Safari (the #169
+  // fragility) and made sign-in appear broken. Deep-link-return must use a
+  // mobile-Safari-safe restore (e.g. a hard navigation) before it's re-enabled.
   const login = useCallback(async () => {
-    const oauthUrl = generateOAuthUrl(true);
+    const oauthUrl = generateOAuthUrl();
     await loginNative(oauthUrl);
   }, []);
 


### PR DESCRIPTION
## Hotfix — production login broken on iPhone (web)
Reported: signing in via the website on iPhone (mobile Safari) fails.

**Cause (regression from v2.19.0):** the deep-link-return work made the *primary* login store a return path. On the web OAuth callback (`consumeOAuthCallback`, `source==='url'`) that triggers a `replaceState` + `popstate` restore which hangs the post-OAuth render on mobile Safari — the exact #169 fragility. Sign-in then appears broken.

**Fix:** revert the primary login to `generateOAuthUrl()` (no stored return path) → restores the known-good v2.18.x behaviour. The `storeReturnPath`/`getAndClearReturnPath` sessionStorage guards stay. Native app unaffected (web deploy doesn't touch it; the restore block is web-only).

Deep-link-return will be re-added later with a mobile-Safari-safe restore (hard navigation).

Lint clean, build green. `patch` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)