### PR TITLE
fix: per-section rota setup merges into shared config instead of wiping it

### DIFF
--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -343,6 +343,10 @@ function RotaSetupWizard() {
         termId: rota.termId,
         scoutid: configRow.scoutid,
         by,
+        // Merge this run's sections into the shared config rather than
+        // replacing it — section leaders set up their own section, so a save
+        // must not delete the others. The rota-wide range grows to cover it.
+        mergeSections: true,
         cfg: {
           start: range.start,
           end: range.end,

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -336,11 +336,12 @@ export async function writeSessionMeta({ rota, fieldId, scoutid, by, fields, tok
  * @param {string} params.configFieldId - RotaConfig column field id (f_N)
  * @param {string|number} params.scoutid - The editor's member row id
  * @param {string} params.by - Editor display name
- * @param {Object} params.cfg - Full plan config ({start, end, termId?, sections})
+ * @param {Object} params.cfg - Full plan config ({start, end, termId?, sections}); ignored when transformCfg is given
+ * @param {(liveCfg: Object) => Object} [params.transformCfg] - When set, derive the config to write from the live winner read inside the lock (used to merge one section's setup into the shared config without clobbering others), instead of replacing with `cfg`
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  */
-export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, token }) {
+export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, transformCfg, token }) {
   await writeOwnCell({
     rota,
     fieldId: configFieldId,
@@ -348,11 +349,12 @@ export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, token
     token,
     mutate: (_ownRaw, items) => {
       const winner = mergeLwwConfig(items.map((item) => item[configFieldId]));
+      const nextCfg = transformCfg ? transformCfg(winner?.cfg ?? {}) : cfg;
       return encodeConfig({
         v: (winner?.v ?? 0) + 1,
         at: new Date().toISOString(),
         by,
-        cfg,
+        cfg: nextCfg,
       });
     },
   });

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -28,6 +28,7 @@ import { ROTA_CREATE_OPTIONS, buildRotaRecordName } from './rotaTemplates.js';
 import { loadRota, prefillRegulars, writeConfig, writeSessionMeta } from './rotaService.js';
 import { fetchProgrammeMeetings } from './programmeService.js';
 import { generateSessionsFromProgramme } from '../utils/rotaDates.js';
+import { mergeSectionConfig } from '../utils/rotaSetupPlan.js';
 
 /**
  * Create or complete the rota record for a year on the host section.
@@ -64,12 +65,13 @@ export async function createOrCompleteRota({ hostSection, year, termId, sessions
  * @param {string|number} params.termId - Term id
  * @param {string|number} params.scoutid - The editor's member row id in the host section
  * @param {string} params.by - Editor display name
- * @param {Object} params.cfg - Full plan config ({start, end, termId?, sections})
+ * @param {Object} params.cfg - Plan config. A full config for the initial write, or one section's slice when mergeSections is set ({start, end, sections, sessions})
+ * @param {boolean} [params.mergeSections] - Merge `cfg`'s sections into the live shared config instead of replacing it, so a per-section setup never deletes other leaders' sections and the date range grows (union) to cover it
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  * @throws {Error} When the RotaConfig column cannot be found
  */
-export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, token }) {
+export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, token, mergeSections = false }) {
   const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, true);
   const configFieldId = findConfigFieldId(structureData);
   if (!configFieldId) {
@@ -81,7 +83,9 @@ export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, 
     configFieldId,
     scoutid,
     by,
-    cfg,
+    ...(mergeSections
+      ? { transformCfg: (live) => mergeSectionConfig(live, cfg) }
+      : { cfg }),
     token,
   });
 }

