### PR TITLE
feat: reference-first deep-link fast path + wider rota cards

### DIFF
--- a/docs/features/post-login-sync-handover.md
+++ b/docs/features/post-login-sync-handover.md
@@ -1,0 +1,100 @@
+# Handover — Page-aware post-login loading (deep-link fast path)
+
+**Status:** In progress — mechanism verified & plan corrected 2026-07-13 (see "Corrected mechanism" below); implementation started.
+**Created:** 2026-07-13 · **Surfaced:** 2026-07-12 (while testing water-rota deep-link sharing)
+**Type:** Refactor of the shared auth + data-loading layer (offline-first).
+
+---
+
+## Problem
+
+After OAuth, the app runs a **global post-login bootstrap** that every route shares: `useAuth.jsx` shows a "Syncing data from OSM…" toast and runs `dataLoadingService.loadAllDataAfterAuth()`, which loads reference data → all sections' events → all attendance → flexi.
+
+**Corrected mechanism (verified 2026-07-13 — the original framing below was imprecise):**
+
+- **First paint is NOT hard-blocked by the `await`.** `useAuth.jsx:243` calls `setIsLoading(false)` and logs *"UI ready to render"* **before** the `await loadAllDataAfterAuth` at line 256. `AppContent` gates the full-screen loader only on `isLoading` (`AppRouter.jsx:40`), so React commits the render and mounts the target route while the bootstrap runs in the background. "Remove the await gate" (old Option A) is therefore *already effectively true* for first paint.
+- **The real coupling is data dependency, not the await.** `loadRota` is only independent when the cache is already **warm**. On a **cold-cache deep link** (the shared-link recipient case), it can't even discover the record: `discoverRotaRecord` (`rotaService.js:82`) scans `databaseService.getSections()`; `resolveRotaTermId` reads cached terms; the member/photo/name maps read cached members. **All of these are populated only by the bootstrap's reference-data step** (`getUserRoles()` → `saveSections()` at `api/auth.js:55`, plus terms + members in `loadInitialReferenceData`).
+- **Consequence on a cold cache:** page renders → `useWaterRota` fires `loadRota` on mount → `getSections()` returns `[]` → `discoverRotaRecord` returns `null` → empty rota. And `useWaterRota`'s effect depends only on `[targetYear]`, so it **never re-runs** when reference data lands moments later — the recipient is stuck on an empty board (or waits out the whole sync) rather than getting a fast rota. It's also a race against the lazy route chunk load.
+
+So the fix is **not** "unblock rendering" — it's **reference-data-first sequencing**: load terms/sections/members first, *then* trigger the target route's own loader, then let the heavy tail (all-section attendance + flexi) finish in the background — and make the route's loader actually re-run once reference data is ready.
+
+**Why it matters now:** pre-existing app behavior, not caused by the deep-link feature. The share flow (PRs #211–#217, shipped v2.19.0) just made it *visible*: people now land on a specific page via a link and notice the whole-app sync. Confirmed live: shared link → sign in → long full sync, not a fast rota load.
+
+## Where it lives (verified 2026-07-13)
+
+| What | Location |
+|---|---|
+| The blocking `await` + "Syncing data from OSM…" toast | `src/features/auth/hooks/useAuth.jsx:254-256` |
+| The global bootstrap itself | `src/shared/services/data/dataLoadingService.js:28` — `async loadAllDataAfterAuth(token, callbacks)` |
+| Other callers (manual refresh paths) | `src/features/events/components/EventDashboard.jsx:139`, `src/routes/AppRouter.jsx:63` |
+| Rota's own light loader (the fast path we'd prefer) | `src/features/water-rota/hooks/useWaterRota.js:22` → `loadRota` (`src/features/water-rota/services/rotaService.js`) |
+| Reference-data load inside the bootstrap | `src/shared/services/referenceData/referenceDataService.js` (`loadAllDataAfterAuth` orchestrates it) |
+| **loadRota's cold-cache dependency** (why the fast path isn't truly independent) | `discoverRotaRecord` → `databaseService.getSections()` (`rotaService.js:82`); `resolveRotaTermId` → cached terms; member/photo maps → cached members |
+| Where sections get written to cache | `getUserRoles()` → `databaseService.saveSections()` (`src/shared/services/api/api/auth.js:55`), part of `loadInitialReferenceData` |
+| **useWaterRota re-run gap** (effect deps only `[targetYear]`, so no reload when reference data lands) | `src/features/water-rota/hooks/useWaterRota.js:41-43` |
+
+## Options considered
+
+- **A — render-first, sync-in-background.** Drop the `await`/gate so the landing page renders as soon as its own data is ready. ⚠️ **Largely a no-op:** verification shows first paint is already unblocked (`setIsLoading(false)` precedes the await). Does nothing for a cold-cache recipient, whose problem is missing reference data, not a blocked render.
+- **B — page-aware fast path.** On a deep link, load only that route's data first (rota → `loadRota`; event → that event's attendance), then kick off the rest. Best UX for shares — but on a cold cache B **requires reference data first** (sections/terms/members), so it can't stand alone.
+- **C — reference-first, then prioritise the landing route's loader** inside/around `loadAllDataAfterAuth`, heavy tail (all-section attendance + flexi) after. This is the load-bearing option: it satisfies loadRota's real dependency.
+
+## Read vs. write (open nuance)
+
+The captured requirement is framed around the **read / first-paint** priority — load the rota/event view first. The user also asked to prioritise the **write** path (rota signups) on a deep link.
+
+- Reads: covered directly by loading the target route first.
+- Writes: currently **implicit** — once `loadRota` completes, the own-cell signup write path (`writeOwnCell` / the own-cell write lock in `rotaService.js`) is available. It is **not** separately specified as "prioritise the write."
+- **Decision needed next session:** do we make "the target view is interactive (readable *and* writable) before the full sync completes" an explicit acceptance criterion, or leave writes as a natural consequence of the read fast-path? (Recommend making it explicit for rota, since the whole point of a shared rota link is to sign up.)
+
+## Recommended approach (starting point, not locked)
+
+Lean **C + B hybrid** (revised from A + B after verification):
+
+1. **Split the bootstrap into two phases.** Phase 1 = reference data only (terms/sections/members via `loadInitialReferenceData`) — cheap, and the precondition for every page-first loader. Phase 2 = the heavy tail (all-section events + attendance + flexi), fired in the background behind the existing non-blocking indicator.
+2. **Between the phases, let the landing route's own loader run** (rota → `loadRota`; event → that event's attendance). The route then paints from its own lighter fetch, not the whole-app sync.
+3. **Make the route loader re-run when reference data becomes ready.** `useWaterRota` today fires `loadRota` once on mount and, on a cold cache, silently shows empty. Give it a signal (reference-ready flag/event, or await a shared "reference ready" promise) so it reloads once sections/terms/members exist.
+
+First paint is already unblocked, so dropping the `await` (old A) is not the mechanism — sequencing + a re-run signal is. Keep offline-first cache pre-warm intact; keep a single source of truth for "reference ready" so the fast path and the background tail don't double-fetch it.
+
+## Acceptance criteria (draft)
+
+1. **Cold-cache** shared rota link → sign in → after reference data lands, the **rota renders from its own `loadRota`** without waiting on all-section events/attendance/flexi; a signup can be made before that heavy tail finishes.
+2. **useWaterRota re-runs** once reference data is ready — no manual refresh needed, no stuck-empty board on a cold cache (the current failure mode).
+3. Same reference-first fast-path for a deep link to a specific event.
+4. A normal (non-deep-link) login still completes the full sync; no data category is silently dropped, and the two-phase split doesn't drop the heavy tail.
+5. The "Syncing data from OSM…" indicator stays **non-blocking** (background) through the heavy tail, and partial-failure reporting (`referenceDataService` per-category errors) still surfaces.
+6. Offline-first behavior unchanged — cached data still serves when offline.
+7. No regression to the identity/startup-data path (globals still populate; see the recent TTL fix, v2.19.4).
+
+## Implemented (2026-07-13, branch `feature/deep-link-reference-first-fast-path`)
+
+Delivered the **rota** cold-cache fast path (the live/reported case):
+
+- **New `referenceDataReady` signal** — `src/shared/services/data/referenceDataReady.js` (`mark`/`is`/`reset`/`subscribe`). Single source of truth for "reference data is cached this session."
+- **Bootstrap fires it** — `dataLoadingService` calls `markReferenceDataReady()` immediately after the reference step succeeds, *before* the heavy tail.
+- **`useWaterRota` re-runs on the signal** and, on a cold cache, **stays in `loading`** instead of flashing "no rota" (distinguishes "sections not cached yet" from "no rota exists this year" via `isReferenceDataReady()`).
+- **Priority fast-path** — `loadRota` takes a `priority` option, threaded into `getFlexiRecords`/`getFlexiStructure`/`getSingleFlexiRecord` → `osmRequest` → the existing priority-ordered `rateLimitQueue`. The hook loads at priority **5** (above background reads at 0, below writes at 10), so the rota's reads jump ahead of the bootstrap flood.
+- **Reset on logout** — `useAuth.logout()` calls `resetReferenceDataReady()` so a new session's cold-cache loaders don't act on a stale flag.
+- **Tests** — `referenceDataReady.test.js` (signal) + `useWaterRota.test.jsx` (warm load / cold-stays-loading-then-fills / no-rota / error / priority arg). Lint + build clean; existing rota/dataLoading/flexi suites green.
+
+**Writes:** signup becomes available as a natural consequence — once `loadRota` completes, `writeOwnCell` is usable; the write path already runs at priority 10 (above the fast-path reads), so a signup on the freshly-loaded board isn't starved.
+
+### Deferred follow-ups
+
+- **Event deep-link fast path (criterion #3):** the same reference-first + priority + re-run treatment for the events route's own loader is **not** done — event loading lives in a different area (`eventDataLoader`/`EventDashboard`) and warrants its own pass. The `referenceDataReady` signal is reusable for it.
+- **Dedupe vs the bootstrap:** the fast-path rota reads and the background flexi tail can still both fetch the same flexi list/structure; priority makes the rota win, but a shared in-flight dedupe would cut redundant OSM calls. Watch the queue depth logs.
+- **Live-device verification:** validate the actual shared-link → sign-in → fast-rota flow on hardware (per the `ios-qa` skill) before closing out.
+
+## Guardrails / do-NOT
+
+- **Scope it as its own piece** (`/spec` or a plan review first) — this touches shared auth + `dataLoadingService` + offline-first pre-warm. Do **not** drive-by edit it inside another change.
+- `loadAllDataAfterAuth` is called from 3 places (`useAuth`, `EventDashboard`, `AppRouter`) — changing its contract affects all three; check each.
+- Preserve the mobile-Safari OAuth constraints (no return-path `replaceState`/`popstate` restore on the web callback — see the `mobile-safari-oauth-returnpath-hang` memory / v2.19.2 revert).
+- Watch OSM rate limits — the fast path must not *duplicate* fetches the full sync will also do (dedupe rota/event loads against the bootstrap).
+
+## Related
+
+- PRD `docs/PRD-functional-rebuild.md`: **§5.7 line ~330** (Landing-route-first requirement), **§7.9** (deep linking & shareable views), **known limitation #10 line ~653** (post-login sync blocks first paint → recommends landing-route-first).
+- Memory: `post_login_full_sync_refactor.md` (source of this handover), `water_rota_feature.md`, `mobile_safari_oauth_returnpath_hang.md`.
+- Share feature that surfaced it: water-rota deep links + copy-link (PRs #211–#217).

--- a/docs/features/water-rota-review.md
+++ b/docs/features/water-rota-review.md
@@ -1,0 +1,165 @@
+# Water Rota — Review, Gap Analysis & Red-Team (2026-07-13)
+
+Purpose: take stock of the shipped Water Session Permit Rota before a term-model
+rework. Three parts: **what's built** (as-built PRD), **what was asked** (intended
+spec across sessions), the **gap**, and a **real-world red-team**. Ends with how the
+outstanding requests map onto the red-team risks and the open decisions.
+
+Sources: `docs/features/water-rota.md` (as-built spec), `water-rota-handover.md`,
+the `water-rota-feature` memory, direct code reading, and a traced red-team audit.
+
+---
+
+## 1. As-built PRD (what shipped — v2.19.0 → v2.22.0)
+
+| Area | As built |
+|---|---|
+| **Storage unit** | One OSM FlexiRecord **per calendar year** — `"Viking Water Rota <year>"` — in a leader-chosen **host section** (usually Adults; must contain all permit holders) |
+| **Session identity** | One column per session, **keyed by absolute date**: `S_<yyyymmdd>_<sectionid>`. Immutable (OSM has no column rename/delete); "removed" sessions marked not-on-water `c:1`, never deleted |
+| **Config** | `RotaConfig` column holds the whole-plan JSON (date range, per-section defaults); each editor writes the full config to their own row; readers take last-writer-wins by `(v, at)` |
+| **Writes** | Each user writes **only their own member row's cell** → signups are conflict-free; session metadata is a candidate `m` merged LWW across rows. Promise-chain lock → live re-fetch → merge own cell → single `updateFlexiRecord` → optimistic cache patch. Online-only (`WRITE_UNAVAILABLE` offline) |
+| **Board** (`/water-rota`) | **Current calendar year only**, host section's **current active term** only. Term overview strip (week navigation — NOT a picker), week-bucketed session cards, one-tap signup, section filter, "sync programme" action, offline banner |
+| **Detail / edit** | `SessionDetailModal` + `SessionEditForm` (activity, times, expected kids, permits-needed, notes, not-on-water toggle) |
+| **My week** (`/water-rota/me`) | User's commitments bucketed this/next/later, inline withdraw |
+| **Setup** (`/water-rota/setup`) | 3-step wizard: host + **all participating sections** + date range → per-section programme review → resumable create + config write. Term dropdown added v2.22.0 but **setup-only, single term per run** |
+| **Identity** | Own member row resolved by stored choice → unique full-name match → one-time picker (`useRotaIdentity`) |
+| **Cover status** | green covered / amber covered-only-with-backups / red short / grey not-on-water or target-unset, computed as `confirmed >= needed` |
+
+Everything is anchored to the **host section's current active term** at the API and
+cache layer: `getSingleFlexiRecord`/`getFlexiStructure`/`updateFlexiRecord` and the
+SQLite/IndexedDB cache all key on `termid` (`WHERE extraid=? AND sectionid=? AND
+termid=?`), and `resolveRotaTermId` returns whatever term is currently active.
+
+## 2. Intended spec (what was asked, across sessions)
+
+The **core** (agreed 2026-07-10) matches the build: per-section on-water planning
+from the OSM programme, permit-holder confirmed/backup signup, at-a-glance cover
+status for leaders. Three **structural** requests are NOT met:
+
+1. **Term-based, not date-based** ("don't build on dates") — the rota should be
+   organised by **term** and roll over with OSM terms, not pinned to a calendar year
+   and absolute session dates.
+2. **A term picker on the board** — to view/switch the term you're looking at; not a
+   one-off dropdown buried in setup.
+3. **Plan one section at a time** — a per-section workflow, not all-sections-in-one-run.
+
+## 3. The gap
+
+| Requirement | Built? | Nature of the gap |
+|---|---|---|
+| Term-based model | ❌ | Rework: record naming, **session-column keys (date → term/week)**, discovery, board loading, cache keys |
+| Term picker on board | ❌ (setup-only, single-term) | `useWaterRota()` hard-binds to `new Date().getFullYear()` + current active term |
+| One section at a time | ❌ | Wizard multi-selects all sections; per-section *merge* was a **v2.21.1 bug fix**, not a designed workflow |
+
+**Crux:** the as-built spec already named the term model as the intended fallback and
+never verified it — spike **#3**: *"confirm cell values persist when the host section's
+term changes… **Fallback: record per term**"* and spike **#1**: *"one record per term
+(~13 columns)"* if the year record grows too big. Those spikes were never run against
+live OSM. "Term-based" resolves an open design question, it doesn't invent a new one.
+
+## 4. Red-team — real-world failure modes
+
+Traced against how a real group runs a summer rota. **Model** = flaw in the
+year/date/term-keyed storage design; **bug** = local defect.
+
+### Top 5 highest-impact risks
+
+1. **Term-rollover data "disappearance" (HIGH, model).** The whole read/write/cache
+   layer keys on the host section's *current active term*. When OSM rolls the term:
+   *offline* users get a **blank board** from a cache-key miss (old grid cached under
+   the old termid, never read); *online* users lose the **entire season's signups/config**
+   *if* OSM scopes flexi values by term (spike #3, unverified). This is the feature's
+   foundational unverified assumption. The documented fallback is record-per-term — a
+   design change, not a patch.
+2. **Green ≠ covered (HIGH, model).** Cover is purely `confirmed >= needed`, but
+   `prefillRegulars` writes every regular as **confirmed** — a regular on holiday shows
+   green until they personally withdraw. No permit-type match (4 kayak permits satisfy a
+   powerboat session) and `needed` ignores expected-YP `k` (no ratio check). A leader can
+   be shown a fully-green week that is actually uncovered — defeats the core promise.
+3. **Permanent wrong-identity, no re-pick UI (HIGH, bug).** `useRotaIdentity.clear()`
+   exists but **is wired to nothing** — no component surfaces a "not you?" control. One
+   mis-tap makes a user sign up / withdraw / edit **as someone else forever**. Cheap to
+   fix, high frequency (shared family names).
+4. **Cross-device config wipe still possible (HIGH, model).** The write lock is
+   module-level (per tab, not per user). Two leaders setting up concurrently read config
+   v5, merge their own section, and both write v6 to the **same anchor cell** — the later
+   write silently drops the earlier leader's whole section. `mergeSectionConfig` (v2.21.1)
+   narrows the window but cannot see a concurrent write, so it doesn't close it.
+5. **Permit holders outside the host section are invisible (HIGH, model).** Everything
+   (members, identity picker, assign-modal) is host-section rows only. A permit holder on
+   a youth roster but not Adults/host can't self-sign (picker dead-ends at "ask your
+   admin") and can't be assigned. No setup-time validation catches it; non-host leaders
+   are silently dropped.
+
+### Also real (lower frequency)
+
+- **Phantom write success (bug, latent):** `detectWriteFailure` deliberately doesn't
+  treat `result:0` as failure; if OSM ever signals a rejected flexi write as `200 {result:0}`,
+  the user sees a confirmed signup that didn't persist until the next refresh.
+- **Dec→Jan season split (model):** the record is named for `range.start`'s year, so a
+  winter season's January sessions live in the previous year's record and vanish from the
+  board on 1 Jan (data intact, unreachable — no year picker).
+- **Setup prefill rate-limit (model-adjacent):** ~40 sequential `multiUpdateFlexiRecord`
+  with no throttle; a rate-limited setup leaves a partially-green board that looks like
+  real cover.
+- **Setup re-run repair is incomplete:** re-running setup restores section *defaults* but
+  **not** regulars-as-signups (prefill only targets newly-added columns), and if a wipe
+  left config null the wizard starts blank and can re-replace rather than merge.
+
+## 5. How the three requests map onto the red-team risks
+
+The outstanding requests are not cosmetic — they resolve **three of the top five** risks:
+
+| Request | Fixes red-team risk |
+|---|---|
+| **Term-based model** (record + columns keyed by term/week, not absolute date) | **#1 term-rollover disappearance** (rollover becomes a natural record boundary, not a data-loss event) and the **Dec→Jan split** |
+| **Term picker on board** | Reaching prior/other terms once the model is term-scoped (today the board can't leave the current year/term) |
+| **One section at a time** (likely per-section plan/record) | **#4 cross-device config wipe** (separate section plans → leaders stop sharing one config cell) and eases **#5** (a leader plans their own section against their own roster) |
+
+Risks **not** addressed by the three requests — worth deciding separately:
+- **#2 Green ≠ covered** — cover-status semantics (opt-in vs auto-confirm regulars,
+  permit-type awareness, ratio). Independent of the term/section rework.
+- **#3 wrong-identity re-pick** — a cheap standalone bug fix; wire up `clear()`.
+
+## 6. Decisions (resolved 2026-07-13)
+
+1. **Term model — DECIDED: one FlexiRecord per term.** `Viking Water Rota <term>`, with
+   session columns covering all sections (up to 9). Session column key becomes
+   term+week/meeting instead of `yyyymmdd`. Rationale: a per-term record holds *fewer*
+   columns than today's per-year record (a year spans multiple terms), so the verified
+   ~43-column/year headroom means per-term is strictly safer on column count. Rollover
+   becomes a clean new record; the old term's record stays intact and reachable via the
+   picker. (Rejected: one-record-per-section-with-terms-as-columns.)
+2. **Planning — DECIDED: per-section workflow.** Each section leader plans only their own
+   section: their on-water weeks, their regular leaders, how many permit holders they
+   need. Not the all-sections wizard. The board stays multi-section for the term (cover
+   overview); setup is scoped to one section.
+3. **Design consequence of 1 + 2 (config isolation):** with a single shared per-term
+   record, per-section planning only becomes truly non-colliding if **config is stored
+   per-section** (each section's plan in its own cell/column), replacing today's single
+   shared `RotaConfig` doc written to one anchor row. Session columns are already
+   per-section. This is what closes red-team risk #4 (cross-device config wipe) — the
+   v2.21.1 merge did not.
+4. **Term picker on the board — DECIDED (in scope):** board-level term selection driving
+   `useWaterRota(term)`; today it hard-binds to current year/active term.
+
+### Still open
+
+5. **Migration — DECIDED: none.** The existing `Viking Water Rota 2026` data is all
+   **test** data and will be deleted. Clean rebuild on the term model, no back-compat, no
+   migration path (fits the repo's remove-deprecated policy). Delete the test FlexiRecord(s)
+   in OSM when convenient.
+6. **Live-OSM spike (#3 cross-term persistence):** no longer a *data-loss* concern (no real
+   data yet), but still worth confirming so the **new** design reads/writes each per-term
+   record under the term it was created in (store the record's termid, don't re-resolve to
+   "current active term"). **Simon to confirm against live OSM.** Cheap, non-blocking.
+7. **Independent risks — fold in or ship first?** #2 green≠covered (auto-confirmed
+   regulars, no permit-type/ratio) and #3 identity re-pick (`clear()` unwired) are
+   orthogonal to the term/section rework. Proposed: **fix #3 now** (tiny), **fold #2 into
+   the rework**.
+
+---
+
+*Next step: write the rework plan / PRD from decisions 1–4 (per-term records, per-section
+planning, per-section config, board term picker), resolve the open items (5–7), then
+build. This review is the input to that plan.*

--- a/docs/features/water-rota-term-model-handover.md
+++ b/docs/features/water-rota-term-model-handover.md
@@ -1,0 +1,71 @@
+# Handover — Water Rota term-model rework
+
+**Status:** Decisions locked, not started. Next session's work.
+**Created:** 2026-07-13 · **Companion:** `water-rota-review.md` (as-built PRD, gap analysis, full red-team — read it first).
+**Type:** Storage-model + workflow rework of the Water Session Permit Rota. Clean rebuild, **no back-compat, no migration**.
+
+---
+
+## Why this exists
+
+The shipped rota (v2.19.0→v2.22.0) diverged from spec on three structural points, and a red-team found the divergence is also the source of the top real-world risk. See `water-rota-review.md` for the full as-built PRD, gap table, and ranked red-team. This handover carries the **decisions** so next session can write the PRD/plan and build.
+
+## Decisions locked (2026-07-13, agreed with Simon)
+
+1. **One FlexiRecord per term** — `Viking Water Rota <term>` (not per calendar year). Store the record's **termid** and read/write it under *that* term forever — never re-resolve to "current active term" (`resolveRotaTermId` today returns the current active term, which is the rollover bug). Per-term holds *fewer* columns than today's per-year record, so column-count is safer, not riskier.
+2. **Sessions keep their real dates.** "Don't build on dates" = **record identity + term resolution**, not date-free sessions. A session still happens on 15 July and its column can stay `S_<yyyymmdd>_<sectionid>`; it just lives inside a term-anchored record read under that record's term.
+3. **Per-section planning.** Each section leader plans only their own section — their on-water weeks (from their programme), their regular leaders, and how many permit holders they need. **Not** the all-sections wizard.
+4. **Per-section config (the key structural change).** Replace today's single shared `RotaConfig` doc (written to one anchor row → the cross-device wipe, red-team risk #4) with **per-section config** (each section's plan in its own cell/column, e.g. `RotaConfig_<sectionid>` written to the editor's own row, LWW). Session columns are already per-section. Then two leaders setting up different sections at once physically cannot clobber each other — closes risk #4, which the v2.21.1 merge only narrowed.
+5. **Board term picker.** Board-level term selection driving `useWaterRota(term)`; today it hard-binds to `new Date().getFullYear()` + current active term. Board still shows the whole term's group-wide cover; setup is scoped to one section.
+6. **Migration: none.** The existing `Viking Water Rota 2026` data is all **test**. **Simon is deleting the old OSM FlexiRecord.** Clean rebuild going forward.
+7. **Independent fixes:** **do #3 now** (identity re-pick — `useRotaIdentity.clear()` exists but is wired to nothing; one mis-tap = act as someone else forever; surface a "Change who I am" control). **Fold #2 into the rework** (cover semantics — see below).
+
+## Target model (one line)
+
+> One record **per term** → per-section **date-bearing** session columns (read under the record's own term) + per-section **config** (isolated cells) → board shows the term's whole-group cover with a **term picker** → setup is **per-section**.
+
+## Must-resolve before/while building
+
+- **SPIKE (feasibility gate) — does OSM let you read/write a flexi record under an arbitrary/past termid?** The whole per-term-record approach assumes you can read term T's record using T's termid even after the term rolls. Two sub-questions from the original spike #3 (`water-rota.md:61-63`, never run):
+  - Are flexi cell values term-scoped at all, or per-member (term only selects roster)?
+  - If term-scoped, does OSM return data when you pass a *past* termid?
+  If past terms are unreadable, past-term rotas can't be shown (maybe acceptable — you mostly care about the current/next term); confirm and design accordingly. **Simon to check against live OSM.** Cheap.
+- **Cover semantics (#2) — how regulars count.** Today `prefillRegulars` writes every regular as **confirmed** (`s:"I"`), so a regular on holiday shows green until they withdraw → green lies. Options for the rework: a distinct "regular / assumed" status that counts separately from "confirmed (opted-in)", or don't prefill signups and show `confirmed X / needed Y (+Z regulars pencilled)`. Decide during PRD. Permit-type match + YP ratio remain deferred but the board should stop implying "covered" when it isn't.
+
+## What gets removed (clean rebuild, no deprecation)
+
+- `buildRotaRecordName(year)` → `buildRotaRecordName(term)`; year-based discovery/loading.
+- `resolveRotaTermId` "current active term" → pinned per-record termid.
+- The all-sections setup wizard → per-section setup.
+- The single shared `RotaConfig` doc → per-section config cells.
+
+## Where it lives (files to touch)
+
+- Encoding/naming: `src/features/water-rota/services/rotaEncoding.js`, `rotaTemplates.js` (`buildRotaRecordName`, `buildSessionColumnName`, config encode/merge).
+- Load/discover/write: `rotaService.js` (`discoverRotaRecord`, `loadRota`, `resolveRotaTermId`, `writeConfig`, `writeOwnCell`, `prefillRegulars`).
+- Setup: `components/setup/RotaSetupWizard.jsx`, `services/rotaSetupService.js`, `utils/rotaSetupPlan.js` (`mergeSectionConfig` → likely gone with per-section config).
+- Board + hook: `components/RotaBoardPage.jsx`, `hooks/useWaterRota.js` (add term param + picker), `TermOverviewStrip.jsx`.
+- Cover: `utils/rotaDisplay.js` (cover-status semantics).
+- Identity: `hooks/useRotaIdentity.js` (wire up `clear()`), a UI control in `RotaBoardPage`/`MyCommitmentsPage`.
+
+## Suggested build sequence
+
+0. Simon: delete old test record + run the spike.
+1. Encoding/storage: per-term record naming, pinned termid, per-section config columns (pure fns + tests first).
+2. Load/discover/write on the new model.
+3. Per-section setup workflow.
+4. Board term picker + whole-term view.
+5. Cover semantics (#2) + identity re-pick (#3).
+6. Delete the year-model / all-sections-wizard / shared-config code.
+
+## Guardrails
+
+- Own-row write discipline stays (signups conflict-free); keep the promise-chain write lock and LWW for metadata/config.
+- Offline-first: reads serve cache, writes online-only (`WRITE_UNAVAILABLE`).
+- Watch OSM rate limits in setup prefill (today ~40 sequential `multiUpdateFlexiRecord`, no throttle — red-team risk).
+- Write the PRD/plan first (`/spec` or a plan review) — this is a model rework, not a patch.
+
+## Related
+
+- `water-rota-review.md` (this session's full review — READ FIRST), `water-rota.md` (as-built spec + original spikes), `water-rota-handover.md` (original build handover).
+- Memory: `[[water-rota-feature]]`, `[[post-login-full-sync-refactor]]`.

--- a/src/features/auth/hooks/useAuth.jsx
+++ b/src/features/auth/hooks/useAuth.jsx
@@ -8,6 +8,7 @@ import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js
 import databaseService from '../../../shared/services/storage/database.js';
 import IndexedDBService from '../../../shared/services/storage/indexedDBService.js';
 import dataLoadingService from '../../../shared/services/data/dataLoadingService.js';
+import { resetReferenceDataReady } from '../../../shared/services/data/referenceDataReady.js';
 import { notifyError, notifyLoading, notifySuccess, notifyWarning, dismissToast } from '../../../shared/utils/notifications.js';
 import { describeOAuthCallbackError } from '../utils/oauthCallbackError.js';
 import { getLoadingResultMessage } from '../../../shared/services/referenceData/referenceDataService.js';
@@ -566,6 +567,9 @@ function useAuthLogic() {
   // Logout function
   const logout = useCallback(async () => {
     await authService.logout();
+    // Clear the reference-ready signal so the next session's cold-cache
+    // loaders wait for a fresh reference load, not this session's stale flag.
+    resetReferenceDataReady();
     broadcastAuthSync();
     setIsAuthenticated(false);
     setUser(null);

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -469,7 +469,7 @@ function RotaBoardPage() {
               {/* Every session that week tiles across the card — each section's
                   nights are separate tiles, filling the width instead of a
                   narrow per-day strip. */}
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 {weekSessions.map((session) => (
                   <SessionMiniCard
                     key={session.key}

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { ERROR: 'ERROR' },
+}));
+
+vi.mock('../../../../shared/services/auth/tokenService.js', () => ({
+  getToken: vi.fn(() => 'test-token'),
+}));
+
+vi.mock('../../services/rotaService.js', () => ({
+  loadRota: vi.fn(),
+}));
+
+vi.mock('../../../../shared/services/data/dataLoadingService.js', () => ({
+  default: { getLoadingStatus: vi.fn(() => ({ isLoadingAll: false })) },
+}));
+
+import { loadRota } from '../../services/rotaService.js';
+import dataLoadingService from '../../../../shared/services/data/dataLoadingService.js';
+import {
+  markReferenceDataReady,
+  resetReferenceDataReady,
+} from '../../../../shared/services/data/referenceDataReady.js';
+import { useWaterRota } from '../useWaterRota.js';
+
+const ROTA = { year: 2026, sessions: [], members: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetReferenceDataReady();
+  dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
+});
+
+describe('useWaterRota', () => {
+  it('loads the rota on mount from a warm cache', async () => {
+    loadRota.mockResolvedValue(ROTA);
+
+    const { result } = renderHook(() => useWaterRota(2026));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rota).toBe(ROTA);
+    expect(loadRota).toHaveBeenCalledWith(2026, 'test-token', { priority: 5 });
+  });
+
+  it('shows an empty board (not loading) when reference is ready but no rota exists', async () => {
+    markReferenceDataReady();
+    loadRota.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useWaterRota(2026));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rota).toBeNull();
+  });
+
+  it('shows an empty board when no rota exists and no load is in progress (no stuck spinner)', async () => {
+    // Warm-cache/offline: reference never marked ready this session and the
+    // bootstrap is not running, so a null rota is a genuine "no rota".
+    loadRota.mockResolvedValue(null);
+    dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
+
+    const { result } = renderHook(() => useWaterRota(2026));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rota).toBeNull();
+  });
+
+  it('stays in loading on a cold cache, then fills in when reference data becomes ready', async () => {
+    // Cold cache with the post-login bootstrap running: first load finds no
+    // cached sections -> null while not ready.
+    dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });
+    loadRota.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useWaterRota(2026));
+
+    // Should remain loading rather than flashing an empty board.
+    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.rota).toBeNull();
+
+    // Reference data lands: the signal re-runs the load, now returning a rota.
+    loadRota.mockResolvedValueOnce(ROTA);
+    await act(async () => {
+      markReferenceDataReady();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rota).toBe(ROTA);
+    expect(loadRota).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces load errors', async () => {
+    loadRota.mockRejectedValue(new Error('nope'));
+
+    const { result } = renderHook(() => useWaterRota(2026));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.rota).toBeNull();
+  });
+});

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -15,7 +15,12 @@ vi.mock('../../services/rotaService.js', () => ({
 }));
 
 vi.mock('../../../../shared/services/data/dataLoadingService.js', () => ({
-  default: { getLoadingStatus: vi.fn(() => ({ isLoadingAll: false })) },
+  default: {
+    getLoadingStatus: vi.fn(() => ({ isLoadingAll: false })),
+    // Default to a never-settling load so the recovery path stays inert unless
+    // a test opts in.
+    whenAllDataSettled: vi.fn(() => new Promise(() => {})),
+  },
 }));
 
 import { loadRota } from '../../services/rotaService.js';
@@ -28,14 +33,26 @@ import { useWaterRota } from '../useWaterRota.js';
 
 const ROTA = { year: 2026, sessions: [], members: [] };
 
+/** Manually-resolvable promise for ordering-sensitive tests. */
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   resetReferenceDataReady();
   dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
+  dataLoadingService.whenAllDataSettled.mockReturnValue(new Promise(() => {}));
 });
 
 describe('useWaterRota', () => {
-  it('loads the rota on mount from a warm cache', async () => {
+  it('loads the rota on mount from a warm cache, at deep-link priority', async () => {
     loadRota.mockResolvedValue(ROTA);
 
     const { result } = renderHook(() => useWaterRota(2026));
@@ -56,8 +73,6 @@ describe('useWaterRota', () => {
   });
 
   it('shows an empty board when no rota exists and no load is in progress (no stuck spinner)', async () => {
-    // Warm-cache/offline: reference never marked ready this session and the
-    // bootstrap is not running, so a null rota is a genuine "no rota".
     loadRota.mockResolvedValue(null);
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
 
@@ -68,19 +83,15 @@ describe('useWaterRota', () => {
   });
 
   it('stays in loading on a cold cache, then fills in when reference data becomes ready', async () => {
-    // Cold cache with the post-login bootstrap running: first load finds no
-    // cached sections -> null while not ready.
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });
     loadRota.mockResolvedValueOnce(null);
 
     const { result } = renderHook(() => useWaterRota(2026));
 
-    // Should remain loading rather than flashing an empty board.
     await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
     expect(result.current.loading).toBe(true);
     expect(result.current.rota).toBeNull();
 
-    // Reference data lands: the signal re-runs the load, now returning a rota.
     loadRota.mockResolvedValueOnce(ROTA);
     await act(async () => {
       markReferenceDataReady();
@@ -89,6 +100,76 @@ describe('useWaterRota', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.rota).toBe(ROTA);
     expect(loadRota).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers to an empty board when the bootstrap settles without reference ever becoming ready (reference load failed)', async () => {
+    // Cold cache with a bootstrap running; reference load will fail so the
+    // ready signal never fires. The board must not spin forever.
+    const settled = deferred();
+    dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });
+    dataLoadingService.whenAllDataSettled.mockReturnValue(settled.promise);
+    loadRota.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useWaterRota(2026));
+
+    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
+    expect(result.current.loading).toBe(true);
+
+    // Bootstrap finishes without success: isLoadingAll flips false, settle resolves.
+    dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
+    await act(async () => {
+      settled.resolve();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rota).toBeNull();
+  });
+
+  it('does not let a slower stale load clobber a newer result (epoch guard)', async () => {
+    // Mount load is slow and resolves null; the ready-signal load resolves ROTA
+    // first. The later null must not overwrite the loaded board.
+    const mountLoad = deferred();
+    const signalLoad = deferred();
+    loadRota
+      .mockReturnValueOnce(mountLoad.promise)
+      .mockReturnValueOnce(signalLoad.promise);
+
+    const { result } = renderHook(() => useWaterRota(2026));
+    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
+
+    // Reference becomes ready -> a second (newer) load starts.
+    await act(async () => {
+      markReferenceDataReady();
+    });
+    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(2));
+
+    // Newer load resolves first with the rota...
+    await act(async () => {
+      signalLoad.resolve(ROTA);
+    });
+    await waitFor(() => expect(result.current.rota).toBe(ROTA));
+
+    // ...then the stale mount load resolves null and must be ignored.
+    await act(async () => {
+      mountLoad.resolve(null);
+    });
+    expect(result.current.rota).toBe(ROTA);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('stops re-running after unmount', async () => {
+    loadRota.mockResolvedValue(ROTA);
+
+    const { result, unmount } = renderHook(() => useWaterRota(2026));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    loadRota.mockClear();
+    unmount();
+    await act(async () => {
+      markReferenceDataReady();
+    });
+
+    expect(loadRota).not.toHaveBeenCalled();
   });
 
   it('surfaces load errors', async () => {

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -5,13 +5,31 @@
  * board renders offline; refresh() re-runs discovery and the live grid
  * fetch.
  *
+ * Deep-link fast path: on a cold cache (a shared-link recipient who just
+ * signed in) loadRota cannot discover the record until the post-login
+ * bootstrap has cached sections/terms/members. This hook therefore (a) waits
+ * in the loading state rather than flashing "no rota" while reference data is
+ * still loading, (b) re-runs once {@link subscribeReferenceDataReady} fires,
+ * and (c) loads at a raised rate-limit priority so the rota jumps ahead of the
+ * background sync's flood of requests.
+ *
  * @module useWaterRota
  */
 
 import { useCallback, useEffect, useState } from 'react';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
+import dataLoadingService from '../../../shared/services/data/dataLoadingService.js';
+import {
+  isReferenceDataReady,
+  subscribeReferenceDataReady,
+} from '../../../shared/services/data/referenceDataReady.js';
 import { loadRota } from '../services/rotaService.js';
+
+// Queue priority for the landing/deep-link rota load: above the background
+// post-login reads (0), below writes (10), so a shared-link recipient's board
+// loads ahead of the whole-app sync.
+const DEEP_LINK_PRIORITY = 5;
 
 /**
  * Load the water rota for a year.
@@ -27,7 +45,21 @@ export function useWaterRota(year) {
     setState((previous) => ({ ...previous, loading: true, error: null }));
     try {
       const token = getToken();
-      const rota = await loadRota(targetYear, token);
+      const rota = await loadRota(targetYear, token, { priority: DEEP_LINK_PRIORITY });
+      if (
+        !rota &&
+        !isReferenceDataReady() &&
+        dataLoadingService.getLoadingStatus().isLoadingAll
+      ) {
+        // Cold-cache deep link with the post-login bootstrap still running:
+        // sections aren't cached yet, so a null result means "not loaded" not
+        // "no rota exists". Stay in loading and let the reference-ready signal
+        // re-run this once the cache is warm. Gated on an in-progress load so a
+        // warm-cache/offline user viewing a year with genuinely no rota falls
+        // through to the empty state below instead of spinning forever.
+        setState((previous) => ({ ...previous, loading: true }));
+        return;
+      }
       setState({ loading: false, rota, error: null });
     } catch (error) {
       logger.error('Water rota load failed', {
@@ -40,6 +72,14 @@ export function useWaterRota(year) {
 
   useEffect(() => {
     refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    // Re-run when the post-login bootstrap finishes caching reference data, so
+    // a cold-cache recipient's board fills in without a manual refresh.
+    return subscribeReferenceDataReady(() => {
+      refresh();
+    });
   }, [refresh]);
 
   return { ...state, refresh, year: targetYear };

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -9,14 +9,17 @@
  * signed in) loadRota cannot discover the record until the post-login
  * bootstrap has cached sections/terms/members. This hook therefore (a) waits
  * in the loading state rather than flashing "no rota" while reference data is
- * still loading, (b) re-runs once {@link subscribeReferenceDataReady} fires,
- * and (c) loads at a raised rate-limit priority so the rota jumps ahead of the
- * background sync's flood of requests.
+ * still loading, (b) re-runs once {@link subscribeReferenceDataReady} fires or
+ * the bootstrap otherwise settles (so a reference *failure* resolves to the
+ * empty/error state instead of hanging), and (c) loads at a raised rate-limit
+ * priority so the rota jumps ahead of the background sync's flood of requests.
+ * A per-request epoch guard ensures a slower stale load can't clobber the
+ * result of a newer one.
  *
  * @module useWaterRota
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import dataLoadingService from '../../../shared/services/data/dataLoadingService.js';
@@ -40,12 +43,22 @@ const DEEP_LINK_PRIORITY = 5;
 export function useWaterRota(year) {
   const targetYear = year ?? new Date().getFullYear();
   const [state, setState] = useState({ loading: true, rota: null, error: null });
+  const requestIdRef = useRef(0);
+  const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {
+    // Latest-request-wins: a slower earlier load (e.g. the cold-cache mount
+    // load returning null) must not overwrite a newer load's result.
+    const requestId = ++requestIdRef.current;
+    const isCurrent = () => requestId === requestIdRef.current;
+
     setState((previous) => ({ ...previous, loading: true, error: null }));
     try {
       const token = getToken();
       const rota = await loadRota(targetYear, token, { priority: DEEP_LINK_PRIORITY });
+      if (!isCurrent()) {
+        return;
+      }
       if (
         !rota &&
         !isReferenceDataReady() &&
@@ -58,10 +71,23 @@ export function useWaterRota(year) {
         // warm-cache/offline user viewing a year with genuinely no rota falls
         // through to the empty state below instead of spinning forever.
         setState((previous) => ({ ...previous, loading: true }));
+        // Safety net: if the bootstrap settles WITHOUT caching reference data
+        // (reference load failed), the ready signal never fires — re-run once
+        // it terminates so we resolve to the empty/error state, never hang.
+        // On the success path the ready signal already re-ran us, so skip the
+        // recovery reload when reference did become ready.
+        dataLoadingService.whenAllDataSettled().then(() => {
+          if (mountedRef.current && !isReferenceDataReady()) {
+            refresh();
+          }
+        });
         return;
       }
       setState({ loading: false, rota, error: null });
     } catch (error) {
+      if (!isCurrent()) {
+        return;
+      }
       logger.error('Water rota load failed', {
         year: targetYear,
         error: error.message,
@@ -69,6 +95,13 @@ export function useWaterRota(year) {
       setState({ loading: false, rota: null, error });
     }
   }, [targetYear]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     refresh();

--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -169,6 +169,30 @@ describe('loadRota', () => {
     expect(rota.sectionNames).toEqual({ '900': 'Adults', '901': 'Cubs' });
   });
 
+  it('threads the priority option into every flexi read (deep-link fast path)', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: CONFIG_CELL, f_2: '' },
+    ]));
+
+    await loadRota(2026, TOKEN, { priority: 5 });
+
+    expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 5);
+    expect(getFlexiStructure).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, false, 5);
+    expect(getSingleFlexiRecord).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, 5);
+  });
+
+  it('defaults the read priority to 0 when the option is omitted', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: CONFIG_CELL, f_2: '' },
+    ]));
+
+    await loadRota(2026, TOKEN);
+
+    expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 0);
+    expect(getFlexiStructure).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, false, 0);
+    expect(getSingleFlexiRecord).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, 0);
+  });
+
   it('enriches members and signups with photo_guid from getMembers', async () => {
     getSingleFlexiRecord.mockResolvedValue(gridWith([
       {

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -75,15 +75,16 @@ function withWriteLock(fn) {
  *
  * @param {number} year - Calendar year
  * @param {string} token - OSM authentication token
+ * @param {number} [priority=0] - Rate-limit queue priority for the flexi-list reads
  * @returns {Promise<{hostSection: Object, recordId: string|number}|null>} Discovery result, or null when no rota exists
  */
-export async function discoverRotaRecord(year, token) {
+export async function discoverRotaRecord(year, token, priority = 0) {
   const recordName = buildRotaRecordName(year);
   const sections = (await databaseService.getSections()) || [];
 
   for (const section of sections) {
     try {
-      const list = await getFlexiRecords(section.sectionid, token);
+      const list = await getFlexiRecords(section.sectionid, token, 'n', false, priority);
       const match = (list?.items || []).find((record) => record.name === recordName);
       if (match) {
         return { hostSection: section, recordId: match.extraid };
@@ -127,11 +128,13 @@ export async function resolveRotaTermId(hostSectionId) {
  * @param {string} token - OSM authentication token
  * @param {Object} [options]
  * @param {boolean} [options.forceRefresh=false] - Bypass the structure cache (use after adding a column)
+ * @param {number} [options.priority=0] - Rate-limit queue priority for this load's reads; raise
+ *   on a deep-link/landing load so the rota jumps ahead of the background post-login sync
  * @returns {Promise<LoadedRota|null>} Decoded rota, or null when none exists for the year
  * @throws {Error} When the record exists but its structure is invalid or unreadable
  */
-export async function loadRota(year, token, { forceRefresh = false } = {}) {
-  const discovery = await discoverRotaRecord(year, token);
+export async function loadRota(year, token, { forceRefresh = false, priority = 0 } = {}) {
+  const discovery = await discoverRotaRecord(year, token, priority);
   if (!discovery) {
     return null;
   }
@@ -142,14 +145,14 @@ export async function loadRota(year, token, { forceRefresh = false } = {}) {
     throw new Error('No active term found for the rota host section');
   }
 
-  const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, forceRefresh);
+  const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, forceRefresh, priority);
   const structure = decodeStructure(structureData);
   const check = validateWaterRotaStructure(structure);
   if (!check.isValid) {
     throw new Error(`Water rota record is invalid: ${check.errors.join('; ')}`);
   }
 
-  const grid = await getSingleFlexiRecord(recordId, hostSection.sectionid, termId, token);
+  const grid = await getSingleFlexiRecord(recordId, hostSection.sectionid, termId, token, priority);
   const items = Array.isArray(grid?.items) ? grid.items : [];
 
   try {

--- a/src/shared/services/api/api/flexiRecords.js
+++ b/src/shared/services/api/api/flexiRecords.js
@@ -20,15 +20,18 @@ const FLEXI_STRUCTURES_CACHE_TTL = 60 * 60 * 1000;
  * @param {string} token - OSM authentication token
  * @param {string} [archived='n'] - Include archived records ('y' or 'n')
  * @param {boolean} [forceRefresh=false] - Force refresh bypassing cache
+ * @param {number} [priority=0] - Rate-limit queue priority; raise so a user-facing
+ *   deep-link load jumps ahead of the background post-login sync
  * @returns {Promise<Object>} FlexiRecord list with items array
  * @throws {Error} When API request fails and no cached data available
  */
-export async function getFlexiRecords(sectionId, token, archived = 'n', forceRefresh = false) {
+export async function getFlexiRecords(sectionId, token, archived = 'n', forceRefresh = false, priority = 0) {
   return osmRequest(
     'getFlexiRecords',
     `/get-flexi-records?sectionid=${encodeURIComponent(sectionId)}&archived=${encodeURIComponent(archived)}`,
     {
       token,
+      priority,
       forceRefresh,
       ttl: FLEXI_RECORDS_CACHE_TTL,
       cacheRead: () => databaseService.getFlexiLists(sectionId),
@@ -46,15 +49,18 @@ export async function getFlexiRecords(sectionId, token, archived = 'n', forceRef
  * @param {number|string} sectionid - OSM section identifier
  * @param {number|string} termid - OSM term identifier
  * @param {string} token - OSM authentication token
+ * @param {number} [priority=0] - Rate-limit queue priority; raise so a user-facing
+ *   deep-link load jumps ahead of the background post-login sync
  * @returns {Promise<Object>} FlexiRecord data with member values
  * @throws {Error} When API request fails or authentication fails
  */
-export async function getSingleFlexiRecord(flexirecordid, sectionid, termid, token) {
+export async function getSingleFlexiRecord(flexirecordid, sectionid, termid, token, priority = 0) {
   return osmRequest(
     'getSingleFlexiRecord',
     `/get-single-flexi-record?flexirecordid=${encodeURIComponent(flexirecordid)}&sectionid=${encodeURIComponent(sectionid)}&termid=${encodeURIComponent(termid)}`,
     {
       token,
+      priority,
       cacheRead: () => databaseService.getFlexiData(flexirecordid, sectionid, termid),
       emptyValue: { identifier: null, items: [] },
     },
@@ -68,15 +74,18 @@ export async function getSingleFlexiRecord(flexirecordid, sectionid, termid, tok
  * @param {number|string} termid - OSM term identifier
  * @param {string} token - OSM authentication token
  * @param {boolean} [forceRefresh=false] - Force refresh bypassing cache
+ * @param {number} [priority=0] - Rate-limit queue priority; raise so a user-facing
+ *   deep-link load jumps ahead of the background post-login sync
  * @returns {Promise<Object|null>} Structure definition with field mappings or null
  * @throws {Error} When API request fails
  */
-export async function getFlexiStructure(extraid, sectionid, termid, token, forceRefresh = false) {
+export async function getFlexiStructure(extraid, sectionid, termid, token, forceRefresh = false, priority = 0) {
   return osmRequest(
     'getFlexiStructure',
     `/get-flexi-structure?flexirecordid=${encodeURIComponent(extraid)}&sectionid=${encodeURIComponent(sectionid)}&termid=${encodeURIComponent(termid)}`,
     {
       token,
+      priority,
       forceRefresh,
       ttl: FLEXI_STRUCTURES_CACHE_TTL,
       cacheRead: () => databaseService.getFlexiStructure(extraid),

--- a/src/shared/services/data/__tests__/dataLoadingService.test.js
+++ b/src/shared/services/data/__tests__/dataLoadingService.test.js
@@ -48,6 +48,12 @@ vi.mock('../eventDataLoader.js', () => ({
   },
 }));
 
+// Mock the reference-ready signal so we can assert the bootstrap fires it
+const mockMarkReferenceDataReady = vi.fn();
+vi.mock('../referenceDataReady.js', () => ({
+  markReferenceDataReady: () => mockMarkReferenceDataReady(),
+}));
+
 describe('DataLoadingService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -582,6 +588,52 @@ describe('DataLoadingService', () => {
       expect(result.success).toBe(true);
       expect(mockLoadEventsForSections).toHaveBeenCalledWith(largeUserRoles, 'test-token');
       expect(mockLoadFlexiRecordData).toHaveBeenCalledWith(largeUserRoles, 'test-token');
+    });
+  });
+
+  describe('reference-ready signal', () => {
+    it('fires markReferenceDataReady on reference success, before the heavy tail', async () => {
+      const callOrder = [];
+
+      mockLoadInitialReferenceData.mockImplementation(async () => {
+        callOrder.push('reference');
+        return {
+          success: true,
+          results: { userRoles: [{ sectionid: 1, name: 'Section 1' }] },
+          summary: 'Reference loaded',
+          hasErrors: false,
+          errors: [],
+        };
+      });
+      mockMarkReferenceDataReady.mockImplementation(() => callOrder.push('markReady'));
+      mockLoadEventsForSections.mockImplementation(async () => {
+        callOrder.push('events');
+        return { success: true, results: [], summary: '', hasErrors: false, errors: [] };
+      });
+      mockLoadFlexiRecordData.mockResolvedValue({
+        success: true, summary: '', hasErrors: false, errors: [],
+      });
+
+      await dataLoadingService.loadAllDataAfterAuth('test-token');
+
+      expect(mockMarkReferenceDataReady).toHaveBeenCalledTimes(1);
+      // Must be signalled after reference loads but before events/attendance/flexi
+      expect(callOrder.indexOf('markReady')).toBeGreaterThan(callOrder.indexOf('reference'));
+      expect(callOrder.indexOf('markReady')).toBeLessThan(callOrder.indexOf('events'));
+    });
+
+    it('does NOT fire markReferenceDataReady when reference loading fails', async () => {
+      mockLoadInitialReferenceData.mockResolvedValue({
+        success: false,
+        results: {},
+        summary: 'Reference failed',
+        hasErrors: true,
+        errors: [{ type: 'terms', message: 'boom' }],
+      });
+
+      await dataLoadingService.loadAllDataAfterAuth('test-token');
+
+      expect(mockMarkReferenceDataReady).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/shared/services/data/__tests__/referenceDataReady.test.js
+++ b/src/shared/services/data/__tests__/referenceDataReady.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  isReferenceDataReady,
+  markReferenceDataReady,
+  resetReferenceDataReady,
+  subscribeReferenceDataReady,
+} from '../referenceDataReady.js';
+
+describe('referenceDataReady', () => {
+  beforeEach(() => {
+    resetReferenceDataReady();
+  });
+
+  it('starts not-ready and flips to ready when marked', () => {
+    expect(isReferenceDataReady()).toBe(false);
+    markReferenceDataReady();
+    expect(isReferenceDataReady()).toBe(true);
+  });
+
+  it('reset returns to not-ready', () => {
+    markReferenceDataReady();
+    resetReferenceDataReady();
+    expect(isReferenceDataReady()).toBe(false);
+  });
+
+  it('notifies subscribers on each mark, including a later re-mark', () => {
+    const listener = vi.fn();
+    subscribeReferenceDataReady(listener);
+    markReferenceDataReady();
+    markReferenceDataReady();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeReferenceDataReady(listener);
+    unsubscribe();
+    markReferenceDataReady();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('keeps notifying other subscribers when one throws', () => {
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    subscribeReferenceDataReady(bad);
+    subscribeReferenceDataReady(good);
+    expect(() => markReferenceDataReady()).not.toThrow();
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/services/data/dataLoadingService.js
+++ b/src/shared/services/data/dataLoadingService.js
@@ -10,6 +10,7 @@
  */
 
 import logger, { LOG_CATEGORIES } from '../utils/logger.js';
+import { markReferenceDataReady } from './referenceDataReady.js';
 
 class DataLoadingService {
   constructor() {
@@ -76,6 +77,10 @@ class DataLoadingService {
 
         if (results.reference.success) {
           totalSuccessCount++;
+          // Signal page-first loaders (e.g. the water rota) that cached
+          // sections/terms/members now exist, so they can render ahead of the
+          // heavy tail (events/attendance/flexi) that follows below.
+          markReferenceDataReady();
           logger.info('Reference data loaded successfully', {
             summary: results.reference.summary,
           }, LOG_CATEGORIES.DATA_SERVICE);

--- a/src/shared/services/data/dataLoadingService.js
+++ b/src/shared/services/data/dataLoadingService.js
@@ -318,6 +318,28 @@ class DataLoadingService {
   }
 
   /**
+   * Resolves once any in-progress full data load has settled (success OR
+   * failure). Page-first loaders (e.g. the water rota) use this to recover
+   * from a bootstrap that finished without caching their data — the
+   * reference-ready signal only fires on success, so on a reference failure a
+   * cold-cache loader would otherwise wait forever. After this resolves the
+   * loader re-runs and falls through to its empty/error state.
+   *
+   * @returns {Promise<void>} Resolves when no full load is in progress
+   */
+  async whenAllDataSettled() {
+    const inFlight = this.loadAllPromise;
+    if (inFlight) {
+      try {
+        await inFlight;
+      } catch {
+        // The caller re-runs regardless; the load's own errors surface via its
+        // result/reporting, not here.
+      }
+    }
+  }
+
+  /**
    * Gets loading status for debugging
    * @returns {Object} Current loading state
    */

--- a/src/shared/services/data/referenceDataReady.js
+++ b/src/shared/services/data/referenceDataReady.js
@@ -15,6 +15,8 @@
  * @module referenceDataReady
  */
 
+import logger, { LOG_CATEGORIES } from '../utils/logger.js';
+
 let ready = false;
 const listeners = new Set();
 
@@ -28,9 +30,9 @@ export function isReferenceDataReady() {
 }
 
 /**
- * Mark reference data as ready and notify every subscriber. Idempotent — safe
- * to call again on refresh paths; each call re-notifies so late-mounted
- * loaders still get nudged.
+ * Mark reference data as ready and notify every subscriber. Setting the ready
+ * flag is idempotent; each call also re-notifies subscribers (a repeated side
+ * effect on purpose) so late-mounted or refresh-path loaders still get nudged.
  *
  * @returns {void}
  */
@@ -39,8 +41,13 @@ export function markReferenceDataReady() {
   for (const listener of listeners) {
     try {
       listener();
-    } catch {
-      // A misbehaving subscriber must not stop the others being notified.
+    } catch (error) {
+      // A misbehaving subscriber must not stop the others being notified, but
+      // a consistently throwing one would silently break the fast-path re-run,
+      // so surface it.
+      logger.warn('referenceDataReady subscriber threw', {
+        error: error?.message,
+      }, LOG_CATEGORIES.ERROR);
     }
   }
 }

--- a/src/shared/services/data/referenceDataReady.js
+++ b/src/shared/services/data/referenceDataReady.js
@@ -1,0 +1,70 @@
+/**
+ * Reference-data readiness signal.
+ *
+ * The post-login bootstrap (dataLoadingService) loads reference data
+ * (terms/sections/members) first, then a heavy tail (all-section events,
+ * attendance, flexi). Page-first loaders that depend on cached reference data
+ * — notably the water rota's `loadRota`, which scans cached sections/terms/
+ * members — mount and run before that reference step finishes on a cold cache,
+ * so they find nothing and, having no re-run trigger, stay empty.
+ *
+ * This module is the single source of truth for "reference data is now cached
+ * this session": the bootstrap calls {@link markReferenceDataReady} once the
+ * reference step succeeds, and page loaders subscribe to re-run themselves.
+ *
+ * @module referenceDataReady
+ */
+
+let ready = false;
+const listeners = new Set();
+
+/**
+ * Whether reference data has been loaded into the cache this session.
+ *
+ * @returns {boolean} True once the bootstrap's reference step has succeeded
+ */
+export function isReferenceDataReady() {
+  return ready;
+}
+
+/**
+ * Mark reference data as ready and notify every subscriber. Idempotent — safe
+ * to call again on refresh paths; each call re-notifies so late-mounted
+ * loaders still get nudged.
+ *
+ * @returns {void}
+ */
+export function markReferenceDataReady() {
+  ready = true;
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // A misbehaving subscriber must not stop the others being notified.
+    }
+  }
+}
+
+/**
+ * Clear readiness (e.g. on logout, before the cache is wiped), so the next
+ * session's cold-cache loaders wait for a fresh reference load instead of
+ * acting on the previous session's stale signal.
+ *
+ * @returns {void}
+ */
+export function resetReferenceDataReady() {
+  ready = false;
+}
+
+/**
+ * Subscribe to reference-data-ready notifications.
+ *
+ * @param {() => void} listener - Called each time reference data is marked ready
+ * @returns {() => void} Unsubscribe function
+ */
+export function subscribeReferenceDataReady(listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary

Three things from this session:

### 1. Reference-first deep-link fast path (water rota)
Shared water-rota deep links landed the recipient in the whole-app post-login sync instead of a fast rota load. Verified root cause: first paint is **not** blocked by the `loadAllDataAfterAuth` await — on a cold cache `loadRota` can't discover its record until the bootstrap's reference step caches sections/terms/members, and `useWaterRota` never re-ran once that landed.

- New `referenceDataReady` signal; the bootstrap fires it right after the reference step succeeds, before the heavy events/attendance/flexi tail.
- `useWaterRota` re-runs on that signal (and on bootstrap *termination*, so a reference failure resolves to empty/error instead of hanging), stays in `loading` on a cold cache rather than flashing "no rota", and loads at a raised rate-limit **priority (5)** so its reads jump the sync flood.
- Per-request **epoch guard** so a slow stale load can't clobber a newer result.
- Signal reset on logout; subscriber-error logging.

### 2. Wider rota session cards
The board grid packed up to 3–4 columns on wide screens, truncating the section-name chip. Capped at 2 columns from `sm` up (mobile unchanged).

### 3. Water-rota review docs (for next session)
- `docs/features/water-rota-review.md` — as-built PRD, asked-vs-built gap, and a real-world red-team.
- `docs/features/water-rota-term-model-handover.md` — locked decisions for the term-model rework.
- Updated `post-login-sync-handover.md` with the corrected mechanism.

## Review & verification
- Ran a 4-agent PR review (code / tests / silent-failure / comments); the two HIGH findings (stuck-spinner on reference failure, overlapping-refresh race) are fixed with tests.
- **Full suite 887 passing**, lint clean, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)