### PR TITLE
fix: surface OSM sign-in failures instead of a silent cryptic URL

### DIFF
--- a/src/features/auth/hooks/useAuth.jsx
+++ b/src/features/auth/hooks/useAuth.jsx
@@ -8,7 +8,8 @@ import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js
 import databaseService from '../../../shared/services/storage/database.js';
 import IndexedDBService from '../../../shared/services/storage/indexedDBService.js';
 import dataLoadingService from '../../../shared/services/data/dataLoadingService.js';
-import { notifyLoading, notifySuccess, notifyWarning, dismissToast } from '../../../shared/utils/notifications.js';
+import { notifyError, notifyLoading, notifySuccess, notifyWarning, dismissToast } from '../../../shared/utils/notifications.js';
+import { describeOAuthCallbackError } from '../utils/oauthCallbackError.js';
 import { getLoadingResultMessage } from '../../../shared/services/referenceData/referenceDataService.js';
 
 // Create Auth Context
@@ -341,12 +342,14 @@ function useAuthLogic() {
       let accessToken;
       let tokenType;
       let expiresIn;
+      let oauthError;
 
       try {
         urlParams = new URLSearchParams(window.location.search);
         accessToken = urlParams.get('access_token');
         tokenType = urlParams.get('token_type');
         expiresIn = urlParams.get('expires_in');
+        oauthError = urlParams.get('error');
 
         // Debug: Log all OAuth parameters we receive
         if (accessToken && import.meta.env.DEV) {
@@ -405,6 +408,25 @@ function useAuthLogic() {
         await consumeOAuthCallback({ accessToken, tokenType, expiresIn, source: 'url' });
         return;
       }
+
+      // The backend redirects here with ?error= when the OSM token exchange
+      // fails (commonly OSM returning an HTML block/error page). Surface it in
+      // plain English — previously it was silent — then scrub the params so a
+      // refresh doesn't re-show it.
+      if (oauthError) {
+        notifyError(describeOAuthCallbackError(oauthError));
+        logger.warn('OAuth callback returned an error', { oauthError }, LOG_CATEGORIES.AUTH);
+        try {
+          const cleaned = new URL(window.location);
+          cleaned.searchParams.delete('error');
+          cleaned.searchParams.delete('error_description');
+          cleaned.searchParams.delete('details');
+          window.history.replaceState({}, '', cleaned);
+        } catch {
+          // best-effort URL cleanup
+        }
+      }
+
       // Check if blocked first
       if (authService.isBlocked()) {
         setIsBlocked(true);

--- a/src/features/auth/utils/__tests__/oauthCallbackError.test.js
+++ b/src/features/auth/utils/__tests__/oauthCallbackError.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { describeOAuthCallbackError } from '../oauthCallbackError.js';
+
+describe('describeOAuthCallbackError', () => {
+  it('gives an actionable "OSM busy/blocking — wait and retry" message for token_exchange_failed', () => {
+    const message = describeOAuthCallbackError('token_exchange_failed');
+    expect(message).toMatch(/OSM/);
+    expect(message).toMatch(/wait a few minutes and try again/i);
+    // must not leak the raw error code as the whole message
+    expect(message).not.toBe('token_exchange_failed');
+  });
+
+  it('gives a generic retry message for any other error code, naming it', () => {
+    const message = describeOAuthCallbackError('invalid_state');
+    expect(message).toMatch(/Sign-in didn’t complete/);
+    expect(message).toMatch(/invalid_state/);
+  });
+});

--- a/src/features/auth/utils/oauthCallbackError.js
+++ b/src/features/auth/utils/oauthCallbackError.js
@@ -1,0 +1,29 @@
+/**
+ * OAuth callback error handling: turn the backend's `?error=` redirect param
+ * into a plain-English, actionable message for the user.
+ *
+ * The backend redirects to the frontend with `?error=<code>&details=<json>`
+ * when the OSM token exchange fails. The frontend previously ignored this
+ * entirely, so a failed sign-in landed the user on a cryptic URL with no
+ * explanation (notably when OSM returns an HTML block/error page instead of a
+ * token — the "OSM has blocked the app" case).
+ *
+ * @module oauthCallbackError
+ */
+
+/**
+ * Map an OAuth callback `error` code to a user-facing message.
+ *
+ * `token_exchange_failed` is the common OSM-side failure: OSM returned a
+ * non-token response (typically an HTML block/error page), so the message is
+ * actionable — stop and wait, since retrying just hits OSM again.
+ *
+ * @param {string} error - The `error` query param from the OAuth callback
+ * @returns {string} A plain-English message for the user
+ */
+export function describeOAuthCallbackError(error) {
+  if (error === 'token_exchange_failed') {
+    return 'Couldn’t complete sign-in — OSM looks busy or is temporarily blocking the app (too many requests). Wait a few minutes and try again.';
+  }
+  return `Sign-in didn’t complete (${error}). Please try again in a moment.`;
+}


### PR DESCRIPTION
## Why
Today's incident: OSM rate-limit-**blocked the app**, so its `/oauth/token` returned an HTML block page → the backend redirected to the frontend with `?error=token_exchange_failed&details=…`. **The frontend ignored `?error` entirely** (it only read `access_token`), so sign-in failed silently on a cryptic URL — no message, no signal to stop retrying. Per §10.1, the blocked state has no UI.

## Change
- On the OAuth callback, read `?error` and show a plain-English, actionable message via `notifyError`, then scrub `error`/`error_description`/`details` from the URL.
- For `token_exchange_failed` (the OSM-block/HTML case): *"OSM looks busy or is temporarily blocking the app (too many requests). Wait a few minutes and try again."*
- New pure `describeOAuthCallbackError` helper + unit test.

Deliberately **not** auto-setting `osm_blocked` from the login error (risks trapping the app in cache-only mode if clear-on-login isn't airtight) — the clear message is the fix.

## Notes
- Frontend-only; **does not touch OSM** — safe to merge during the block.
- Unit-tested; can't live-verify the exact block message without OSM actually blocking (won't deliberately reproduce). Lint clean, build green.
- `fix:` → patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)