### PR TITLE
feat: rota board — a card per week with sessions tiling across the width

### DIFF
--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -12,7 +12,7 @@ import {
   resolveAllSessions,
   withdrawalNeedsConfirm,
 } from '../utils/rotaDisplay.js';
-import { bucketSessionsByWeek, groupSessionsByDay, startOfIsoWeek } from '../utils/rotaDates.js';
+import { bucketSessionsByWeek, startOfIsoWeek } from '../utils/rotaDates.js';
 import { useRotaPermissions } from '../hooks/useRotaPermissions.js';
 import { useSectionYPCounts } from '../hooks/useSectionYPCounts.js';
 import { useOnlineStatus } from '../hooks/useOnlineStatus.js';
@@ -454,8 +454,11 @@ function RotaBoardPage() {
                 }
               }}
               aria-label={`Week of ${format(parseISO(weekStart), 'd MMMM yyyy')}`}
+              className={`rounded-xl border bg-white p-3 shadow-sm sm:p-4 ${
+                weekStart === currentWeekStart ? 'border-scout-blue/40' : 'border-gray-200'
+              }`}
             >
-              <h2 className={`text-sm font-semibold py-1.5 ${
+              <h2 className={`pb-2 text-sm font-semibold ${
                 weekStart === currentWeekStart ? 'text-scout-blue' : 'text-gray-500'
               }`}>
                 Week of {format(parseISO(weekStart), 'd MMMM')}
@@ -463,22 +466,16 @@ function RotaBoardPage() {
                   <span className="ml-2 text-xs font-medium uppercase tracking-wide">this week</span>
                 )}
               </h2>
-              <div className="space-y-3">
-                {groupSessionsByDay(weekSessions).map(({ date, sessions: daySessions }) => (
-                  <div key={date}>
-                    <h3 className="pt-1 text-xs font-semibold text-gray-500">
-                      {format(parseISO(date), 'EEEE d MMM')}
-                    </h3>
-                    <div className="mt-1 flex gap-2 overflow-x-auto pb-1">
-                      {daySessions.map((session) => (
-                        <SessionMiniCard
-                          key={session.key}
-                          session={session}
-                          onSelect={() => openSession(session.key)}
-                        />
-                      ))}
-                    </div>
-                  </div>
+              {/* Every session that week tiles across the card — each section's
+                  nights are separate tiles, filling the width instead of a
+                  narrow per-day strip. */}
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {weekSessions.map((session) => (
+                  <SessionMiniCard
+                    key={session.key}
+                    session={session}
+                    onSelect={() => openSession(session.key)}
+                  />
                 ))}
               </div>
             </section>

--- a/src/features/water-rota/components/SessionMiniCard.jsx
+++ b/src/features/water-rota/components/SessionMiniCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { format, parseISO } from 'date-fns';
 import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
 import { COVER_STATUS, coverStatusTintClass, sectionChipClass } from '../utils/rotaDisplay.js';
 
@@ -16,7 +17,7 @@ const MAX_AVATARS = 3;
  * @returns {JSX.Element} Mini card
  */
 function SessionMiniCard({ session, onSelect }) {
-  const { sectionName, label, activityTag, needed, cancelled, hasMeta, confirmed, backups, status } = session;
+  const { sectionName, date, label, activityTag, needed, cancelled, hasMeta, confirmed, backups, status } = session;
   const people = [...confirmed, ...backups];
   const overflow = people.length - MAX_AVATARS;
 
@@ -39,12 +40,17 @@ function SessionMiniCard({ session, onSelect }) {
       type="button"
       data-testid={`minicard-${session.key}`}
       onClick={() => onSelect(session)}
-      className={`w-44 min-w-[11rem] rounded-lg border p-2.5 text-left ${coverStatusTintClass(status)} ${
+      className={`w-full rounded-lg border p-2.5 text-left ${coverStatusTintClass(status)} ${
         cancelled ? 'opacity-70' : ''
       }`}
     >
-      <span className={`block truncate px-2 py-0.5 rounded-full text-xs font-semibold text-center ${sectionChipClass(sectionName)}`}>
-        {sectionName}
+      <span className="flex items-center justify-between gap-1.5">
+        <span className={`truncate px-2 py-0.5 rounded-full text-xs font-semibold ${sectionChipClass(sectionName)}`}>
+          {sectionName}
+        </span>
+        <span className="shrink-0 text-[11px] font-medium text-gray-500">
+          {format(parseISO(date), 'EEE d MMM')}
+        </span>
       </span>
       <span className="mt-1 block truncate text-xs text-gray-600">{label || (cancelled ? ' ' : 'Activity not set')}</span>
       {activityTag && (

--- a/src/features/water-rota/components/__tests__/SessionMiniCard.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionMiniCard.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import SessionMiniCard from '../SessionMiniCard.jsx';
+import { COVER_STATUS } from '../../utils/rotaDisplay.js';
+
+function makeSession(overrides = {}) {
+  return {
+    key: 'S_20260708_49097',
+    fieldId: 'f_2',
+    date: '2026-07-08',
+    sectionId: '49097',
+    sectionName: 'Beavers',
+    label: 'Bell boats',
+    activityTag: 'Kayaking',
+    needed: 3,
+    cancelled: false,
+    hasMeta: true,
+    confirmed: [{ scoutid: '1', name: 'Alice Smith', status: 'I', photo_guid: null }],
+    backups: [],
+    status: COVER_STATUS.SHORT,
+    ...overrides,
+  };
+}
+
+describe('SessionMiniCard', () => {
+  it('shows section, its own date, the label, activity tag, and cover ratio', () => {
+    render(<SessionMiniCard session={makeSession()} onSelect={() => {}} />);
+
+    expect(screen.getByText('Beavers')).toBeInTheDocument();
+    // The tile carries its own date now that day headers are gone.
+    expect(screen.getByText('Wed 8 Jul')).toBeInTheDocument();
+    expect(screen.getByText('Bell boats')).toBeInTheDocument();
+    expect(screen.getByText('Kayaking')).toBeInTheDocument();
+    expect(screen.getByText('1/3')).toBeInTheDocument();
+  });
+
+  it('shows "Not on water" and never "Activity not set" for a cancelled week', () => {
+    render(
+      <SessionMiniCard
+        session={makeSession({ cancelled: true, label: '', status: COVER_STATUS.OFF })}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Not on water')).toBeInTheDocument();
+    expect(screen.queryByText('Activity not set')).not.toBeInTheDocument();
+  });
+
+  it('prompts "Activity not set" and "Set up" for an on-water week with no meta or label', () => {
+    render(
+      <SessionMiniCard
+        session={makeSession({ label: '', hasMeta: false, needed: null, confirmed: [], status: COVER_STATUS.UNSET })}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Activity not set')).toBeInTheDocument();
+    expect(screen.getByText('Set up')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when tapped', () => {
+    const onSelect = vi.fn();
+    render(<SessionMiniCard session={makeSession()} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId('minicard-S_20260708_49097'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Implements the approved layout redesign (mockup: card-per-week, sessions tiling across).

## Problem
The board rendered **Week → Day → a fixed-width (`w-44`) horizontal strip**. Since most days have 1–2 sessions, a wide monitor showed a tall, skinny column with lots of empty margin and endless vertical scroll — painful on setup day.

## Change
A **card per week**, with every session that week tiling across a **responsive grid** (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`), mirroring the event-attendance layout.

- Each week is a bordered card; the current week is highlighted.
- **Every session is its own tile** — each section's multiple nights (2 Cubs, 2 Scouts, …) show separately and fill the width, no per-day strips.
- `SessionMiniCard` now carries **its own day/date** (day sub-headers are gone) and is **full-width** so it fills its grid cell.
- Cards collapse 4 → 3 → 2 → 1 columns as the screen narrows, so it works on mobile.

## Filtering (unchanged, by design)
The section filter stays a **display-only choice of sections** — it narrows what's shown and **never touches the plan/config**. (If the pills are missing, that's the separate config-losing-a-section issue, not this change.)

## Tests
New `SessionMiniCard` coverage (it had none): renders section/date/label/activity-tag/ratio; not-on-water shows "Not on water" and never "Activity not set"; an on-water week with no meta prompts "Activity not set" + "Set up"; tap calls `onSelect`.

Full suite: 866 passing / 13 skipped. Lint 0 errors. Build ✅.

🤖 Generated with [Claude Code](https://claude.ai/code)