### PR TITLE
fix: rota session edit no longer locked out by a malformed stored time

### DIFF
--- a/src/features/water-rota/components/SessionEditForm.jsx
+++ b/src/features/water-rota/components/SessionEditForm.jsx
@@ -15,10 +15,28 @@ import { ACTIVITY_PRESETS } from '../services/rotaTemplates.js';
  * @param {string} [props.submitLabel] - Submit button label when not saving
  * @returns {JSX.Element} Edit form
  */
+/**
+ * Coerce a stored time to a clean 24h "HH:mm" that both the <input type="time">
+ * and the save-validation accept. Tolerates a stray space, a seconds suffix, or
+ * a single-digit hour; anything unparseable returns null so the caller applies
+ * its own default. Without this, a session whose time was stored slightly off
+ * (e.g. "12:30:00") would lock the edit form with a permanently-greyed Save.
+ *
+ * @param {*} value - Stored time value
+ * @returns {string|null} "HH:mm", or null when absent/unparseable
+ */
+function toClockValue(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const match = /^(\d{1,2}):(\d{2})(?::\d{2})?$/.exec(value.trim());
+  return match ? `${match[1].padStart(2, '0')}:${match[2]}` : null;
+}
+
 function SessionEditForm({ session, sectionYPCount, saving = false, onSave, submitLabel = 'Save session' }) {
   const [activity, setActivity] = useState(session.activity ?? '');
-  const [startTime, setStartTime] = useState(session.startTime ?? '18:30');
-  const [endTime, setEndTime] = useState(session.endTime ?? '20:00');
+  const [startTime, setStartTime] = useState(toClockValue(session.startTime) ?? '18:30');
+  const [endTime, setEndTime] = useState(toClockValue(session.endTime) ?? '20:00');
   const [kids, setKids] = useState(session.kids ?? sectionYPCount ?? 0);
   const [needed, setNeeded] = useState(session.needed ?? 0);
   const [notes, setNotes] = useState(session.notes ?? '');

--- a/src/features/water-rota/components/__tests__/SessionEditForm.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionEditForm.test.jsx
@@ -82,6 +82,26 @@ describe('SessionEditForm', () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
+  it('normalizes a malformed stored time so Save is not locked out', () => {
+    const onSave = vi.fn();
+    // A session whose times were stored with a seconds suffix would fail the
+    // HH:mm save check and grey out Save even with an activity — regression.
+    render(
+      <SessionEditForm
+        session={makeSession({ startTime: '12:30:00', endTime: '14:00:00' })}
+        sectionYPCount={30}
+        onSave={onSave}
+      />,
+    );
+
+    // Activity is already set; Save must work despite the odd stored times.
+    fireEvent.click(screen.getByText('Save session'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].st).toBe('12:30');
+    expect(onSave.mock.calls[0][0].en).toBe('14:00');
+  });
+
   it('renders a custom submit label', () => {
     const onSave = vi.fn();
     render(


### PR DESCRIPTION
## Bug (reported live)

Sessions showing **"12:30–12:30"** couldn't be edited — the **Save button stayed greyed even with an activity selected**. Root cause: the save-validation is strict `HH:mm`:

```js
const valid = activity.trim() !== '' && /^\d{2}:\d{2}$/.test(startTime) && /^\d{2}:\d{2}$/.test(endTime);
```

If a session's stored start/end time is slightly off — a seconds suffix (`12:30:00`), a stray space, a single-digit hour — it displays as ~"12:30" but **fails the regex**, so Save is permanently disabled and the leader is locked out of that session.

## Fix

Normalize the incoming time when the edit form opens (`toClockValue`) so the field starts as a clean `HH:mm` that both the `<input type="time">` and the validation accept. Unparseable values fall back to the default (18:30 / 20:00) rather than locking Save. Because the saved value is always clean, the session's displayed time **self-heals on the next save**.

Tolerates: `"12:30:00"` → `12:30`, `" 12:30"` / `"12:30 "` → `12:30`, `"9:30"` → `09:30`.

## Test
A session with `'12:30:00'` / `'14:00:00'` now saves and writes `'12:30'` / `'14:00'`.

Full suite: 862 passing / 13 skipped. Lint 0 errors. Build ✅.

## Note
This unblocks editing. The upstream question of *how* a malformed time got stored (a specific session set to 12:30–12:30 with no activity, off the current programme) is separate — those sessions can now be corrected by hand via Edit, and re-saving cleans the stored value.

🤖 Generated with [Claude Code](https://claude.ai/code)