### PR TITLE
fix: rota shows the real programme title, not a guessed/stale activity

### DIFF
--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -214,14 +214,16 @@ function RotaBoardPage() {
   const handleSyncProgramme = async () => {
     setSyncing(true);
     try {
-      const { added, orphaned, errors, uncheckedSections = [], failedSections = [] } =
-        await syncRotaWithProgramme({ rota, token: getToken() });
+      const { added, orphaned, errors, titlesUpdated = 0, uncheckedSections = [], failedSections = [] } =
+        await syncRotaWithProgramme({ rota, token: getToken(), scoutid: identity?.scoutid, by: identity?.name });
       if (errors.length > 0) {
         notifyError(`Sync finished with ${errors.length} error${errors.length === 1 ? '' : 's'} — try again to finish.`);
-      } else if (added === 0 && orphaned.length === 0 && uncheckedSections.length === 0 && failedSections.length === 0) {
+      } else if (added === 0 && orphaned.length === 0 && titlesUpdated === 0 && uncheckedSections.length === 0 && failedSections.length === 0) {
         notifyInfo('Rota already matches the programmes.');
       } else if (added > 0) {
         notifySuccess(`Added ${added} new session${added === 1 ? '' : 's'}.`);
+      } else if (titlesUpdated > 0) {
+        notifySuccess(`Updated ${titlesUpdated} session name${titlesUpdated === 1 ? '' : 's'} from the programme.`);
       }
       if (orphaned.length > 0) {
         notifyInfo(

--- a/src/features/water-rota/components/SessionCard.jsx
+++ b/src/features/water-rota/components/SessionCard.jsx
@@ -32,7 +32,7 @@ function SessionCard({
   const {
     date,
     sectionName,
-    activity,
+    label,
     startTime,
     endTime,
     kids,
@@ -85,7 +85,7 @@ function SessionCard({
         {!cancelled && (
           <span className="mt-1 flex items-center gap-2">
             <span className="text-sm font-medium text-gray-800">
-              {activity || 'Activity not set'}
+              {label || 'Activity not set'}
             </span>
             {kids !== null && (
               <span className="text-xs text-gray-500">~{kids} YP</span>

--- a/src/features/water-rota/components/SessionDetailModal.jsx
+++ b/src/features/water-rota/components/SessionDetailModal.jsx
@@ -220,7 +220,7 @@ function SessionDetailModal({
           <>
             <div className="text-sm text-gray-700">
               <p className="font-medium text-gray-900">
-                {session.activity || 'Activity not set'}
+                {session.label || 'Activity not set'}
                 {session.startTime && (
                   <span className="ml-2 font-normal text-gray-500">
                     {session.startTime}–{session.endTime}

--- a/src/features/water-rota/components/SessionMiniCard.jsx
+++ b/src/features/water-rota/components/SessionMiniCard.jsx
@@ -16,7 +16,7 @@ const MAX_AVATARS = 3;
  * @returns {JSX.Element} Mini card
  */
 function SessionMiniCard({ session, onSelect }) {
-  const { sectionName, activity, needed, cancelled, hasMeta, confirmed, backups, status } = session;
+  const { sectionName, label, needed, cancelled, hasMeta, confirmed, backups, status } = session;
   const people = [...confirmed, ...backups];
   const overflow = people.length - MAX_AVATARS;
 
@@ -46,7 +46,7 @@ function SessionMiniCard({ session, onSelect }) {
       <span className={`block truncate px-2 py-0.5 rounded-full text-xs font-semibold text-center ${sectionChipClass(sectionName)}`}>
         {sectionName}
       </span>
-      <span className="mt-1 block truncate text-xs text-gray-600">{activity || 'Activity not set'}</span>
+      <span className="mt-1 block truncate text-xs text-gray-600">{label || (cancelled ? ' ' : 'Activity not set')}</span>
 
       <span className={`mt-1 block ${ratioMuted ? 'text-sm font-medium text-gray-400' : 'text-lg font-bold text-gray-900'}`}>
         {ratioLabel}

--- a/src/features/water-rota/components/__tests__/SessionCard.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionCard.test.jsx
@@ -12,6 +12,8 @@ function makeSession(overrides = {}) {
     sectionId: '49097',
     sectionName: 'Cubs',
     activity: 'Kayaking',
+    programmeTitle: '',
+    label: 'Kayaking',
     startTime: '18:15',
     endTime: '19:30',
     kids: 24,

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -84,12 +84,19 @@ function buildSessionOverrides(descriptors, sectionDefaults) {
   const overrides = {};
   for (const descriptor of descriptors) {
     const key = buildSessionColumnName(descriptor.date, descriptor.sectionId);
+    // The raw programme meeting title is the honest session label — store it on
+    // every session (on-water and not) so the board shows what the programme
+    // actually says instead of a guessed water-activity preset.
+    const title = descriptor.title || null;
     if (descriptor.onWater === false) {
-      overrides[key] = { c: 1 };
+      overrides[key] = title ? { c: 1, pt: title } : { c: 1 };
       continue;
     }
     const base = defaultsBySid.get(String(descriptor.sectionId));
     const override = {};
+    if (title) {
+      override.pt = title;
+    }
     if (descriptor.activity && descriptor.activity !== base?.act) {
       override.act = descriptor.activity;
     }

--- a/src/features/water-rota/services/__tests__/rotaSetupService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaSetupService.test.js
@@ -198,8 +198,44 @@ describe('syncRotaWithProgramme', () => {
 
     const result = await syncRotaWithProgramme({ rota, token: 'tok' });
 
-    expect(result).toEqual({ added: 0, orphaned: [], errors: [], uncheckedSections: [], failedSections: [] });
+    expect(result).toEqual({ added: 0, orphaned: [], errors: [], titlesUpdated: 0, uncheckedSections: [], failedSections: [] });
     expect(createOrCompleteFlexiRecord).not.toHaveBeenCalled();
+  });
+
+  it('backfills programme titles onto matching sessions when given an editor identity', async () => {
+    fetchProgrammeMeetings.mockResolvedValue([
+      { date: '2026-06-02', startTime: null, endTime: null, title: 'Cubs Kayaking' },
+      { date: '2026-06-09', startTime: null, endTime: null, title: 'Cubs Canoe Trip' },
+    ]);
+    getFlexiStructure.mockResolvedValue({
+      config: JSON.stringify([{ id: 'f_9', name: 'RotaConfig' }]),
+    });
+    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: '' }] });
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    const result = await syncRotaWithProgramme({ rota, token: 'tok', scoutid: 900, by: 'Simon Clark' });
+
+    expect(result.added).toBe(0);
+    expect(result.titlesUpdated).toBe(2);
+    // One LWW config write carrying the real meeting titles for both sessions.
+    expect(updateFlexiRecord).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.cfg.sessions).toEqual({
+      S_20260602_49097: { pt: 'Cubs Kayaking' },
+      S_20260609_49097: { pt: 'Cubs Canoe Trip' },
+    });
+  });
+
+  it('skips the title backfill (no config write) without an editor identity', async () => {
+    fetchProgrammeMeetings.mockResolvedValue([
+      { date: '2026-06-02', startTime: null, endTime: null, title: 'Cubs Kayaking' },
+      { date: '2026-06-09', startTime: null, endTime: null, title: 'Cubs Canoe Trip' },
+    ]);
+
+    const result = await syncRotaWithProgramme({ rota, token: 'tok' });
+
+    expect(result.titlesUpdated).toBe(0);
+    expect(updateFlexiRecord).not.toHaveBeenCalled();
   });
 
   it('reports a section whose programme fetch fails as failed (not unchecked) and does not orphan it', async () => {

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -121,13 +121,15 @@ export function diffSessions(existingColumns, descriptors) {
  * @param {Object} params
  * @param {import('./rotaService.js').LoadedRota} params.rota - Loaded rota with config
  * @param {string} params.token - OSM authentication token
- * @returns {Promise<{added: number, orphaned: Array, errors: Array, uncheckedSections: string[], failedSections: string[]}>}
+ * @param {string|number} [params.scoutid] - Editor's host-section row id, to attribute the title backfill config write
+ * @param {string} [params.by] - Editor display name for the title backfill config write
+ * @returns {Promise<{added: number, orphaned: Array, errors: Array, titlesUpdated: number, uncheckedSections: string[], failedSections: string[]}>}
  *   Sync outcome. `uncheckedSections` = sections with no active term (benign,
  *   nothing to sync); `failedSections` = sections whose programme fetch threw
  *   (a real error, e.g. expired token) — both are excluded from `orphaned`.
  * @throws {Error} When the rota has no config to sync against
  */
-export async function syncRotaWithProgramme({ rota, token }) {
+export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
   const cfg = rota?.config?.cfg;
   if (!cfg) {
     throw new Error('The rota has no plan config yet — run setup first');
@@ -211,10 +213,51 @@ export async function syncRotaWithProgramme({ rota, token }) {
     }, LOG_CATEGORIES.API);
   }
 
+  // Backfill programme titles onto every session (existing + newly added) so
+  // the board shows the real meeting name instead of a guessed water-activity
+  // preset. Only descriptors from sections we actually read this run are used,
+  // so a section we couldn't reach never loses its stored title. Needs the
+  // editor's identity to attribute the LWW config write; harmlessly skipped
+  // without it (titles then land on the next sync once identity resolves).
+  let titlesUpdated = 0;
+  if (scoutid && by) {
+    const nextSessions = { ...(cfg.sessions ?? {}) };
+    for (const descriptor of descriptors) {
+      if (!descriptor.title) {
+        continue;
+      }
+      const key = buildSessionColumnName(descriptor.date, descriptor.sectionId);
+      const existing = nextSessions[key] ?? {};
+      if (existing.pt !== descriptor.title) {
+        nextSessions[key] = { ...existing, pt: descriptor.title };
+        titlesUpdated += 1;
+      }
+    }
+    if (titlesUpdated > 0) {
+      try {
+        await writeRotaConfig({
+          hostSection: rota.hostSection,
+          recordId: rota.recordId,
+          termId: rota.termId,
+          scoutid,
+          by,
+          cfg: { ...cfg, sessions: nextSessions },
+          token,
+        });
+      } catch (error) {
+        titlesUpdated = 0;
+        logger.warn('Programme sync: title backfill config write failed', {
+          error: error.message,
+        }, LOG_CATEGORIES.API);
+      }
+    }
+  }
+
   return {
     added: toAdd.length - errors.filter((entry) => entry.field !== '_meta').length,
     orphaned,
     errors,
+    titlesUpdated,
     uncheckedSections: [...unchecked],
     failedSections: [...failed],
   };

--- a/src/features/water-rota/utils/__tests__/rotaDisplay.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaDisplay.test.js
@@ -180,6 +180,63 @@ describe('resolveSessionView', () => {
     expect(view.key).toBe('S_20260714_49097');
     expect(view.fieldId).toBeNull();
   });
+
+  it('does NOT label a not-on-water week with the section default activity', () => {
+    // Regression (Thu Squirrels): a dry config-only week ({c:1}) inherited the
+    // section's default water activity and wrongly showed "Kayaking".
+    const configOff = {
+      ...CONFIG,
+      cfg: { ...CONFIG.cfg, sessions: { S_20260714_49097: { c: 1 } } },
+    };
+    const view = resolveSessionView(
+      { fieldId: null, date: '2026-07-14', sectionId: '49097', meta: null, signups: [] },
+      configOff,
+    );
+    expect(view.cancelled).toBe(true);
+    expect(view.activity).toBe('');
+    expect(view.label).toBe('');
+  });
+
+  it('shows the programme title as the label, above the water-activity preset', () => {
+    const configWithTitle = {
+      ...CONFIG,
+      cfg: {
+        ...CONFIG.cfg,
+        sessions: { S_20260714_49097: { pt: 'Beavers River Day', act: 'Canoeing' } },
+      },
+    };
+    const view = resolveSessionView({ ...baseSession, meta: null, signups: [] }, configWithTitle);
+    expect(view.programmeTitle).toBe('Beavers River Day');
+    expect(view.label).toBe('Beavers River Day');
+    expect(view.activity).toBe('Canoeing');
+  });
+
+  it('keeps the programme title on a not-on-water week (label = title, no water preset)', () => {
+    const configOff = {
+      ...CONFIG,
+      cfg: { ...CONFIG.cfg, sessions: { S_20260714_49097: { c: 1, pt: 'Squirrels Craft Night' } } },
+    };
+    const view = resolveSessionView(
+      { fieldId: null, date: '2026-07-14', sectionId: '49097', meta: null, signups: [] },
+      configOff,
+    );
+    expect(view.cancelled).toBe(true);
+    expect(view.label).toBe('Squirrels Craft Night');
+    expect(view.activity).toBe('');
+  });
+
+  it('leaves the label empty for an on-water week with no title and no activity', () => {
+    // Regression (Wed Beavers): the title guess missed and the section default
+    // was empty, so the board showed "Activity not set". Capturing the title
+    // (above) is the fix; here we pin that label is '' without one.
+    const configNoAct = {
+      ...CONFIG,
+      cfg: { ...CONFIG.cfg, sections: [{ ...CONFIG.cfg.sections[0], act: '' }] },
+    };
+    const view = resolveSessionView({ ...baseSession, meta: null, signups: [] }, configNoAct);
+    expect(view.cancelled).toBe(false);
+    expect(view.label).toBe('');
+  });
 });
 
 describe('resolveAllSessions', () => {

--- a/src/features/water-rota/utils/rotaDisplay.js
+++ b/src/features/water-rota/utils/rotaDisplay.js
@@ -54,7 +54,9 @@ export function coverStatus({ confirmedCount, backupCount, needed, cancelled }) 
  * @property {string} date - yyyy-mm-dd
  * @property {string} sectionId - OSM section id
  * @property {string} sectionName - Display section name
- * @property {string} activity - Activity name
+ * @property {string} activity - Water-activity preset (Kayaking/Canoeing/…); '' when unset or not on water
+ * @property {string} programmeTitle - Programme meeting title captured from OSM ('' when none)
+ * @property {string} label - Board label: programmeTitle, falling back to activity ('' when neither)
  * @property {string} startTime - HH:mm
  * @property {string} endTime - HH:mm
  * @property {number|null} kids - Expected young people, null when unset
@@ -91,6 +93,19 @@ export function resolveSessionView(session, config, sectionNames = {}) {
   const confirmed = session.signups.filter((signup) => signup.status === SIGNUP_STATUS.IN);
   const backups = session.signups.filter((signup) => signup.status === SIGNUP_STATUS.BACKUP);
 
+  const cancelled = (meta?.c ?? override?.c ?? 0) === 1;
+  // Water-activity preset (Kayaking/Canoeing/…): kept for the edit form and
+  // permit context. A not-on-water week must NOT inherit the section's default
+  // water activity — that fall-through is what wrongly labelled a dry week
+  // "Kayaking". Only on-water weeks borrow the section default.
+  const activity = cancelled
+    ? (meta?.act ?? override?.act ?? '')
+    : (meta?.act ?? override?.act ?? sectionDefaults?.act ?? '');
+  // The programme meeting title, captured at setup and refreshed on sync. This
+  // is the honest label for a session — shown in preference to the guessed
+  // water-activity preset (which was often wrong or empty).
+  const programmeTitle = meta?.pt ?? override?.pt ?? '';
+
   const view = {
     fieldId: session.fieldId,
     // Stable identity for React keys and selection — session columns share it
@@ -99,13 +114,18 @@ export function resolveSessionView(session, config, sectionNames = {}) {
     date: session.date,
     sectionId: session.sectionId,
     sectionName: sectionDefaults?.sname ?? sectionNames[String(session.sectionId)] ?? `Section ${session.sectionId}`,
-    activity: meta?.act ?? override?.act ?? sectionDefaults?.act ?? '',
+    activity,
+    programmeTitle,
+    // What the board displays for "what is this session": the real programme
+    // title, falling back to the water-activity preset for rotas set up before
+    // titles were captured ('' when neither exists).
+    label: programmeTitle || activity,
     startTime: meta?.st ?? override?.st ?? sectionDefaults?.st ?? '',
     endTime: meta?.en ?? override?.en ?? sectionDefaults?.en ?? '',
     kids: meta?.k ?? override?.k ?? sectionDefaults?.k ?? null,
     needed: meta?.p ?? override?.p ?? sectionDefaults?.p ?? null,
     notes: meta?.n ?? '',
-    cancelled: (meta?.c ?? override?.c ?? 0) === 1,
+    cancelled,
     hasMeta: Boolean(meta),
     confirmed,
     backups,


### PR DESCRIPTION
## Bugs

Two board labelling bugs you spotted, one root cause:

- **Wed Beavers (on-water)** showed **"Activity not set"** — its programme meeting title didn't match a water-activity preset, so `guessActivityFromTitle` returned nothing and no label was stored.
- **Thu Squirrels (not-on-water)** showed **"Kayaking"** — not-on-water weeks store only `{c:1}`, so the label fell through to the section's *default* water activity, and the mini-card never suppressed activity for cancelled weeks.

The session label was derived from a **guessed water-activity preset** instead of the programme itself.

## Fix — show the real programme title

- **Store the title.** The programme meeting title (`pt`) is now saved in the per-session config override at setup, for every week (on-water and not).
- **Backfill existing rotas.** Programme-sync writes `pt` onto existing sessions (attributed via the editor's identity, standard LWW config write), so the current rota gets titles **without re-running setup**. Surfaced as *"Updated N session names from the programme."*
- **Display.** `resolveSessionView` now exposes `programmeTitle` and a `label` (programme title → falls back to the water-activity preset → `''`). The board, card, and modal render `label`. A not-on-water week **no longer inherits** the section's default activity.
- **Preset preserved.** The water-activity preset (Kayaking/Canoeing/…) stays editable in the session form for permit context — it's just no longer the primary board label.

Result: Beavers shows its actual meeting name; Squirrels shows its real title (or blank when dry), never a bogus "Kayaking".

## Tests

- `rotaDisplay`: not-on-water no longer inherits the section default; programme title becomes the label (on-water and not-on-water); on-water with neither title nor activity is blank.
- `rotaSetupService`: sync backfills titles when given an identity; skips the config write without one.
- Full suite: 852 passing / 13 skipped. Lint 0 errors. Build ✅.

## Note
Your current rota gets its titles the next time you tap **Sync with programme** (while signed in) — that runs the backfill.

🤖 Generated with [Claude Code](https://claude.ai/code)