--- a/src/features/water-rota/utils/__tests__/rotaSetupPlan.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaSetupPlan.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { buildSessionOverrides } from '../rotaSetupPlan.js';
+import { buildSessionOverrides, mergeSectionConfig } from '../rotaSetupPlan.js';
 
 describe('buildSessionOverrides', () => {
   const sectionDefaults = [{ sid: '49097', act: 'Kayaking', st: '18:15', en: '19:30' }];
@@ -57,5 +57,68 @@ describe('buildSessionOverrides', () => {
       sectionDefaults,
     );
     expect(overrides.S_20260714_49097).toEqual({ c: 1 });
+  });
+});
+
+describe('mergeSectionConfig', () => {
+  const base = {
+    start: '2026-06-01',
+    end: '2026-07-31',
+    sections: [
+      { sid: '10', sname: 'Beavers', act: 'Kayaking' },
+      { sid: '20', sname: 'Cubs', act: 'Canoeing' },
+    ],
+    sessions: {
+      S_20260603_10: { pt: 'Beavers night' },
+      S_20260605_20: { pt: 'Cubs night', c: 1 },
+    },
+  };
+
+  it('rewrites only the touched section and preserves the others', () => {
+    // Beavers leader re-runs setup; Cubs must be untouched.
+    const patch = {
+      start: '2026-06-08',
+      end: '2026-07-31',
+      sections: [{ sid: '10', sname: 'Beavers', act: 'Canoeing' }],
+      sessions: { S_20260610_10: { pt: 'Beavers new' } },
+    };
+    const merged = mergeSectionConfig(base, patch);
+
+    // Cubs section + its session survive intact
+    expect(merged.sections).toContainEqual({ sid: '20', sname: 'Cubs', act: 'Canoeing' });
+    expect(merged.sessions.S_20260605_20).toEqual({ pt: 'Cubs night', c: 1 });
+    // Beavers is replaced: new defaults, old session dropped, new session added
+    expect(merged.sections.find((s) => s.sid === '10')).toEqual({ sid: '10', sname: 'Beavers', act: 'Canoeing' });
+    expect(merged.sessions.S_20260603_10).toBeUndefined();
+    expect(merged.sessions.S_20260610_10).toEqual({ pt: 'Beavers new' });
+  });
+
+  it('unions the date range so a section extends it, never truncates', () => {
+    const merged = mergeSectionConfig(base, {
+      start: '2026-05-15', end: '2026-08-31', sections: [{ sid: '10' }], sessions: {},
+    });
+    expect(merged.start).toBe('2026-05-15');
+    expect(merged.end).toBe('2026-08-31');
+  });
+
+  it('keeps the base range when the patch range sits inside it', () => {
+    const merged = mergeSectionConfig(base, {
+      start: '2026-06-10', end: '2026-07-10', sections: [{ sid: '10' }], sessions: {},
+    });
+    expect(merged.start).toBe('2026-06-01');
+    expect(merged.end).toBe('2026-07-31');
+  });
+
+  it('acts as a plain write when the base config is empty (first setup)', () => {
+    const patch = {
+      start: '2026-06-01', end: '2026-07-31',
+      sections: [{ sid: '10', sname: 'Beavers' }],
+      sessions: { S_20260603_10: { pt: 'x' } },
+    };
+    const merged = mergeSectionConfig({}, patch);
+    expect(merged.sections).toEqual([{ sid: '10', sname: 'Beavers' }]);
+    expect(merged.sessions).toEqual({ S_20260603_10: { pt: 'x' } });
+    expect(merged.start).toBe('2026-06-01');
+    expect(merged.end).toBe('2026-07-31');
   });
 });

--- a/src/features/water-rota/utils/rotaSetupPlan.js
+++ b/src/features/water-rota/utils/rotaSetupPlan.js
@@ -6,7 +6,74 @@
  * @module rotaSetupPlan
  */
 
