### PR TITLE
feat: show the water activity as a tag beside the programme title on the rota

### DIFF
--- a/src/features/water-rota/components/SessionCard.jsx
+++ b/src/features/water-rota/components/SessionCard.jsx
@@ -33,6 +33,7 @@ function SessionCard({
     date,
     sectionName,
     label,
+    activityTag,
     startTime,
     endTime,
     kids,
@@ -87,6 +88,11 @@ function SessionCard({
             <span className="text-sm font-medium text-gray-800">
               {label || 'Activity not set'}
             </span>
+            {activityTag && (
+              <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+                {activityTag}
+              </span>
+            )}
             {kids !== null && (
               <span className="text-xs text-gray-500">~{kids} YP</span>
             )}

--- a/src/features/water-rota/components/SessionDetailModal.jsx
+++ b/src/features/water-rota/components/SessionDetailModal.jsx
@@ -221,6 +221,11 @@ function SessionDetailModal({
             <div className="text-sm text-gray-700">
               <p className="font-medium text-gray-900">
                 {session.label || 'Activity not set'}
+                {session.activityTag && (
+                  <span className="ml-2 rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
+                    {session.activityTag}
+                  </span>
+                )}
                 {session.startTime && (
                   <span className="ml-2 font-normal text-gray-500">
                     {session.startTime}–{session.endTime}

--- a/src/features/water-rota/components/SessionMiniCard.jsx
+++ b/src/features/water-rota/components/SessionMiniCard.jsx
@@ -16,7 +16,7 @@ const MAX_AVATARS = 3;
  * @returns {JSX.Element} Mini card
  */
 function SessionMiniCard({ session, onSelect }) {
-  const { sectionName, label, needed, cancelled, hasMeta, confirmed, backups, status } = session;
+  const { sectionName, label, activityTag, needed, cancelled, hasMeta, confirmed, backups, status } = session;
   const people = [...confirmed, ...backups];
   const overflow = people.length - MAX_AVATARS;
 
@@ -47,6 +47,11 @@ function SessionMiniCard({ session, onSelect }) {
         {sectionName}
       </span>
       <span className="mt-1 block truncate text-xs text-gray-600">{label || (cancelled ? ' ' : 'Activity not set')}</span>
+      {activityTag && (
+        <span className="mt-0.5 inline-block max-w-full truncate rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 align-top">
+          {activityTag}
+        </span>
+      )}
 
       <span className={`mt-1 block ${ratioMuted ? 'text-sm font-medium text-gray-400' : 'text-lg font-bold text-gray-900'}`}>
         {ratioLabel}

--- a/src/features/water-rota/components/__tests__/SessionCard.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionCard.test.jsx
@@ -14,6 +14,7 @@ function makeSession(overrides = {}) {
     activity: 'Kayaking',
     programmeTitle: '',
     label: 'Kayaking',
+    activityTag: '',
     startTime: '18:15',
     endTime: '19:30',
     kids: 24,
@@ -42,6 +43,13 @@ describe('SessionCard', () => {
     expect(screen.getByText('~24 YP')).toBeInTheDocument();
     expect(screen.getByText('of 3 permit holders', { exact: false })).toBeInTheDocument();
     expect(screen.getByText('· 1 backup', { exact: false })).toBeInTheDocument();
+  });
+
+  it('shows the programme title as the label and the activity as a secondary tag', () => {
+    render(<SessionCard session={makeSession({ label: 'Bell boats', activity: 'Kayaking', activityTag: 'Kayaking', programmeTitle: 'Bell boats' })} />);
+
+    expect(screen.getByText('Bell boats')).toBeInTheDocument();
+    expect(screen.getByText('Kayaking')).toBeInTheDocument();
   });
 
   it('renders the not-on-water state without cover details', () => {

--- a/src/features/water-rota/utils/__tests__/rotaDisplay.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaDisplay.test.js
@@ -209,6 +209,24 @@ describe('resolveSessionView', () => {
     expect(view.programmeTitle).toBe('Beavers River Day');
     expect(view.label).toBe('Beavers River Day');
     expect(view.activity).toBe('Canoeing');
+    // Both values present and different → activity rides along as a tag.
+    expect(view.activityTag).toBe('Canoeing');
+  });
+
+  it('suppresses the activity tag when it has no title or would duplicate the label', () => {
+    // Activity only, no title → activity is the main label, so no tag.
+    const noTitle = resolveSessionView({ ...baseSession, meta: null, signups: [] }, CONFIG);
+    expect(noTitle.label).toBe('Kayaking');
+    expect(noTitle.activityTag).toBe('');
+
+    // Title equal to the activity → don't show it twice.
+    const dupe = {
+      ...CONFIG,
+      cfg: { ...CONFIG.cfg, sessions: { S_20260714_49097: { pt: 'Kayaking', act: 'Kayaking' } } },
+    };
+    const dupeView = resolveSessionView({ ...baseSession, meta: null, signups: [] }, dupe);
+    expect(dupeView.label).toBe('Kayaking');
+    expect(dupeView.activityTag).toBe('');
   });
 
   it('keeps the programme title on a not-on-water week (label = title, no water preset)', () => {

--- a/src/features/water-rota/utils/rotaDisplay.js
+++ b/src/features/water-rota/utils/rotaDisplay.js
@@ -57,6 +57,7 @@ export function coverStatus({ confirmedCount, backupCount, needed, cancelled }) 
  * @property {string} activity - Water-activity preset (Kayaking/Canoeing/…); '' when unset or not on water
  * @property {string} programmeTitle - Programme meeting title captured from OSM ('' when none)
  * @property {string} label - Board label: programmeTitle, falling back to activity ('' when neither)
+ * @property {string} activityTag - Water activity shown as a tag beneath the title ('' when it would duplicate the title or there is no title)
  * @property {string} startTime - HH:mm
  * @property {string} endTime - HH:mm
  * @property {number|null} kids - Expected young people, null when unset
@@ -105,6 +106,11 @@ export function resolveSessionView(session, config, sectionNames = {}) {
   // is the honest label for a session — shown in preference to the guessed
   // water-activity preset (which was often wrong or empty).
   const programmeTitle = meta?.pt ?? override?.pt ?? '';
+  // When a session has both a programme title AND a water activity, the title
+  // leads and the activity rides alongside as a secondary tag. Suppressed when
+  // they'd duplicate, or when there is no title for a tag to sit under (then the
+  // activity is already the main label).
+  const activityTag = programmeTitle && activity && activity !== programmeTitle ? activity : '';
 
   const view = {
     fieldId: session.fieldId,
@@ -120,6 +126,9 @@ export function resolveSessionView(session, config, sectionNames = {}) {
     // title, falling back to the water-activity preset for rotas set up before
     // titles were captured ('' when neither exists).
     label: programmeTitle || activity,
+    // Secondary label: the water activity shown as a tag beneath the title
+    // ('' when it would duplicate the title or there is no title).
+    activityTag,
     startTime: meta?.st ?? override?.st ?? sectionDefaults?.st ?? '',
     endTime: meta?.en ?? override?.en ?? sectionDefaults?.en ?? '',
     kids: meta?.k ?? override?.k ?? sectionDefaults?.k ?? null,


### PR DESCRIPTION
## Why

The rota now stores **two values per session** — the programme title (`pt`) and the water activity (`act`). But the board label only showed the title, so an activity a leader had **deliberately set** was stored yet invisible on the tile (only reachable in the edit form).

## Change — show both

The programme title stays the primary label; the water activity rides alongside as a small secondary tag.

- `resolveSessionView` adds **`activityTag`** — the activity, shown **only** when a title exists and the two differ (never duplicates the label; never dangles without a title to sit under).
- `SessionMiniCard`, `SessionCard`, and `SessionDetailModal` render the tag beneath/beside the title.

Example: a "Bell boats" week where a leader set "Kayaking" now shows **Bell boats** with a **Kayaking** tag. A week whose title *is* the activity shows it once.

## Tests
- `activityTag` set when title + activity differ; suppressed when there's no title or they'd duplicate.
- `SessionCard` renders both the title and the tag.
- Full suite: 854 passing / 13 skipped. Lint 0 errors. Build ✅.

🤖 Generated with [Claude Code](https://claude.ai/code)