-import { buildSessionColumnName } from '../services/rotaEncoding.js';
+import { buildSessionColumnName, parseSessionColumnName } from '../services/rotaEncoding.js';
+
+/**
+ * Earlier of two yyyy-mm-dd date strings, ignoring null/undefined.
+ * @param {string|null|undefined} a
+ * @param {string|null|undefined} b
+ * @returns {string|undefined}
+ */
+function earlier(a, b) {
+  if (!a) return b || undefined;
+  if (!b) return a;
+  return a <= b ? a : b;
+}
+
+/**
+ * Later of two yyyy-mm-dd date strings, ignoring null/undefined.
+ * @param {string|null|undefined} a
+ * @param {string|null|undefined} b
+ * @returns {string|undefined}
+ */
+function later(a, b) {
+  if (!a) return b || undefined;
+  if (!b) return a;
+  return a >= b ? a : b;
+}
+
+/**
+ * Merge one setup run's sections into the shared rota config without disturbing
+ * the sections it didn't touch. Section leaders set up their own section, so a
+ * save must NEVER replace the whole config (which would delete every other
+ * leader's section). Only the sections in `patch` are rewritten; the rota-wide
+ * date range grows to cover the patch (union), so each section extends it.
+ *
+ * @param {Object|null|undefined} base - Live shared config ({start,end,sections,sessions})
+ * @param {{sections?: Array<{sid: string}>, sessions?: Object, start?: string, end?: string}} patch - This run's data
+ * @returns {Object} Merged config
+ */
+export function mergeSectionConfig(base, patch) {
+  const baseCfg = base ?? {};
+  const p = patch ?? {};
+  const touched = new Set((p.sections ?? []).map((s) => String(s.sid)));
+
+  // Sections: keep untouched sections, replace/add the touched ones.
+  const sections = [
+    ...(baseCfg.sections ?? []).filter((s) => !touched.has(String(s.sid))),
+    ...(p.sections ?? []),
+  ];
+
+  // Sessions: drop the touched sections' old overrides (this run redefines
+  // them), keep every other section's, then add this run's.
+  const sessions = {};
+  for (const [col, override] of Object.entries(baseCfg.sessions ?? {})) {
+    const parsed = parseSessionColumnName(col);
+    if (parsed && touched.has(String(parsed.sectionId))) {
+      continue;
+    }
+    sessions[col] = override;
+  }
+  Object.assign(sessions, p.sessions ?? {});
+
+  return {
+    ...baseCfg,
+    start: earlier(baseCfg.start, p.start),
+    end: later(baseCfg.end, p.end),
+    sections,
+    sessions,
+  };
+}
 
 /**
  * Build the per-session config map from all generated descriptors: water


### PR DESCRIPTION
## The data-loss bug

Section leaders set up **their own section**, but the setup wizard wrote `cfg: { sections: <only this run's>, sessions: <only this run's> }` and this **replaced** the entire shared config (LWW, highest version wins).

> One leader saving their section **deleted every other section** from the rota — section defaults gone (so the filter pills vanish), other sections' sessions stripped of their overrides and left orphaned / reset to defaults.

This is the root cause of the "broken config" behind the missing pills, the 12:30 defaults, and the "Activity not set" sessions.

## Fix — merge, don't replace

The setup config write is now a **merge against the live config**, done inside the LWW lock:

- **`mergeSectionConfig`** (pure): keep every untouched section and its session overrides; rewrite only the sections in this run; **union** the date range so each section *extends* it rather than truncating another's.
- **`writeConfig`** gains `transformCfg(liveCfg)` — the merge runs against the winner read inside the write lock, so two leaders saving near-simultaneously don't clobber each other.
- **`writeRotaConfig({ mergeSections: true })`** wires it; the wizard opts in.

Now per-section setup is genuinely independent: Beavers' leader saving never touches Cubs.

## Tests
- A section re-run **preserves the other sections and their sessions**.
- Range **unions** (extends, never truncates); a patch inside the base range keeps the base range.
- Empty base behaves as a plain first write.

Full suite: 870 passing / 13 skipped. Lint 0 errors. Build ✅.

## Next
Term picker (replacing the date inputs with a per-section term selector) is the planned follow-up — it just feeds this same union.

🤖 Generated with [Claude Code](https://claude.ai/code)