### PR TITLE
feat: water rota term model — per-section records, season picker, per-host identity

### DIFF
--- a/docs/features/water-rota-term-model-handover.md
+++ b/docs/features/water-rota-term-model-handover.md
@@ -1,5 +1,12 @@
 # Handover — Water Rota term-model rework
 
+> **⚠️ SUPERSEDED 2026-07-14.** Live-OSM review found terms are per-section (no group-wide
+> term; Adults has year-terms only), which breaks this doc's shared-record-per-term model.
+> The revised design — **one record per (section, its own term), all hosted in Adults,
+> single RotaConfig column per record, season-bucket board picker** — lives in
+> `water-rota-term-model-prd.md`. Decisions below stand EXCEPT #1 (shared per-term record)
+> and #4 (per-section config columns), both replaced by per-section records.
+
 **Status:** Decisions locked, not started. Next session's work.
 **Created:** 2026-07-13 · **Companion:** `water-rota-review.md` (as-built PRD, gap analysis, full red-team — read it first).
 **Type:** Storage-model + workflow rework of the Water Session Permit Rota. Clean rebuild, **no back-compat, no migration**.

--- a/docs/features/water-rota-term-model-prd.md
+++ b/docs/features/water-rota-term-model-prd.md
@@ -1,0 +1,744 @@
+# Water Rota — Term-Model Rework: PRD & Implementation Plan
+
+**Status:** Ready to build · **Created:** 2026-07-13 · **Revised:** 2026-07-14 (per-section-record model, verified against live OSM)
+**Type:** Storage-model + workflow rework. Clean rebuild, **no migration, no back-compat** (OSM verified CLEAN — zero water-rota records live or archived in any section).
+**Companions:** `water-rota-review.md` (as-built + red-team), `water-rota-term-model-handover.md` (partially superseded — see §1), `water-rota.md` (as-built storage spec).
+**Delivery:** ONE feature branch, ONE PR, clean commits per work package (§9).
+
+---
+
+## 1. Summary + goals / non-goals
+
+### Problem
+
+The shipped rota (v2.19.0→v2.22.0) is one FlexiRecord per calendar year, and every
+read/write/cache keys on the host section's **current active term**
+(`resolveRotaTermId`, `rotaService.js:109-120`). When OSM rolls the term, offline
+users get a blank board from a cache-key miss (`getFlexiData` keys on `termid`,
+`database.js:1611`). Setup is an all-sections wizard writing one shared
+`RotaConfig` doc that two leaders can clobber cross-device (red-team #4).
+
+### Live-OSM facts that shape the design (verified 2026-07-13/14, Simon)
+
+1. **Flexi cell values are NOT term-scoped.** They are per-member and
+   term-independent; `termid` only selects the roster/read context. Term rollover
+   never loses data — the termid used for reads matters for **cache/read
+   consistency only** (the SQLite/IndexedDB flexi cache keys on termid,
+   `database.js:1611`).
+2. **OSM terms are PER-SECTION.** Each section has its own termids, names, and
+   dates. The Adults host section (11107) has ONLY whole-year terms ("2026",
+   termid 901823, 2026-01-01→2026-12-31). Youth sections have seasonal terms with
+   *different* termids and dates for the same season: eight sections' Summer-2026
+   terms span Apr 1–Jul 17 through Apr 12–Aug 31 (termids 846930–927091), with
+   names varying ("Summer 2026", "Summer Term 2026"; historically "2023-Summer",
+   bare "Autumn"). **Term names are not reliable identifiers and no termid is
+   shared across sections.**
+
+Fact 2 kills any "one shared record per term" design: a record named for the
+Cubs term is undiscoverable by a Scouts leader (different termid, name, dates) →
+duplicate records by design. Dead.
+
+### The model (one line, DECIDED with Simon 2026-07-13/14)
+
+> **One FlexiRecord per (planning section, that section's own term), ALL hosted in
+> the Adults host section.** Each record holds ONE plain `RotaConfig` column
+> (single section → nothing to merge) plus that section's date-bearing
+> `S_<yyyymmdd>_<sid>` columns. Record identity — planning sectionid, planning
+> termid, season bucket — machine-parses from the record **name**. The board
+> picks a **season bucket** ("Summer 2026"), loads ALL
+> sections' records in that bucket, and aggregates them into the existing
+> group-wide view.
+
+Consequences vs. the shared-record draft: no join flow, no cross-section
+first-setup race, no `RotaConfig_<sid>` columns, no config merging of any kind.
+New cost: the board becomes a **multi-record aggregation** (§5).
+
+### Goals
+
+1. Per-(section, section-term) records hosted in Adults; record identity is
+   fully name-derived and never depends on any term resolution
+   (`resolveRotaTermId` and its year-model discovery deleted). The host termid is
+   a mere API/cache parameter, resolved at call time from the cached
+   current-active-term lookup (§3.3).
+2. Per-section setup that creates/completes only that section's own record,
+   against that section's own terms.
+3. Board **season-bucket picker** driving `useWaterRota(seasonBucket)`; the board
+   aggregates N records into the existing group-wide view; My-week aggregates
+   across records.
+4. Discovery = ONE `getFlexiRecords` call on the host section.
+5. Identity resolved/stored **once per host section** (not per record) + a
+   "Change who I am" re-pick control (`useRotaIdentity.clear()`, red-team #3).
+6. Delete all year-model / all-sections-wizard / shared-config code.
+
+### Non-goals (deferred / unchanged decisions)
+
+- **Cover semantics (red-team #2) — DEFERRED.** Keep the auto-confirm status quo:
+  `prefillRegulars` writes regulars as confirmed (`rotaService.js:381-419`),
+  `coverStatus` stays `confirmed >= needed` (`rotaDisplay.js:33-47`). No change to
+  `rotaDisplay.js` cover logic in this rework.
+- **Migration — NONE.** OSM verified clean; no reader for the old year model ships.
+- **Permit holders outside the host section (red-team #5)** — rows remain Adults
+  members. Now an explicit design choice: Adults hosting is *why* any permit
+  holder can sign up for any section's sessions.
+- No new DB tables, no storage-layer migrations (do not touch
+  `src/shared/services/storage/` schema).
+
+---
+
+## 2. Target model — encoding spec
+
+Examples use planning section `49097` ("Scouts", own term 924956 "Summer 2026",
+Apr 1–Aug 31) and host section `11107` (Adults, year-term 901823).
+
+### 2.1 Record: one per (planning section, planning term), hosted in Adults
+
+**Name format:** `Viking Water Rota <SectionName> <SeasonBucket> [<sectionid>.<termid>]`
+
+> Example: `Viking Water Rota Scouts Summer 2026 [49097.924956]`
+
+- `<SectionName>` — planning section's display name (readable in OSM's own UI).
+- `<SeasonBucket>` — the deterministic season label (§2.2), **not** the raw OSM
+  term name (raw names are unreliable: "Summer Term 2026", "2023-Summer",
+  "Autumn"). Baking the bucket into the **name** (rather than config) is the
+  proposed choice because discovery must group records into picker buckets from
+  the cached flexi list alone — no record read, works offline.
+- `[<sectionid>.<termid>]` — the machine key; **both ids are the planning
+  section's own**:
+  - `sectionid` — planning section whose sessions/config this record holds.
+  - `termid` — the planning section's **own** term the plan was built from
+    (identity + programme re-sync context).
+- The host section's termid is deliberately **not** part of the record identity —
+  it is a mere API/cache parameter, resolved at call time from the app's cached
+  current-active-term lookup (§3.3).
+- The app never displays the raw record name (it shows section + bucket labels).
+- The old year-name parse (`Viking Water Rota 2026`) returns null — good.
+
+```js
+// rotaTemplates.js
+export const ROTA_RECORD_NAME_PREFIX = 'Viking Water Rota';
+
+export function buildRotaRecordName({ sectionName, seasonBucket, sectionId, termId }) {
+  return `${ROTA_RECORD_NAME_PREFIX} ${sectionName} ${seasonBucket} [${sectionId}.${termId}]`;
+}
+
+export function parseRotaRecordName(name) {
+  const match = /^Viking Water Rota (.+) ((?:Spring|Summer|Autumn) \d{4}) \[(\d+)\.(\d+)\]$/
+    .exec(String(name ?? '').trim());
+  return match
+    ? { sectionName: match[1].trim(), seasonBucket: match[2],
+        sectionId: match[3], termId: match[4] }
+    : null;
+}
+```
+
+`parseRotaRecordYear` (`rotaTemplates.js:120-123`) is **deleted**.
+
+### 2.2 Season bucket — deterministic from the planning term's dates
+
+Term names are unreliable; dates are not. Derive the bucket from the planning
+term's date range **at creation time** (pure function in `rotaTemplates.js`):
+
+```js
+// Midpoint month -> UK school-season bucket: Jan–Mar Spring, Apr–Aug Summer, Sep–Dec Autumn.
+export function seasonBucketForRange(startISO, endISO) {
+  const mid = new Date((Date.parse(startISO) + Date.parse(endISO)) / 2);
+  const month = mid.getUTCMonth() + 1;
+  const season = month <= 3 ? 'Spring' : month <= 8 ? 'Summer' : 'Autumn';
+  return `${season} ${mid.getUTCFullYear()}`;
+}
+```
+
+All eight live Summer-2026 term variants (Apr 1–Jul 17 … Apr 12–Aug 31) midpoint
+into May–June → `Summer 2026`. A Dec–Feb straddling term midpoints into January →
+`Spring <later year>` — consistent across sections, which is all that matters:
+the bucket is a deterministic *grouping key*, not a term name.
+
+### 2.3 Session columns — UNCHANGED
+
+`S_<yyyymmdd>_<sectionid>` stays (`rotaEncoding.js:117-134`). Per record they are
+all one section's columns, but the sectionid **stays in the key for cross-record
+uniqueness when the board aggregates** — the column name is the session's React
+key and URL identity (`rotaDisplay.js:117-121`, `?session=` at
+`RotaBoardPage.jsx:75`). `buildSessionColumnName` / `parseSessionColumnName` /
+`parseSessionCell` / `mergeSessionColumn` / `encodeSignup` / `encodeSessionMeta`
+are untouched.
+
+### 2.4 Config — ONE plain `RotaConfig` column per record, single-section payload
+
+The per-section `RotaConfig_<sid>` columns idea is **dead** — a single-section
+record makes it redundant. Keep `ROTA_CONFIG_COLUMN = 'RotaConfig'`
+(`rotaEncoding.js:29`) but reshape the payload to one section's plan:
+
+```jsonc
+{
+  "v": 3,                         // LWW version
+  "at": "2026-07-14T18:30:00Z",   // ISO instant, LWW tiebreak
+  "by": "Jane Leader",
+  "cfg": {
+    "sid": "49097",
+    "sname": "Scouts",
+    "act": "Kayaking",            // section default activity
+    "st": "18:30",
+    "en": "20:00",
+    "k": 24,                      // expected YP default (optional)
+    "p": 4,                       // permit holders needed default (optional)
+    "regulars": ["101", "102"],   // scoutids pre-filled as confirmed
+    "start": "2026-06-02",        // plan date range
+    "end":   "2026-07-21",
+    "sessions": {                 // per-session overrides + not-on-water weeks
+      "S_20260609_49097": { "c": 1, "pt": "Camp weekend" },
+      "S_20260616_49097": { "act": "Canoeing", "pt": "River trip" }
+    }
+  }
+}
+```
+
+- `cfg.termId` (today at `rotaEncoding.js:79`) is removed — identity lives in the
+  record name. `cfg.sections[]` (array) becomes the flat single-section object.
+- **Write target unchanged:** the deterministic **anchor row** (lowest-scoutid
+  host member, `RotaSetupWizard.jsx:341-349`), LWW by `(v, at)` across rows via
+  the existing locked read-merge-write (`rotaService.js:347-364`). This keeps
+  "did setup finish" decoupled from identity resolution. The only concurrent
+  writers are co-leaders of the *same* section, which LWW already resolves.
+- **`mergeSectionConfig` (`rotaSetupPlan.js:46-76`) and the
+  `mergeSections`/`transformCfg` path (`rotaSetupService.js:74-91`,
+  `rotaService.js:343,355`) are deleted** — there is nothing to merge.
+
+**Zod change** (`rotaEncoding.js`): `rotaConfigSchema.cfg` becomes the
+single-section object (`sid`/`sname`/`act`/`st`/`en` required; `k`/`p`/`regulars`/
+`start`/`end`/`sessions` optional; `.passthrough()` kept for forward-compat).
+`sectionDefaultsSchema` (`rotaEncoding.js:41-54`) folds into it;
+`sessionOverrideSchema`/`sessionMetaSchema`/`sessionCellSchema` unchanged.
+`parseConfigCell` / `mergeLwwConfig` / `encodeConfig` keep their names and LWW
+semantics — only the `cfg` shape changes.
+
+### 2.5 Group-view assembly (board consumer shape preserved)
+
+The board consumes `rota.config.cfg.sections[]` + `cfg.sessions{}`
+(`rotaDisplay.js:84-91`, `RotaBoardPage.jsx:102-112`). Assemble that from the N
+loaded records of a bucket so **`rotaDisplay.js` stays untouched**:
+
+```js
+// rotaService.js — pure
+export function assembleGroupConfig(records) {   // records: LoadedRota[] (each .config may be null)
+  const sections = [];
+  const sessions = {};
+  let start, end;
+  for (const record of records) {
+    const c = record.config?.cfg;
+    if (!c) continue;
+    sections.push({ sid: c.sid, sname: c.sname, act: c.act, st: c.st, en: c.en,
+                    k: c.k, p: c.p, regulars: c.regulars ?? [] });
+    Object.assign(sessions, c.sessions ?? {});   // S_<date>_<sid> keys never collide across records
+    start = !start || (c.start && c.start < start) ? (c.start ?? start) : start;
+    end   = !end   || (c.end   && c.end   > end)   ? (c.end   ?? end)   : end;
+  }
+  return sections.length ? { cfg: { start, end, sections, sessions } } : null;
+}
+```
+
+Null when no record has config yet → the board's "setup isn't finished" banner
+(`RotaBoardPage.jsx:378-397`) still triggers.
+
+---
+
+## 3. Discovery, season picker, and read-termid design
+
+### 3.1 Host section resolution
+
+All records live in the Adults section, so discovery resolves the host first.
+Extract the wizard's existing heuristic (`RotaSetupWizard.jsx:111-116`) into a
+shared pure helper:
+
+```js
+// rotaService.js
+export function findHostSection(sections) {
+  return (sections ?? []).find((s) =>
+    `${s.section ?? ''} ${s.sectionname ?? ''}`.toLowerCase().includes('adult')) ?? null;
+}
+```
+
+If no Adults section is visible to the user, discovery falls back to scanning all
+cached sections' flexi lists (rare; a user without Adults access cannot read the
+records anyway, so the fallback mostly shapes the empty-state message).
+
+### 3.2 Discovery — ONE flexi-list call
+
+```js
+export async function discoverRotaRecords(token, priority = 0) {
+  const sections = (await databaseService.getSections()) || [];
+  const hostSection = findHostSection(sections);
+  const scan = hostSection ? [hostSection] : sections;        // fallback per §3.1
+  const byIdentity = new Map();                               // `${sectionId}.${termId}` -> descriptor
+  for (const section of scan) {
+    const list = await getFlexiRecords(section.sectionid, token, 'n', false, priority);
+    for (const item of list?.items || []) {
+      const parsed = parseRotaRecordName(item.name);
+      if (!parsed) continue;
+      const key = `${parsed.sectionId}.${parsed.termId}`;
+      const existing = byIdentity.get(key);
+      // NUMERIC lowest-extraid dedupe for accidental same-name duplicates.
+      if (!existing || Number(item.extraid) < Number(existing.recordId)) {
+        byIdentity.set(key, { ...parsed, recordId: item.extraid, hostSection: section });
+      }
+    }
+  }
+  return [...byIdentity.values()];
+}
+```
+
+- Replaces the loop-over-all-sections discovery (`rotaService.js:81-101`) with one
+  `getFlexiRecords` call on the host in the normal case, riding the same cached
+  flexi list (`rotaService.js:87` pattern) so it works offline after first load.
+- Descriptors carry record identity only (`sectionId`, `termId`, `seasonBucket`,
+  `recordId`, `hostSection`); the host read-context termid is **not** in the
+  descriptor — `loadRota` resolves it itself (§3.3).
+- Dedupe is `Number(extraid)` comparison, not `localeCompare` (extraids `9` vs
+  `10` must pick `9`).
+
+### 3.3 Read-context termid — resolved at call time
+
+`loadRota(descriptor, ...)` resolves the host read-context termid **at call time**
+from the app's existing cached current-active-term lookup —
+`CurrentActiveTermsService.getCurrentActiveTerm(descriptor.hostSection.sectionid)`
+(`currentActiveTermsService.js:7-25`, an IndexedDB read: cached,
+offline-capable) — and threads it through every
+`getFlexiStructure`/`getSingleFlexiRecord` (`flexiRecords.js:57,82`),
+`updateFlexiRecord`/`multiUpdateFlexiRecord`, and `saveFlexiData`/`getFlexiData`
+(`database.js:1603,1674`) call as `(extraid, hostSectionId, hostTermid)`.
+
+This is **not** the old `resolveRotaTermId` bug returning: the bug was that
+record *identity* and *discovery* depended on the current active term, so
+rollover orphaned the record. Here identity and season are fully name-derived;
+the host termid is a mere API/cache parameter. `resolveRotaTermId`
+(`rotaService.js:109-120`) is still **deleted** — the resolution lives inside
+`loadRota` against the host section, not the planning section.
+
+**Accepted edge:** a device offline across the host section's year-term
+rollover (Jan 1) can cache-miss records whose season straddles the year — once
+its current-active-terms store has rolled to the new Adults termid (any online
+`getTerms` refresh, `terms.js:157-237`) but its flexi grids are still cached
+under the old one, the board is blank until the next online load re-caches the
+grids. Self-healing, and no data loss — values aren't term-scoped (fact 1).
+**Operating assumption (Simon, 2026-07-14): water sessions run April–September
+at most, so no season ever straddles New Year — this edge is theoretical for
+this group.**
+
+### 3.4 Season picker data source & default
+
+- **Source:** group `discoverRotaRecords()` output by `seasonBucket`. Only buckets
+  that actually have records appear — offline-safe, no `getTerms` needed.
+- **Default selection:** the bucket whose season window contains today (derive the
+  window from the label: Spring = Jan–Mar, Summer = Apr–Aug, Autumn = Sep–Dec of
+  the labelled year); else the latest bucket by `(year, season order)`.
+- **Setup term source (unchanged mechanism):** the wizard lists
+  `getTerms(token)[sectionId]` for the **planning section's own terms**
+  (`RotaSetupWizard.jsx:220-223`), defaulting to its current active term
+  (`RotaSetupWizard.jsx:234-247`).
+
+---
+
+## 4. Per-section setup workflow
+
+Replaces the 3-step all-sections wizard. **One section, one record, per run.**
+There is no join flow and no cross-section race: each section's setup only ever
+touches its own record.
+
+### 4.1 Steps (UX)
+
+**Step 1 — Section + term.**
+- **Section:** single-select (today's multi-select chips at
+  `RotaSetupWizard.jsx:457-480` become one choice; default = the leader's first
+  youth section, reusing the waiting-list/adults filters at
+  `RotaSetupWizard.jsx:109-124`).
+- **Host:** auto-detected Adults (§3.1), shown read-only ("the rota roster lives
+  here so every permit holder can sign up"). Error state if no Adults section.
+- **Term:** dropdown of the planning section's **own** terms via `getTerms`,
+  default current active. Date range seeds from the term and is fine-tunable
+  (`RotaSetupWizard.jsx:482-529` behaviour kept).
+- **Re-edit:** if `discoverRotaRecords()` already has a record for
+  `(section, term)`, seed the wizard from its config (adapting the seed-from-
+  config effect at `RotaSetupWizard.jsx:134-191`, minus the multi-section
+  reconstruction).
+
+**Step 2 — Programme review (this section only).** Fetch this section's programme
+for the chosen term (`fetchProgrammeMeetings`), auto-pick water nights
+(`looksLikeWaterSession`), section defaults (activity/times/expected-YP/permits),
+regulars via `useSectionLeaders`/`useSectionYPCounts`. No section tab strip
+(`RotaSetupWizard.jsx:544-563` deleted).
+
+**Step 3 — Preview + create.** Resumable create-or-complete → config write →
+regulars prefill.
+
+### 4.2 Service calls
+
+```
+section = {sid, sname}; term = the section's own {termid, name, startdate, enddate}
+hostSection = findHostSection(sections)
+hostTermId  = (await CurrentActiveTermsService.getCurrentActiveTerm(hostSection.sectionid)).currentTermId
+bucket      = seasonBucketForRange(term.startdate, term.enddate)
+
+// A. Create or complete (idempotent — adds only missing columns, flexiRecordCreationService.js:224;
+//    force-refreshes the list before any create, flexiRecordCreationService.js:103-107)
+result = await createOrCompleteRota({
+  hostSection, hostTermId,                         // hostTermId: resolved current host termid,
+                                                   // used ONLY for the creation API's structure reads —
+                                                   // it is NOT part of the record identity or name
+  record: { sectionId: sid, sectionName: sname, termId: term.termid, seasonBucket: bucket },
+  sessions: waterSessionsForThisSection,           // -> S_<date>_<sid> columns
+  token,
+})
+// template.name   = buildRotaRecordName({sectionName, seasonBucket, sectionId, termId})  (§2.1)
+// template.fields = [ROTA_CONFIG_COLUMN, ...sessionColumnNames]
+
+// B. Load the record; write its config to the anchor row (as-built pattern, no merge)
+rota = await loadRota(descriptor, token, { forceRefresh: true })
+await writeConfig({ rota, configFieldId, scoutid: anchorRow.scoutid, by,
+  cfg: { sid, sname, act, st, en, k, p, regulars,
+         start: range.start, end: range.end,
+         sessions: buildSessionOverrides(thisSectionsSessions, [sectionDefault]) },
+  token })                                          // plain LWW-bumped replace
+
+// C. Prefill this section's regulars onto newly created columns only
+//    (result.addedFields guard as at RotaSetupWizard.jsx:384-399), throttled (§4.3)
+await prefillRegulars({ rota, regularsBySection: { [sid]: regulars }, token, sessions: newSessions })
+```
+
+Re-running setup is idempotent end-to-end: only missing columns are added, and
+prefill targets only `addedFields` (never re-touching sessions, so withdrawals
+survive re-edits, as today).
+
+### 4.3 Rate limiting — prefill throttle
+
+`prefillRegulars` fires back-to-back `multiUpdateFlexiRecord` calls
+(`rotaService.js:389-416`). Add a fixed inter-call delay:
+
+```js
+const PREFILL_THROTTLE_MS = 300;
+// between session iterations:
+await new Promise((resolve) => setTimeout(resolve, PREFILL_THROTTLE_MS));
+```
+
+Per-section setup fills one section's sessions per run (typically ≤ ~14), so this
+adds ≤ ~4s worst case — cheap insurance on top of the underlying rate-limit queue.
+
+### 4.4 Sync programme / activate session
+
+`syncRotaWithProgramme` (`rotaSetupService.js:136-286`) simplifies to **one
+record, one section**: fetch that section's programme for the record's own
+planning `termId`, diff (`diffSessions`), append columns, backfill titles into the
+single-section config. The multi-section loop and its unchecked/failed-sections
+bookkeeping (`rotaSetupService.js:148-186`) collapse to a single section's result.
+The board's "Sync programme" action iterates the bucket's records sequentially and
+reports per section. `activateWaterSession` (`rotaSetupService.js:305-341`) keeps
+its shape — it operates on the owning record's rota.
+
+---
+
+## 5. Board changes — season picker + multi-record aggregation
+
+### 5.1 Loading: `useWaterRota(seasonBucket)` → `loadRotaGroup`
+
+```js
+// rotaService.js
+export async function loadRotaGroup(seasonBucket, token, { forceRefresh = false, priority = 0 } = {}) {
+  const descriptors = (await discoverRotaRecords(token, priority))
+    .filter((d) => !seasonBucket || d.seasonBucket === seasonBucket);
+  if (descriptors.length === 0) return null;
+  const records = await Promise.all(descriptors.map((d) => loadRota(d, token, { forceRefresh, priority })));
+  return assembleRotaGroup(seasonBucket, records.filter(Boolean));
+}
+```
+
+- **Read cost, explicit:** cold load = 1 flexi-list read + N × (structure + grid)
+  ≈ `1 + 2N` requests (N ≤ 9 sections → ≤ 19). Dispatched in parallel via
+  `Promise.all` but **paced by the shared rate-limit queue** every flexi read
+  already rides (`flexiRecords.js:57,82` → `withRateLimitQueue`), at the existing
+  deep-link priority (`useWaterRota.js:35`). Warm loads serve the flexi cache;
+  offline renders entirely from cache under each record's
+  `(extraid, hostSectionId, resolved host termid)` key (§3.3).
+- `loadRota(descriptor, ...)` is today's `loadRota` (`rotaService.js:136-215`)
+  minus discovery, resolving the host read-termid per §3.3: structure validation
+  (`vikingWaterRotaValidation.js` is unchanged in shape — single `RotaConfig` +
+  `S_` columns), single-section config merge, session-column merges, grid cache
+  write, photo map, members.
+
+### 5.2 Group shape
+
+```js
+// assembleRotaGroup(seasonBucket, records) ->
+{
+  seasonBucket,                          // 'Summer 2026'
+  hostSection,                           // shared Adults section (from any record)
+  records,                               // LoadedRota[] — each keeps recordId, termId (host read-termid resolved at load, §3.3), configFieldId
+  config: assembleGroupConfig(records),  // §2.5 — board consumer shape
+  sessions,                              // union of records' sessions, each + { record } back-reference
+  members,                               // Adults roster (same rows in every record — take from first)
+  sectionNames,                          // as today (rotaService.js:224-236)
+}
+```
+
+`LoadedRota.year` is **deleted**. Every aggregated session carries a `record`
+back-reference so writes route to the owning record.
+
+### 5.3 Write routing
+
+`writeSignup` / `writeSessionMeta` / `assignSignup` keep their signatures
+(`rotaService.js:267-331`) — callers pass `session.record` as the `rota`
+argument. Two aggregation-specific fixes:
+
+- **`fieldId` is only unique per record** (`f_1` exists in every record). The
+  pending-state key in `useRotaSignup` (`useRotaSignup.js:35-42`,
+  `pendingFieldId`) becomes the session **key** (column name — globally unique
+  per §2.3); `setSignup(session, status)` replaces `setSignup(fieldId, status)`.
+  Call sites updated: `RotaBoardPage.jsx:201-212,494,523`,
+  `MyCommitmentsPage.jsx:56-63,148,170`, and `SessionDetailModal`.
+- The module-level write lock (`rotaService.js:45-58`) already serializes across
+  records (it is per-module, not per-record) — unchanged.
+
+### 5.4 Picker UI + URL
+
+- `RotaBoardPage` renders a season dropdown from the discovered buckets (§3.4);
+  heading becomes "Water Rota {seasonBucket}".
+- The picked bucket lives in the URL as `?season=Summer+2026` alongside the
+  existing `?session=` / `?section=` params (`RotaBoardPage.jsx:74-94`) so shared
+  links pin the season. Default when absent: §3.4.
+- The deep-link fast path (`useWaterRota.js:49-116` — reference-data-ready
+  re-run, raised priority, latest-request-wins epoch guard) is preserved
+  verbatim; it wraps `loadRotaGroup` instead of `loadRota(year)`. Discovery needs
+  cached sections, so the same ready-signal gating covers the picker list too.
+- Section filter, YP counts, `resolveAllSessions`, `TermOverviewStrip`, week
+  bucketing all read the assembled `config`/`sessions` and are unchanged
+  (`RotaBoardPage.jsx:96-181`).
+
+### 5.5 My week
+
+`MyCommitmentsPage` reads the same aggregated group — `resolveAllSessions` +
+`myStatusFor` (`MyCommitmentsPage.jsx:40-47`) already operate on the assembled
+view, so commitments naturally span every section's record in the bucket.
+
+---
+
+## 6. Identity — once per host section + re-pick control
+
+Every record shares the Adults roster, so identity must resolve **once**, not
+once per record (today it is keyed per `recordId`, `useRotaIdentity.js:47-49`,
+which under this model would prompt N times):
+
+- `identityStorageKey(recordId)` → `viking_rota_identity_<hostSectionId>`.
+  `useRotaIdentity(rotaGroup)` reads `rotaGroup.hostSection.sectionid` +
+  `rotaGroup.members`; the resolution order (stored choice → unique full-name
+  match → picker, `useRotaIdentity.js:63-100`) is unchanged.
+- **Re-pick control (red-team #3, in scope):** `clear()`
+  (`useRotaIdentity.js:114-119`) is wired to nothing today. Add a "Signed in as
+  **{name}** · Change" control on `RotaBoardPage` (near the header) and a
+  matching "Change who I am" affordance on `MyCommitmentsPage`
+  (`MyCommitmentsPage.jsx:115-121`), both calling `clear()` then opening the
+  existing `IdentityPickerModal` (`RotaBoardPage.jsx:501-509`,
+  `MyCommitmentsPage.jsx:96-104`).
+
+---
+
+## 7. Deletion list (clean rebuild, no deprecation)
+
+| File | Delete / replace |
+|---|---|
+| `services/rotaTemplates.js` | `buildRotaRecordName(year)` → identity-object form (§2.1); **delete** `parseRotaRecordYear`; **add** `parseRotaRecordName`, `seasonBucketForRange` |
+| `services/rotaEncoding.js` | Reshape `rotaConfigSchema.cfg` to single-section (§2.4); **delete** `cfg.termId` and the `sections[]`-array shape (`sectionDefaultsSchema` folds in); keep `ROTA_CONFIG_COLUMN`, `parseConfigCell`, `mergeLwwConfig`, `encodeConfig` (payload shape change only) |
+| `services/rotaService.js` | **Delete** `resolveRotaTermId` (`:109-120`) and year-based `discoverRotaRecord` (`:81-101`); **add** `findHostSection`, `discoverRotaRecords` (host-only, numeric dedupe), descriptor-based `loadRota` (resolves the host read-termid at call time, §3.3), `loadRotaGroup`, `assembleGroupConfig`, `assembleRotaGroup`; **delete** `writeConfig`'s `transformCfg` param (`:343,355`); throttle `prefillRegulars`; `LoadedRota.year` gone |
+| `utils/rotaSetupPlan.js` | **Delete** `mergeSectionConfig` + `earlier`/`later` helpers (`:17-33,46-76`). Keep `buildSessionOverrides` |
+| `services/rotaSetupService.js` | Rewrite `createOrCompleteRota` (record identity + single section), `writeRotaConfig` (drop `mergeSections`, `:74-91`), `syncRotaWithProgramme` (single record; drop multi-section loop `:148-186`), `activateWaterSession` (owning record) |
+| `components/setup/RotaSetupWizard.jsx` | Remove sections multi-select (`:457-480`), per-section tab strip (`:544-563`), host-section select (`:436-455` → read-only Adults), multi-section seed reconstruction (`:154-180`); single-section flow |
+| `hooks/useWaterRota.js` | Remove `new Date().getFullYear()` default (`:44`); take `seasonBucket`; wrap `loadRotaGroup` |
+| `hooks/useRotaSignup.js` | `pendingFieldId` → pending session key; `setSignup(session, status)` |
+| `hooks/useRotaIdentity.js` | Per-record storage key (`:47-49`) → per-host-section; accept the rota group |
+| `components/RotaBoardPage.jsx` | Season picker + `?season=`; heading; identity re-pick; signup call-site updates |
+| `components/MyCommitmentsPage.jsx` | Aggregated group; identity re-pick; signup call-site updates |
+| `services/vikingWaterRotaValidation.js` | Unchanged in shape (single `RotaConfig` + `S_` columns) — doc-comment updates only |
+
+### Tests removed / rewritten
+
+- **Delete:** `rotaSetupPlan.test.js` `mergeSectionConfig` block (`:63-104`);
+  `rotaSetupService.test.js` `mergeSections` config cases;
+  `rotaService.test.js` year-based discovery cases (`:96-124`).
+- **Rewrite:** `rotaEncoding.test.js` config round-trips (`:179-215`) to the
+  single-section shape; `rotaService.test.js` `loadRota` (`:126-269`) for
+  descriptor + call-time host read-termid; `rotaTemplates.test.js` naming;
+  `useWaterRota.test.jsx` for bucket + group; `useRotaIdentity.test.jsx` for the
+  per-host-section key.
+
+---
+
+## 8. Test plan
+
+Vitest, colocated `__tests__` (existing pattern: pure functions direct; services
+mock the flexi API + `databaseService` as `rotaService.test.js` already does).
+
+### 8.1 Pure functions
+
+| Function | Cases |
+|---|---|
+| `buildRotaRecordName` / `parseRotaRecordName` | round-trip; section names with spaces/digits ("1st Walton Scouts"); extracts both ids + bucket from the two-part bracket; old year name `Viking Water Rota 2026` → null; old three-part-bracket names → null; junk → null |
+| `seasonBucketForRange` | all eight live Summer-2026 ranges (Apr 1–Jul 17 … Apr 12–Aug 31) → `Summer 2026`; Jan–Mar → Spring; Sep–Dec → Autumn; Dec–Feb straddle → Spring of the later year; UTC-deterministic |
+| single-section `rotaConfigSchema` | encode/parse round-trip; rejects missing `sid`/`act`; keeps unknown fields (forward-compat, mirrors `rotaEncoding.test.js:67-71`); corrupt → null |
+| `mergeLwwConfig` | unchanged LWW cases (`rotaEncoding.test.js:73-96`) over the new payload |
+| `assembleGroupConfig` / `assembleRotaGroup` | N records → sections[] + merged sessions{} (no key collisions); range = min/max; configless records skipped; all-configless → null config; sessions carry `record` back-reference; members taken once |
+| `findHostSection` | finds Adults by name; null when absent |
+
+### 8.2 Services (mocked API)
+
+- `discoverRotaRecords` — ONE `getFlexiRecords` call when Adults exists; fallback
+  scan otherwise; parses identity + bucket from names; **numeric** lowest-extraid
+  dedupe (extraids `9` vs `10` picks `9`); ignores non-rota names.
+- `loadRota(descriptor)` — resolves the host read-termid once via
+  `CurrentActiveTermsService.getCurrentActiveTerm(hostSectionId)` and every
+  read/cache call receives that same value consistently (assert
+  `getFlexiStructure`/`getSingleFlexiRecord`/`saveFlexiData` args); errors
+  cleanly when no host term is cached; single-section config; null config
+  tolerated (`rotaService.test.js:244` case preserved); threads `priority`.
+- `loadRotaGroup` — filters by bucket; aggregates N records; null when bucket
+  empty; a single failed record read fails the group load (surfaced via the
+  hook's error state, as today's single-record load does).
+- Write routing — `writeSignup` against `session.record` patches **that**
+  record's cache slot; the write lock serializes writes to different records.
+- `prefillRegulars` — throttle asserted with fake timers; one multi-update per
+  on-water session (existing cases `:429-483` adapted).
+- `createOrCompleteRota` — template = `[RotaConfig, ...cols]` under the new name;
+  idempotent re-run adds only missing columns.
+- `syncRotaWithProgramme` — single record: programme fetched under the record's
+  own planning `termId`; title backfill into single-section config (existing
+  cases `:214-343` adapted; multi-section unchecked/failed cases collapse).
+
+### 8.3 Hooks / components
+
+- `useRotaIdentity` — per-host-section key; same identity across two records;
+  `clear()` re-opens the picker (existing tests adapted).
+- `useRotaSignup` — pending keyed by session key; two same-`fieldId` sessions in
+  different records don't cross-trigger pending state.
+- `useWaterRota` — bucket param; deep-link fast path preserved
+  (`useWaterRota.test.jsx` adapted).
+- `RotaBoardPage` — season picker renders buckets; switching reloads; `?season=`
+  round-trip; identity re-pick flow. `RotaSetupWizard` — single-section create.
+
+---
+
+## 9. Work packages (ordered, ONE branch)
+
+Branch: `feature/water-rota-term-model`. Each package = one clean commit. After
+**every** package, from `/Users/simon/vsCodeProjects/VikingEventMgmt/ios app`:
+
+```bash
+npm run lint && npm run test:run && npm run build
+```
+
+### WP1 — Encoding, naming, season bucket (pure)
+
+- **Files:** `services/rotaTemplates.js`, `services/rotaEncoding.js`,
+  `services/vikingWaterRotaValidation.js` (comments only); tests
+  `rotaTemplates.test.js`, `rotaEncoding.test.js`.
+- **Do:** §2.1, §2.2, §2.4 — record name build/parse with the two-part
+  `[sid.termid]` bracket, `seasonBucketForRange`, single-section config
+  schema. Delete `parseRotaRecordYear`, `cfg.termId`.
+- **Acceptance:** §8.1 pure tests green; `git grep parseRotaRecordYear` empty;
+  build passes.
+
+### WP2 — Services: discovery, load, group aggregation, write routing
+
+- **Files:** `services/rotaService.js`; tests `rotaService.test.js`.
+- **Do:** §3, §5.1–5.3, §2.5 — `findHostSection`, `discoverRotaRecords` (one host
+  call, numeric dedupe), descriptor-based `loadRota` resolving the host
+  read-termid at call time (§3.3), `loadRotaGroup` +
+  `assembleGroupConfig`/`assembleRotaGroup`; delete `resolveRotaTermId` +
+  `transformCfg`; throttle `prefillRegulars`.
+- **Acceptance:** §8.2 green; asserts prove every read/write/cache within one
+  load uses the one consistently resolved host termid; `resolveRotaTermId` gone.
+
+### WP3 — Per-section setup
+
+- **Files:** `services/rotaSetupService.js`, `utils/rotaSetupPlan.js`,
+  `components/setup/RotaSetupWizard.jsx`; tests `rotaSetupService.test.js`,
+  `rotaSetupPlan.test.js`.
+- **Do:** §4 — single-section wizard (section + own-term + read-only Adults
+  host), `createOrCompleteRota` with the new record identity, plain config write,
+  single-record `syncRotaWithProgramme`/`activateWaterSession`; delete
+  `mergeSectionConfig`.
+- **Acceptance:** setup tests green; two different sections' setups create two
+  independent records in Adults (verified via `npm run dev` against live OSM);
+  re-run idempotent.
+
+### WP4 — Board season picker + multi-record aggregation + My week
+
+- **Files:** `hooks/useWaterRota.js`, `hooks/useRotaSignup.js`,
+  `components/RotaBoardPage.jsx`, `components/MyCommitmentsPage.jsx`,
+  `components/SessionDetailModal.jsx` (signup call sites); tests
+  `useWaterRota.test.jsx` + component tests.
+- **Do:** §5 — `useWaterRota(seasonBucket)` over `loadRotaGroup`; season dropdown
+  + `?season=`; write routing via `session.record`; pending-by-session-key; My
+  week over the aggregate; heading label.
+- **Acceptance:** board shows two sections' sessions for one bucket; signup on
+  each routes to its own record; offline board renders from cache; deep-link fast
+  path intact.
+
+### WP5 — Identity: per-host-section + re-pick
+
+- **Files:** `hooks/useRotaIdentity.js`, `components/RotaBoardPage.jsx`,
+  `components/MyCommitmentsPage.jsx`; tests `useRotaIdentity.test.jsx`.
+- **Do:** §6 — storage key per host section; group-shaped input; "Change who I
+  am" controls wired to `clear()` + picker.
+- **Acceptance:** one identity pick covers all records; re-pick clears and
+  re-prompts; choice persists.
+
+### WP6 — Deletion sweep + docs
+
+- **Files:** anything in §7 not yet removed; `index.js` re-exports;
+  `docs/features/water-rota.md` storage section.
+- **Do:** grep-verify zero live references to `resolveRotaTermId`,
+  `parseRotaRecordYear`, `mergeSectionConfig`, `transformCfg`, `mergeSections`,
+  `rota.year`, `pendingFieldId`, year-based `buildRotaRecordName`; delete dead
+  tests; update the as-built doc to the per-section-record model.
+- **Acceptance:** `git grep` clean of all deleted symbols; full
+  `lint && test:run && build` green; `npx cap sync` clean.
+
+---
+
+## 10. Risks & open questions
+
+1. **Adults-host auto-detection is name-based (LOW, structural).**
+   `findHostSection` matches "adult" in the section name — the same heuristic the
+   wizard already uses (`RotaSetupWizard.jsx:111-112`), but it is now
+   load-bearing for discovery, not just a wizard default. If the group renames
+   the Adults section, discovery falls back to scanning all sections (still
+   correct, slower). **Flag for Simon (minor):** confirm heuristic + fallback is
+   acceptable vs. persisting a chosen host section id locally.
+
+2. **Record-name suffix visible in OSM's web UI (COSMETIC).** Names like
+   `Viking Water Rota Scouts Summer 2026 [49097.924956]` appear in OSM's flexi
+   list. The app never shows the raw name. **Flag for Simon:** confirm the
+   two-part id suffix is acceptable.
+
+3. **N-record cold-load cost (LOW, quantified).** ≤ `1 + 2N` queued requests
+   (≤ 19 for 9 sections) on a cold board load, paced by the existing rate-limit
+   queue at deep-link priority; warm/offline loads are pure cache. Accept.
+
+4. **Season-bucket edge cases (LOW).** Midpoint-month bucketing maps every
+   verified live term correctly; a pathological term spanning two seasons lands
+   in exactly one bucket deterministically, which is the only requirement (the
+   label is a grouping key, not a term name).
+
+5. **Duplicate records for the same (section, term) (LOW, non-destructive).**
+   Only a same-section double-create race can produce one; numeric lowest-extraid
+   dedupe converges every device on one record, and
+   `createOrCompleteFlexiRecord` force-refreshes the list before create
+   (`flexiRecordCreationService.js:103-107`). Orphans deletable in OSM.
+
+6. **One failed record read degrades the whole bucket load (LOW).** §8.2 keeps
+   fail-fast (matches today's single-record behaviour and the board's error +
+   retry state, `RotaBoardPage.jsx:293-307`). Partial rendering with a per-record
+   warning is a possible follow-up, not v1.
+
+7. **Cover semantics still "green = confirmed count" (KNOWN, deferred)** per §1;
+   revisit as a follow-up (red-team #2).
+
+8. **Host-section-only permit holders (KNOWN, accepted).** Rows are Adults
+   members (red-team #5) — now an explicit design choice enabling cross-section
+   signups.

--- a/docs/features/water-rota.md
+++ b/docs/features/water-rota.md
@@ -4,12 +4,15 @@ Plan and staff regular on-water sessions across sections (e.g. Cubs Tuesday, Sco
 over a summer date range. Section leaders see per-session cover status; permit holders sign
 up (confirmed or backup) and see their week at a glance.
 
-Full design plan: agreed 2026-07-10 (see PR description). This document tracks the storage
-design and open spike questions.
+Full design plan: agreed 2026-07-10 (see PR description). Term-model rework (per-section
+records, season-bucket picker): agreed 2026-07-13/14, see
+`docs/features/water-rota-term-model-prd.md`. This document tracks the as-built storage
+design.
 
 ## Feature map
 
-- `/water-rota` — the board: term overview strip (one status dot per session per week),
+- `/water-rota` — the board: a **season picker** (only buckets with a discovered record
+  are offered) driving the term overview strip (one status dot per session per week),
   week-bucketed session cards with one-tap `I'm in` / `Backup` signup pills, section
   filter, offline banner, and (for plan editors) a "Sync programme" action that appends
   columns for newly added programme meetings and flags vanished ones.
@@ -17,29 +20,59 @@ design and open spike questions.
   edit form (activity presets, times, expected-kids defaulting to the section YP total,
   permit-holders-needed, notes) and a restorable "Not on water this week" toggle.
 - `/water-rota/me` — **My week**: the user's commitments bucketed this week / next week /
-  later, with inline withdraw (confirm dialog when leaving a session short).
-- `/water-rota/setup` — 3-step wizard: host section + sections + date range → per-section
-  programme review with on-water checkboxes (weekly-slot fallback) → preview + resumable
-  creation + initial config write.
-- Identity: signups write to the user's own member row, resolved by stored choice →
-  unique full-name match → one-time picker (`useRotaIdentity`).
+  later, aggregated across every record in the selected season, with inline withdraw
+  (confirm dialog when leaving a session short).
+- `/water-rota/setup` — per-section wizard: section + its own term (host section
+  auto-detected, read-only) → programme review for that section only, with on-water
+  checkboxes (weekly-slot fallback) → preview + resumable creation + initial config
+  write. Re-running against an already-set-up (section, term) seeds the wizard from its
+  existing record.
+- Identity: signups write to the user's own member row, resolved once per **host
+  section** by stored choice → unique full-name match → one-time picker
+  (`useRotaIdentity`), with a "Change who I am" re-pick control on the board and My week.
 - Cover status: green covered / amber covered-only-with-backups / red short / grey
   not-on-water or target-unset (`rotaDisplay.js`).
 
 ## Storage design
 
-One OSM FlexiRecord per calendar year — `Viking Water Rota <year>` — created in a
-leader-chosen **host section** (usually Adults; it must contain all permit holders).
-Rows are host-section members. Two column kinds:
+One OSM FlexiRecord per **(planning section, that section's own term)**, all hosted in
+the Adults section (it must contain all permit holders; auto-detected by
+`findHostSection`) — not one record per calendar year. Each record covers exactly one
+planning section's sessions and config.
 
-- `RotaConfig` — whole-plan config JSON (date range, per-section defaults). Each plan
+**Record name:** `Viking Water Rota <SectionName> <SeasonBucket> [<sectionid>.<termid>]`,
+e.g. `Viking Water Rota Scouts Summer 2026 [49097.924956]`. `<sectionid>.<termid>` are the
+**planning** section's own ids — record identity is fully name-derived and never depends
+on term resolution. `<SeasonBucket>` (`Spring/Summer/Autumn <year>`) is a deterministic
+label computed from the planning term's date-range midpoint
+(`seasonBucketForRange`, `rotaTemplates.js`), not the raw OSM term name (raw names are
+unreliable across sections — see spikes below). The app never shows the raw record name;
+it displays section + bucket labels. Parsing lives in `parseRotaRecordName`
+(`rotaTemplates.js`).
+
+The **host section's** termid is not part of a record's identity — it is a mere API/cache
+parameter for structure/grid reads, resolved at call time from the app's cached
+current-active-term lookup (`CurrentActiveTermsService.getCurrentActiveTerm`) inside
+`loadRota`. Discovery is one `getFlexiRecords` call on the host section
+(`discoverRotaRecords`), grouping the parsed records by season bucket; the board's season
+picker loads all records in the chosen bucket and aggregates them into one group view
+(`loadRotaGroup` / `assembleRotaGroup`) so `rotaDisplay.js` and the board/My-week
+components consume the same shape as before the rework.
+
+Rows are host-section members. Two column kinds per record:
+
+- `RotaConfig` — a single-section plan config JSON (date range, one section's defaults —
+  `sid`/`sname`/`act`/`st`/`en`/`k`/`p`/`regulars`, plus per-session overrides). Each plan
   editor writes the full config to **their own row**; readers take the last-writer-wins
-  winner across rows by `(v, at)`.
+  winner across rows by `(v, at)`. There is nothing to merge across sections — a record
+  covers exactly one section, so no config-merge step exists.
 - `S_<yyyymmdd>_<sectionid>` — one column per session. Column name is the session
-  identity (immutable, matching OSM's lack of column rename/delete). A cell holds the
-  row member's signup (`s`: `"I"` in / `"B"` backup, `sat` timestamp) plus an optional
-  session-metadata candidate (`m`: activity, times, expected kids `k`, permits needed
-  `p`, notes `n`, not-on-water flag `c`), merged LWW across the column.
+  identity (immutable, matching OSM's lack of column rename/delete); the sectionid stays
+  in the key so session keys never collide when the board aggregates records from
+  multiple sections. A cell holds the row member's signup (`s`: `"I"` in / `"B"` backup,
+  `sat` timestamp) plus an optional session-metadata candidate (`m`: activity, times,
+  expected kids `k`, permits needed `p`, notes `n`, not-on-water flag `c`), merged LWW
+  across the column.
 
 Key property: **each user only ever writes their own row**, so signups can never
 conflict across users; only metadata needs LWW resolution. Encoding/merging lives in
@@ -49,24 +82,26 @@ Sessions are generated from each section's OSM programme meetings (dates + times
 a manual weekly-slot fallback for sections whose programme is empty
 (`src/features/water-rota/utils/rotaDates.js`).
 
-## Spike questions (verify against live OSM before PR 3 ships)
+## Spikes — resolved (verified 2026-07-13, live OSM)
 
-Record findings here as they are confirmed:
+1. **Column count** — no longer a concern: a record now covers one section's sessions
+   (~14 columns + config) instead of a full-summer, all-sections year record.
+2. **Cell size** — confirmed a ~4KB cell value round-trips `update-flexi-record` safely.
+3. **Cross-term persistence** — confirmed: flexi cell values are per-member and
+   **not term-scoped**; `termid` only selects the read/roster context, never the data.
+   Term rollover never loses data. This is what makes the host termid a pure call-time API
+   parameter (above) rather than part of a record's identity — the actual problem the old
+   year-model had was record *discovery* depending on the current active term, not data
+   loss.
+4. **Programme endpoint shape** — confirmed `GET /ext/programme/` returns usable
+   `starttime`/`endtime` for our sections; no fallback needed in practice.
+5. **Permissions key** — confirmed and in use to gate plan editing and signup
+   (`useRotaPermissions.js`).
 
-1. **Column count** — is a record with ~40 custom columns (a full summer + config) fine
-   in OSM's UI and API? Fallback if not: one record per term (~13 columns), encoding
-   unchanged.
-2. **Cell size** — confirm a ~4KB cell value survives `update-flexi-record` round-trips
-   so session notes are safe. Cells are designed to stay under 1KB.
-3. **Cross-term persistence** — confirm cell values persist when the host section's term
-   changes (values should be per-member, term only selects the roster). Fallback: record
-   per term.
-4. **Programme endpoint shape** — exact query params and response fields of
-   `GET /ext/programme/` for our sections (the public OSM API spec is anonymized).
-   Confirm `starttime`/`endtime` presence; fall back to per-section preset times if
-   absent.
-5. **Permissions key** — the exact `section.permissions` key/threshold that indicates
-   flexi-record write access (used to gate plan editing and signup).
+Additional live-OSM fact that shaped the term-model rework: **OSM terms are per-section**
+— each section has its own termids, names, and dates, and no termid is shared across
+sections, so no single record can be scoped to "the group's" term. See
+`water-rota-term-model-prd.md` §1 for the full write-up.
 
 ## Deferred beyond v1
 

--- a/docs/features/water-rota.md
+++ b/docs/features/water-rota.md
@@ -20,8 +20,8 @@ design.
   edit form (activity presets, times, expected-kids defaulting to the section YP total,
   permit-holders-needed, notes) and a restorable "Not on water this week" toggle.
 - `/water-rota/me` — **My week**: the user's commitments bucketed this week / next week /
-  later, aggregated across every record in the selected season, with inline withdraw
-  (confirm dialog when leaving a session short).
+  later, aggregated across every record in the default (current) season, with inline
+  withdraw (confirm dialog when leaving a session short).
 - `/water-rota/setup` — per-section wizard: section + its own term (host section
   auto-detected, read-only) → programme review for that section only, with on-water
   checkboxes (weekly-slot fallback) → preview + resumable creation + initial config
@@ -62,10 +62,13 @@ components consume the same shape as before the rework.
 Rows are host-section members. Two column kinds per record:
 
 - `RotaConfig` — a single-section plan config JSON (date range, one section's defaults —
-  `sid`/`sname`/`act`/`st`/`en`/`k`/`p`/`regulars`, plus per-session overrides). Each plan
-  editor writes the full config to **their own row**; readers take the last-writer-wins
-  winner across rows by `(v, at)`. There is nothing to merge across sections — a record
-  covers exactly one section, so no config-merge step exists.
+  `sid`/`sname`/`act`/`st`/`en`/`k`/`p`/`regulars`, plus per-session overrides). Two write
+  modes: setup does a full replace into a **deterministic member row** (so re-running setup
+  always finds the same candidate to seed from); programme sync's title backfill
+  shallow-merges just the changed keys onto the live winner, written into **the editor's
+  own row**. Readers take the last-writer-wins winner across rows by `(v, at)`. There is
+  nothing to merge across sections — a record covers exactly one section, so no
+  cross-section config-merge step exists.
 - `S_<yyyymmdd>_<sectionid>` — one column per session. Column name is the session
   identity (immutable, matching OSM's lack of column rename/delete); the sectionid stays
   in the key so session keys never collide when the board aggregates records from
@@ -74,9 +77,12 @@ Rows are host-section members. Two column kinds per record:
   expected kids `k`, permits needed `p`, notes `n`, not-on-water flag `c`), merged LWW
   across the column.
 
-Key property: **each user only ever writes their own row**, so signups can never
-conflict across users; only metadata needs LWW resolution. Encoding/merging lives in
-`src/features/water-rota/services/rotaEncoding.js` (pure, clock-free, zod-validated).
+Key property: **each user only ever writes their own row** for signups, so signups can
+never conflict across users; only metadata needs LWW resolution. Two exceptions write
+another member's row directly: setup/regular pre-fill (organiser-only, cells empty) and a
+leader's `assignSignup` (adding a permit holder they know is coming). Encoding/merging
+lives in `src/features/water-rota/services/rotaEncoding.js` (pure, clock-free,
+zod-validated).
 
 Sessions are generated from each section's OSM programme meetings (dates + times), with
 a manual weekly-slot fallback for sections whose programme is empty

--- a/src/features/water-rota/components/MyCommitmentsPage.jsx
+++ b/src/features/water-rota/components/MyCommitmentsPage.jsx
@@ -30,9 +30,14 @@ const BUCKET_LABELS = [
  */
 function MyCommitmentsPage() {
   const { loading, rota, error, refresh } = useWaterRota();
-  const identityState = useRotaIdentity(rota);
+  // useRotaIdentity resolves once per host section (WP5 will formalize this);
+  // the group has no top-level recordId, so shim one from the shared host
+  // section id — the same value WP5's per-host-section storage key will use.
+  const identityState = useRotaIdentity(
+    rota ? { recordId: rota.hostSection?.sectionid ?? null, members: rota.members } : null,
+  );
   const { identity, needsPicker, choose } = identityState;
-  const { setSignup, pendingFieldId } = useRotaSignup(rota, identity, refresh);
+  const { setSignup, pendingKey } = useRotaSignup(rota, identity, refresh);
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const [confirmChange, setConfirmChange] = useState(null);
@@ -59,7 +64,7 @@ function MyCommitmentsPage() {
       setConfirmChange({ session, newStatus });
       return;
     }
-    setSignup(session.fieldId, newStatus);
+    setSignup(session, newStatus);
   };
 
   if (loading) {
@@ -145,7 +150,7 @@ function MyCommitmentsPage() {
                       session={session}
                       myStatus={myStatusFor(session, identity.scoutid)}
                       onSignupChange={handleSignupChange}
-                      signupPending={Boolean(session.fieldId) && pendingFieldId === session.fieldId}
+                      signupPending={Boolean(session.fieldId) && pendingKey === session.key}
                     />
                   ))}
                 </div>
@@ -167,7 +172,7 @@ function MyCommitmentsPage() {
         cancelText="Stay signed up"
         confirmVariant="warning"
         onConfirm={() => {
-          setSignup(confirmChange.session.fieldId, confirmChange.newStatus);
+          setSignup(confirmChange.session, confirmChange.newStatus);
           setConfirmChange(null);
         }}
         onCancel={() => setConfirmChange(null)}

--- a/src/features/water-rota/components/MyCommitmentsPage.jsx
+++ b/src/features/water-rota/components/MyCommitmentsPage.jsx
@@ -117,7 +117,7 @@ function MyCommitmentsPage() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-4">
+    <div className="max-w-3xl lg:max-w-6xl mx-auto px-4 py-4">
       <div className="flex items-center justify-between gap-2">
         <h1 className="text-lg font-semibold text-gray-900">My sessions</h1>
         <button

--- a/src/features/water-rota/components/MyCommitmentsPage.jsx
+++ b/src/features/water-rota/components/MyCommitmentsPage.jsx
@@ -30,13 +30,8 @@ const BUCKET_LABELS = [
  */
 function MyCommitmentsPage() {
   const { loading, rota, error, refresh } = useWaterRota();
-  // useRotaIdentity resolves once per host section (WP5 will formalize this);
-  // the group has no top-level recordId, so shim one from the shared host
-  // section id — the same value WP5's per-host-section storage key will use.
-  const identityState = useRotaIdentity(
-    rota ? { recordId: rota.hostSection?.sectionid ?? null, members: rota.members } : null,
-  );
-  const { identity, needsPicker, choose } = identityState;
+  const identityState = useRotaIdentity(rota);
+  const { identity, needsPicker, choose, clear } = identityState;
   const { setSignup, pendingKey } = useRotaSignup(rota, identity, refresh);
 
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -57,6 +52,11 @@ function MyCommitmentsPage() {
   );
 
   const upcomingSoon = buckets.thisWeek.length + buckets.nextWeek.length;
+
+  const handleChangeIdentity = () => {
+    clear();
+    setPickerOpen(true);
+  };
 
   const handleSignupChange = (session, newStatus) => {
     const currentStatus = myStatusFor(session, identity.scoutid);
@@ -118,7 +118,16 @@ function MyCommitmentsPage() {
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-4">
-      <h1 className="text-lg font-semibold text-gray-900">My sessions</h1>
+      <div className="flex items-center justify-between gap-2">
+        <h1 className="text-lg font-semibold text-gray-900">My sessions</h1>
+        <button
+          type="button"
+          onClick={handleChangeIdentity}
+          className="text-sm text-scout-blue hover:text-scout-blue-dark font-medium"
+        >
+          Change who I am
+        </button>
+      </div>
       <p className="mt-1 text-sm text-gray-600">
         {upcomingSoon === 0
           ? 'Nothing in the next two weeks.'

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -42,20 +42,26 @@ function readStoredFilters() {
 }
 
 /**
- * The rota board: term overview strip plus a week-bucketed session list
- * with one-tap signups and a session detail/edit modal. Auto-scrolls to
- * the current week on load. Renders empty/error/first-run states when
- * there is no rota for the year.
+ * The rota board: season picker, term overview strip, and a week-bucketed
+ * session list with one-tap signups and a session detail/edit modal.
+ * Auto-scrolls to the current week on load. Renders empty/error/first-run
+ * states when there is no rota for the season bucket.
  *
  * @returns {JSX.Element} Board page
  */
 function RotaBoardPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { loading, rota, error, refresh, year } = useWaterRota();
-  const identityState = useRotaIdentity(rota);
+  const seasonParam = searchParams.get('season');
+  const { loading, rota, error, refresh, seasonBucket, buckets } = useWaterRota(seasonParam || undefined);
+  // useRotaIdentity resolves once per host section (WP5 will formalize this);
+  // the group has no top-level recordId, so shim one from the shared host
+  // section id — the same value WP5's per-host-section storage key will use.
+  const identityState = useRotaIdentity(
+    rota ? { recordId: rota.hostSection?.sectionid ?? null, members: rota.members } : null,
+  );
   const { identity, needsPicker, choose } = identityState;
-  const { setSignup, pendingFieldId } = useRotaSignup(rota, identity, refresh);
+  const { setSignup, pendingKey } = useRotaSignup(rota, identity, refresh);
   const { canEdit } = useRotaPermissions(rota);
 
   const online = useOnlineStatus();
@@ -66,13 +72,41 @@ function RotaBoardPage() {
   const weekRefs = useRef(new Map());
   const didAutoScroll = useRef(false);
   const appliedUrlSection = useRef(false);
+  const appliedUrlSeason = useRef(false);
 
   // The open session and the section filter are driven by the URL so the board
   // is deep-linkable and shareable: ?session=<key> opens that session's modal,
-  // ?section=<id>[,<id>] narrows the board to those sections. selectedKey is
-  // derived from the URL so the phone back button closes the modal.
+  // ?section=<id>[,<id>] narrows the board to those sections, ?season=<bucket>
+  // pins the season. selectedKey is derived from the URL so the phone back
+  // button closes the modal.
   const sectionParam = searchParams.get('section');
   const selectedKey = searchParams.get('session');
+
+  // A season-less link pins the resolved default once discovery settles, so a
+  // shared board link keeps showing the same season even after it stops being
+  // the default.
+  useEffect(() => {
+    if (appliedUrlSeason.current || seasonParam || !seasonBucket) {
+      return;
+    }
+    appliedUrlSeason.current = true;
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('season', seasonBucket);
+      return next;
+    }, { replace: true });
+  }, [seasonParam, seasonBucket, setSearchParams]);
+
+  const handleSeasonChange = (event) => {
+    const value = event.target.value;
+    appliedUrlSeason.current = true;
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('season', value);
+      next.delete('session');
+      return next;
+    });
+  };
 
   const openSession = (key) => {
     setSearchParams((prev) => {
@@ -208,21 +242,48 @@ function RotaBoardPage() {
       setConfirmChange({ session, newStatus });
       return;
     }
-    setSignup(session.fieldId, newStatus);
+    setSignup(session, newStatus);
   };
 
   const handleSyncProgramme = async () => {
     setSyncing(true);
     try {
-      const {
-        added, orphaned, errors,
-        titlesUpdated = 0, titleWriteFailed = false, titlesSkippedNoIdentity = false,
-        uncheckedSections = [], failedSections = [],
-      } = await syncRotaWithProgramme({ rota, token: getToken(), scoutid: identity?.scoutid, by: identity?.name });
-      if (errors.length > 0) {
-        notifyError(`Sync finished with ${errors.length} error${errors.length === 1 ? '' : 's'} — try again to finish.`);
+      const token = getToken();
+      let added = 0;
+      let orphaned = 0;
+      let titlesUpdated = 0;
+      let titleWriteFailed = false;
+      let titlesSkippedNoIdentity = false;
+      const uncheckedSections = [];
+      const failedSections = [];
+      const sectionSyncErrors = [];
+
+      // One record per planning section — sync each in turn so failures stay
+      // scoped to that section instead of aborting the whole bucket.
+      for (const record of rota.records ?? []) {
+        const sectionLabel = record.config?.cfg?.sname ?? record.sectionNames?.[record.sectionId] ?? record.sectionId;
+        try {
+          const result = await syncRotaWithProgramme({ rota: record, token, scoutid: identity?.scoutid, by: identity?.name });
+          added += result.added;
+          orphaned += result.orphaned.length;
+          titlesUpdated += result.titlesUpdated;
+          titleWriteFailed = titleWriteFailed || result.titleWriteFailed;
+          titlesSkippedNoIdentity = titlesSkippedNoIdentity || result.titlesSkippedNoIdentity;
+          uncheckedSections.push(...result.uncheckedSections);
+          failedSections.push(...result.failedSections);
+          if (result.errors.length > 0) {
+            sectionSyncErrors.push({ sectionLabel, errors: result.errors });
+          }
+        } catch (error) {
+          sectionSyncErrors.push({ sectionLabel, errors: [{ error: error.message }] });
+        }
+      }
+
+      if (sectionSyncErrors.length > 0) {
+        const names = sectionSyncErrors.map((entry) => entry.sectionLabel).join(', ');
+        notifyError(`Sync finished with errors for ${names} — try again to finish.`);
       } else if (
-        added === 0 && orphaned.length === 0 && titlesUpdated === 0 &&
+        added === 0 && orphaned === 0 && titlesUpdated === 0 &&
         !titleWriteFailed && !titlesSkippedNoIdentity &&
         uncheckedSections.length === 0 && failedSections.length === 0
       ) {
@@ -238,9 +299,9 @@ function RotaBoardPage() {
       } else if (titlesSkippedNoIdentity) {
         notifyInfo('Session names weren’t updated — pick who you are on the rota first.');
       }
-      if (orphaned.length > 0) {
+      if (orphaned > 0) {
         notifyInfo(
-          `${orphaned.length} session${orphaned.length === 1 ? ' is' : 's are'} no longer on the programme — mark them not on water if needed.`,
+          `${orphaned} session${orphaned === 1 ? ' is' : 's are'} no longer on the programme — mark them not on water if needed.`,
         );
       }
       // A real fetch failure (e.g. an expired token) is an error, not the benign
@@ -286,6 +347,27 @@ function RotaBoardPage() {
     }
   };
 
+  // Only buckets with at least one record appear (PRD §3.4) — offered
+  // whenever there's a real choice, in both the empty and loaded states, so a
+  // season with no rota yet doesn't strand the user away from one that has.
+  const seasonPicker = buckets.length > 1 && (
+    <select
+      value={seasonParam || seasonBucket || ''}
+      onChange={handleSeasonChange}
+      aria-label="Season"
+      className="text-sm border border-gray-300 rounded-md px-2 py-1 text-gray-700 bg-white"
+    >
+      {buckets.map((bucket) => (
+        <option key={bucket} value={bucket}>{bucket}</option>
+      ))}
+    </select>
+  );
+
+  // Edit/setup links from the board only carry an unambiguous single-section
+  // context — otherwise the wizard falls back to its own default.
+  const soleSectionId = filterSections.length === 1 ? filterSections[0].sectionid : null;
+  const setupPath = soleSectionId ? `/water-rota/setup?section=${soleSectionId}` : '/water-rota/setup';
+
   if (loading) {
     return <LoadingScreen message="Loading water rota..." />;
   }
@@ -309,9 +391,10 @@ function RotaBoardPage() {
   if (!rota) {
     return (
       <div className="max-w-lg mx-auto px-4 py-16 text-center">
+        {seasonPicker && <div className="mb-4 flex justify-center">{seasonPicker}</div>}
         <div className="text-5xl" aria-hidden="true">🛶</div>
         <h2 className="mt-4 text-lg font-semibold text-gray-900">
-          No water rota for {year} yet
+          {seasonBucket ? `No water rota for ${seasonBucket} yet` : 'No water rota set up yet'}
         </h2>
         <p className="mt-2 text-sm text-gray-500">
           Set up this summer&apos;s on-water sessions from each section&apos;s programme, then
@@ -331,13 +414,16 @@ function RotaBoardPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-4">
       <div className="flex items-center justify-between gap-2">
-        <h1 className="text-lg font-semibold text-gray-900">Water Rota {year}</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-lg font-semibold text-gray-900">Water Rota {rota.seasonBucket}</h1>
+          {seasonPicker}
+        </div>
         <div className="flex items-center gap-4">
           {canEdit && online && (
             <>
               <button
                 type="button"
-                onClick={() => navigate('/water-rota/setup')}
+                onClick={() => navigate(setupPath)}
                 className="text-sm text-scout-blue hover:text-scout-blue-dark font-medium"
               >
                 Edit plan
@@ -385,7 +471,7 @@ function RotaBoardPage() {
           {canEdit ? (
             <button
               type="button"
-              onClick={() => navigate('/water-rota/setup')}
+              onClick={() => navigate(setupPath)}
               className="mt-2 px-4 py-1.5 rounded-md bg-scout-orange text-white text-sm font-semibold hover:opacity-90"
             >
               Finish setup
@@ -491,7 +577,7 @@ function RotaBoardPage() {
           canEdit={canEdit}
           sectionYPCount={ypCounts[selectedSession.sectionId] ?? null}
           myStatus={identity ? myStatusFor(selectedSession, identity.scoutid) : null}
-          signupPending={Boolean(selectedSession.fieldId) && pendingFieldId === selectedSession.fieldId}
+          signupPending={Boolean(selectedSession.fieldId) && pendingKey === selectedSession.key}
           onSignupChange={handleSignupChange}
           refresh={refresh}
           onClose={closeSession}
@@ -520,7 +606,7 @@ function RotaBoardPage() {
         cancelText="Stay signed up"
         confirmVariant="warning"
         onConfirm={() => {
-          setSignup(confirmChange.session.fieldId, confirmChange.newStatus);
+          setSignup(confirmChange.session, confirmChange.newStatus);
           setConfirmChange(null);
         }}
         onCancel={() => setConfirmChange(null)}

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -54,13 +54,8 @@ function RotaBoardPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const seasonParam = searchParams.get('season');
   const { loading, rota, error, refresh, seasonBucket, buckets } = useWaterRota(seasonParam || undefined);
-  // useRotaIdentity resolves once per host section (WP5 will formalize this);
-  // the group has no top-level recordId, so shim one from the shared host
-  // section id — the same value WP5's per-host-section storage key will use.
-  const identityState = useRotaIdentity(
-    rota ? { recordId: rota.hostSection?.sectionid ?? null, members: rota.members } : null,
-  );
-  const { identity, needsPicker, choose } = identityState;
+  const identityState = useRotaIdentity(rota);
+  const { identity, needsPicker, choose, clear } = identityState;
   const { setSignup, pendingKey } = useRotaSignup(rota, identity, refresh);
   const { canEdit } = useRotaPermissions(rota);
 
@@ -230,6 +225,11 @@ function RotaBoardPage() {
       return;
     }
     weekRefs.current.get(weekStart)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const handleChangeIdentity = () => {
+    clear();
+    setPickerOpen(true);
   };
 
   const handleSignupChange = (session, newStatus) => {
@@ -454,6 +454,20 @@ function RotaBoardPage() {
           </button>
         </div>
       </div>
+
+      {identity && (
+        <div className="mt-1.5 text-xs text-gray-500">
+          Signed in as <span className="font-medium text-gray-700">{identity.name}</span>
+          {' · '}
+          <button
+            type="button"
+            onClick={handleChangeIdentity}
+            className="text-scout-blue hover:text-scout-blue-dark font-medium"
+          >
+            Change
+          </button>
+        </div>
+      )}
 
       {!online && (
         <div className="mt-3 rounded-lg border border-gray-300 bg-gray-50 px-4 py-2.5 text-sm text-gray-600">

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -18,6 +18,7 @@ import { useSectionYPCounts } from '../hooks/useSectionYPCounts.js';
 import { useOnlineStatus } from '../hooks/useOnlineStatus.js';
 import { syncRotaWithProgramme } from '../services/rotaSetupService.js';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
+import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import { notifyError, notifyInfo, notifySuccess } from '../../../shared/utils/notifications.js';
 import { copyToClipboard, shareOrigin } from '../../../shared/utils/clipboard.js';
 import SessionMiniCard from './SessionMiniCard.jsx';
@@ -272,6 +273,7 @@ function RotaBoardPage() {
       let titlesUpdated = 0;
       let titleWriteFailed = false;
       let titlesSkippedNoIdentity = false;
+      let prefillErrorsCount = 0;
       const uncheckedSections = [];
       const failedSections = [];
       const sectionSyncErrors = [];
@@ -287,12 +289,17 @@ function RotaBoardPage() {
           titlesUpdated += result.titlesUpdated;
           titleWriteFailed = titleWriteFailed || result.titleWriteFailed;
           titlesSkippedNoIdentity = titlesSkippedNoIdentity || result.titlesSkippedNoIdentity;
+          prefillErrorsCount += result.prefillErrors?.length ?? 0;
           uncheckedSections.push(...result.uncheckedSections);
           failedSections.push(...result.failedSections);
           if (result.errors.length > 0) {
             sectionSyncErrors.push({ sectionLabel, errors: result.errors });
           }
         } catch (error) {
+          logger.error('Programme sync: section failed', {
+            sectionId: record.sectionId,
+            error: error.message,
+          }, LOG_CATEGORIES.API);
           sectionSyncErrors.push({ sectionLabel, errors: [{ error: error.message }] });
         }
       }
@@ -303,7 +310,8 @@ function RotaBoardPage() {
       } else if (
         added === 0 && orphaned === 0 && titlesUpdated === 0 &&
         !titleWriteFailed && !titlesSkippedNoIdentity &&
-        uncheckedSections.length === 0 && failedSections.length === 0
+        uncheckedSections.length === 0 && failedSections.length === 0 &&
+        prefillErrorsCount === 0
       ) {
         notifyInfo('Rota already matches the programmes.');
       } else if (added > 0) {
@@ -320,6 +328,13 @@ function RotaBoardPage() {
       if (orphaned > 0) {
         notifyInfo(
           `${orphaned} session${orphaned === 1 ? ' is' : 's are'} no longer on the programme — mark them not on water if needed.`,
+        );
+      }
+      // A pre-fill write failure on a newly added session must not read as
+      // sync success — the session exists but its regulars weren't added.
+      if (prefillErrorsCount > 0) {
+        notifyInfo(
+          `Regulars couldn't be pre-filled for ${prefillErrorsCount} session${prefillErrorsCount === 1 ? '' : 's'} — open them to add manually.`,
         );
       }
       // A real fetch failure (e.g. an expired token) is an error, not the benign

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -92,6 +92,24 @@ function RotaBoardPage() {
     }, { replace: true });
   }, [seasonParam, seasonBucket, setSearchParams]);
 
+  // A stale/invalid ?season= (e.g. an old shared link naming a bucket that no
+  // longer exists) is silently replaced by useWaterRota's fallback bucket —
+  // clamp the URL to match once buckets are known, so the season <select>
+  // never holds a value with no matching option.
+  useEffect(() => {
+    if (!seasonParam || buckets.length === 0 || !seasonBucket || seasonParam === seasonBucket) {
+      return;
+    }
+    if (buckets.includes(seasonParam)) {
+      return;
+    }
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('season', seasonBucket);
+      return next;
+    }, { replace: true });
+  }, [seasonParam, seasonBucket, buckets, setSearchParams]);
+
   const handleSeasonChange = (event) => {
     const value = event.target.value;
     appliedUrlSeason.current = true;

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -587,7 +587,7 @@ function RotaBoardPage() {
               {/* Every session that week tiles across the card — each section's
                   nights are separate tiles, filling the width instead of a
                   narrow per-day strip. */}
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {weekSessions.map((session) => (
                   <SessionMiniCard
                     key={session.key}

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -430,7 +430,7 @@ function RotaBoardPage() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-4">
+    <div className="max-w-3xl lg:max-w-6xl mx-auto px-4 py-4">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <h1 className="text-lg font-semibold text-gray-900">Water Rota {rota.seasonBucket}</h1>

--- a/src/features/water-rota/components/SessionDetailModal.jsx
+++ b/src/features/water-rota/components/SessionDetailModal.jsx
@@ -15,6 +15,26 @@ import SignupButtons from './SignupButtons.jsx';
 import AddPermitHolderModal from './AddPermitHolderModal.jsx';
 
 /**
+ * Only the keys of `next` whose value actually differs from `base` — so a
+ * save only carries the fields the editor actually touched, letting a
+ * concurrent co-leader's edit to any other field survive the live-winner
+ * merge in writeSessionMeta.
+ *
+ * @param {Object} next - Fields as submitted by the form
+ * @param {Object} base - The values the form opened with
+ * @returns {Object} Patch of only the changed keys
+ */
+function diffFields(next, base) {
+  const patch = {};
+  for (const [key, value] of Object.entries(next)) {
+    if (value !== base[key]) {
+      patch[key] = value;
+    }
+  }
+  return patch;
+}
+
+/**
  * Session detail: who's signed up, session notes, a copy-link button to share
  * the session, a one-tap signup footer, and — for plan editors — the edit form,
  * add/remove permit-holder controls, and the "Not on water" / "Put on the
@@ -62,6 +82,15 @@ function SessionDetailModal({
       notifyError('Pick your name first so edits can be attributed to you.');
       return;
     }
+    // Only send the fields the editor actually changed from what the form
+    // opened with — a full-object write would silently discard a concurrent
+    // co-leader's edit to any field left untouched here.
+    const metaPatch = diffFields(fields, currentFields);
+    if (Object.keys(metaPatch).length === 0) {
+      setEditing(false);
+      onClose();
+      return;
+    }
     setSaving(true);
     try {
       await writeSessionMeta({
@@ -69,7 +98,7 @@ function SessionDetailModal({
         fieldId: session.fieldId,
         scoutid: identity.scoutid,
         by: identity.name,
-        fields,
+        metaPatch,
         token: getToken(),
       });
       notifySuccess(successText ?? 'Session updated');
@@ -89,7 +118,8 @@ function SessionDetailModal({
     en: session.endTime || '20:00',
     k: session.kids ?? sectionYPCount ?? 0,
     p: session.needed ?? 0,
-    n: session.notes,
+    n: session.notes ?? '',
+    c: session.cancelled ? 1 : 0,
   };
 
   const handleSave = (fields) => saveMeta({ ...fields, c: session.cancelled ? 1 : 0 });

--- a/src/features/water-rota/components/SessionDetailModal.jsx
+++ b/src/features/water-rota/components/SessionDetailModal.jsx
@@ -100,6 +100,11 @@ function SessionDetailModal({
         by: identity.name,
         metaPatch,
         token: getToken(),
+        // Resolved effective values (config-derived when the column has no
+        // meta yet) — the merge base for a virgin column, so a first write
+        // (e.g. notes-only) doesn't reset activity/times/permits to global
+        // defaults.
+        base: currentFields,
       });
       notifySuccess(successText ?? 'Session updated');
       setEditing(false);

--- a/src/features/water-rota/components/SessionDetailModal.jsx
+++ b/src/features/water-rota/components/SessionDetailModal.jsx
@@ -21,8 +21,8 @@ import AddPermitHolderModal from './AddPermitHolderModal.jsx';
  * water" toggles.
  *
  * @param {Object} props
- * @param {import('../utils/rotaDisplay.js').SessionView|null} props.session - Session to show (null = closed)
- * @param {import('../services/rotaService.js').LoadedRota} props.rota - Loaded rota
+ * @param {import('../utils/rotaDisplay.js').SessionView|null} props.session - Session to show (null = closed); writes route to `session.record`, its owning record
+ * @param {import('../services/rotaService.js').RotaGroup} props.rota - Loaded rota group (used here only for the shared member roster)
  * @param {{scoutid: string, name: string}|null} props.identity - Resolved identity (required for edits/signups)
  * @param {boolean} props.canEdit - Offer plan-editing UI
  * @param {number|null} props.sectionYPCount - Section YP total for the kids default
@@ -65,7 +65,7 @@ function SessionDetailModal({
     setSaving(true);
     try {
       await writeSessionMeta({
-        rota,
+        rota: session.record,
         fieldId: session.fieldId,
         scoutid: identity.scoutid,
         by: identity.name,
@@ -107,7 +107,7 @@ function SessionDetailModal({
     setSaving(true);
     try {
       await activateWaterSession({
-        rota,
+        rota: session.record,
         date: session.date,
         sectionId: session.sectionId,
         fields,
@@ -134,7 +134,7 @@ function SessionDetailModal({
     }
     setAssigning(true);
     try {
-      await assignSignup({ rota, fieldId: session.fieldId, scoutid, status: SIGNUP_STATUS.IN, token: getToken() });
+      await assignSignup({ rota: session.record, fieldId: session.fieldId, scoutid, status: SIGNUP_STATUS.IN, token: getToken() });
       notifySuccess('Permit holder added');
       setAddingPermitHolder(false);
       await refresh();
@@ -151,7 +151,7 @@ function SessionDetailModal({
     }
     setRemovingScoutid(scoutid);
     try {
-      await assignSignup({ rota, fieldId: session.fieldId, scoutid, status: null, token: getToken() });
+      await assignSignup({ rota: session.record, fieldId: session.fieldId, scoutid, status: null, token: getToken() });
       notifySuccess('Removed from this session');
       await refresh();
     } catch (error) {

--- a/src/features/water-rota/components/SessionMiniCard.jsx
+++ b/src/features/water-rota/components/SessionMiniCard.jsx
@@ -3,7 +3,7 @@ import { format, parseISO } from 'date-fns';
 import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
 import { COVER_STATUS, coverStatusTintClass, sectionChipClass } from '../utils/rotaDisplay.js';
 
-const MAX_AVATARS = 3;
+const MAX_AVATARS = 4;
 
 /**
  * Compact tappable board tile for one session: section chip and activity,
@@ -19,7 +19,10 @@ const MAX_AVATARS = 3;
 function SessionMiniCard({ session, onSelect }) {
   const { sectionName, date, label, activityTag, needed, cancelled, hasMeta, confirmed, backups, status } = session;
   const people = [...confirmed, ...backups];
-  const overflow = people.length - MAX_AVATARS;
+  // A "+1" chip would occupy the exact slot the hidden avatar needs, so one
+  // extra person is shown outright; the chip only appears from "+2" up.
+  const visibleCount = people.length === MAX_AVATARS + 1 ? people.length : MAX_AVATARS;
+  const overflow = people.length - visibleCount;
 
   let ratioLabel;
   if (cancelled) {
@@ -65,7 +68,7 @@ function SessionMiniCard({ session, onSelect }) {
 
       {people.length > 0 && (
         <span className="mt-1.5 flex -space-x-3" aria-label={`Signed up: ${people.map((p) => p.name).join(', ')}`}>
-          {people.slice(0, MAX_AVATARS).map((person) => (
+          {people.slice(0, visibleCount).map((person) => (
             <span
               key={person.scoutid}
               className={`inline-block rounded-full ring-2 ${

--- a/src/features/water-rota/components/SessionMiniCard.jsx
+++ b/src/features/water-rota/components/SessionMiniCard.jsx
@@ -3,7 +3,7 @@ import { format, parseISO } from 'date-fns';
 import MemberAvatar from '../../../shared/components/ui/MemberAvatar.jsx';
 import { COVER_STATUS, coverStatusTintClass, sectionChipClass } from '../utils/rotaDisplay.js';
 
-const MAX_AVATARS = 4;
+const MAX_AVATARS = 8;
 
 /**
  * Compact tappable board tile for one session: section chip and activity,
@@ -67,7 +67,7 @@ function SessionMiniCard({ session, onSelect }) {
       </span>
 
       {people.length > 0 && (
-        <span className="mt-1.5 flex -space-x-3" aria-label={`Signed up: ${people.map((p) => p.name).join(', ')}`}>
+        <span className="mt-1.5 flex flex-wrap gap-y-1 -space-x-3" aria-label={`Signed up: ${people.map((p) => p.name).join(', ')}`}>
           {people.slice(0, visibleCount).map((person) => (
             <span
               key={person.scoutid}

--- a/src/features/water-rota/components/__tests__/SessionDetailModal.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionDetailModal.test.jsx
@@ -231,8 +231,32 @@ describe('SessionDetailModal', () => {
       by: IDENTITY.name,
       metaPatch: { st: '19:00' },
       token: 'tok',
+      base: { act: 'Kayaking', st: '18:15', en: '19:30', k: 24, p: 3, n: '', c: 0 },
     });
     await waitFor(() => expect(refresh).toHaveBeenCalled());
+  });
+
+  it('passes the session\'s config-derived values as the merge base on a notes-only edit (virgin column)', async () => {
+    const refresh = vi.fn(async () => undefined);
+    render(
+      <SessionDetailModal
+        {...baseProps}
+        // hasMeta: false — activity/times/kids/needed here come from the
+        // section's config defaults, not from any saved meta.
+        session={makeSession({ hasMeta: false, activity: 'Sailing', startTime: '17:00', endTime: '18:30', kids: 12, needed: 2 })}
+        refresh={refresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Edit session'));
+    fireEvent.change(screen.getByLabelText('Notes'), { target: { value: 'Bring lifejackets' } });
+    fireEvent.click(screen.getByText('Save session'));
+
+    await waitFor(() => expect(writeSessionMeta).toHaveBeenCalledTimes(1));
+    expect(writeSessionMeta).toHaveBeenCalledWith(expect.objectContaining({
+      metaPatch: { n: 'Bring lifejackets' },
+      base: { act: 'Sailing', st: '17:00', en: '18:30', k: 12, p: 2, n: '', c: 0 },
+    }));
   });
 
   it('skips the write entirely when the editor saves without changing anything', async () => {

--- a/src/features/water-rota/components/__tests__/SessionDetailModal.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionDetailModal.test.jsx
@@ -28,6 +28,14 @@ import { SIGNUP_STATUS } from '../../services/rotaEncoding.js';
 
 const IDENTITY = { scoutid: '10', name: 'Simon Clark' };
 
+// The session's owning record (rotaService.assembleRotaGroup's `record`
+// back-reference) — every write call site routes to this, not the group.
+const RECORD = {
+  hostSection: { sectionid: '1' },
+  recordId: 'record-49097',
+  termId: 'term-1',
+};
+
 function makeSession(overrides = {}) {
   return {
     fieldId: 'f_5',
@@ -44,14 +52,16 @@ function makeSession(overrides = {}) {
     hasMeta: true,
     confirmed: [],
     backups: [],
+    record: RECORD,
     ...overrides,
   };
 }
 
+// The rota group prop: SessionDetailModal only reads it for the shared
+// member roster (AddPermitHolderModal) — writes route via session.record.
 const ROTA = {
   hostSection: { sectionid: '1' },
-  year: 2026,
-  termId: 'term-1',
+  seasonBucket: 'Summer 2026',
   members: [
     { scoutid: '10', name: 'Simon Clark' },
     { scoutid: '30', name: 'New Permit Holder' },
@@ -96,7 +106,7 @@ describe('SessionDetailModal', () => {
 
     expect(activateWaterSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        rota: ROTA,
+        rota: RECORD,
         date: '2026-07-14',
         sectionId: '49097',
         by: IDENTITY.name,
@@ -139,7 +149,7 @@ describe('SessionDetailModal', () => {
 
     await waitFor(() => expect(assignSignup).toHaveBeenCalledTimes(1));
     expect(assignSignup).toHaveBeenCalledWith({
-      rota: ROTA,
+      rota: RECORD,
       fieldId: 'f_5',
       scoutid: '30',
       status: null,
@@ -189,7 +199,7 @@ describe('SessionDetailModal', () => {
     await waitFor(() => expect(assignSignup).toHaveBeenCalledTimes(1));
 
     expect(assignSignup).toHaveBeenCalledWith({
-      rota: ROTA,
+      rota: RECORD,
       fieldId: 'f_5',
       scoutid: '30',
       status: SIGNUP_STATUS.IN,

--- a/src/features/water-rota/components/__tests__/SessionDetailModal.test.jsx
+++ b/src/features/water-rota/components/__tests__/SessionDetailModal.test.jsx
@@ -21,7 +21,7 @@ vi.mock('../../../../shared/utils/notifications.js', () => ({
 }));
 
 import SessionDetailModal from '../SessionDetailModal.jsx';
-import { assignSignup } from '../../services/rotaService.js';
+import { assignSignup, writeSessionMeta } from '../../services/rotaService.js';
 import { activateWaterSession } from '../../services/rotaSetupService.js';
 import { notifyError, notifySuccess } from '../../../../shared/utils/notifications.js';
 import { SIGNUP_STATUS } from '../../services/rotaEncoding.js';
@@ -207,6 +207,64 @@ describe('SessionDetailModal', () => {
     });
     expect(notifySuccess).toHaveBeenCalledWith('Permit holder added');
     await waitFor(() => expect(refresh).toHaveBeenCalled());
+  });
+
+  it('saves only the fields the editor actually changed (dirty-field patch)', async () => {
+    const refresh = vi.fn(async () => undefined);
+    render(
+      <SessionDetailModal
+        {...baseProps}
+        session={makeSession()}
+        refresh={refresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Edit session'));
+    fireEvent.change(screen.getByLabelText('Start'), { target: { value: '19:00' } });
+    fireEvent.click(screen.getByText('Save session'));
+
+    await waitFor(() => expect(writeSessionMeta).toHaveBeenCalledTimes(1));
+    expect(writeSessionMeta).toHaveBeenCalledWith({
+      rota: RECORD,
+      fieldId: 'f_5',
+      scoutid: IDENTITY.scoutid,
+      by: IDENTITY.name,
+      metaPatch: { st: '19:00' },
+      token: 'tok',
+    });
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+  });
+
+  it('skips the write entirely when the editor saves without changing anything', async () => {
+    const refresh = vi.fn(async () => undefined);
+    const onClose = vi.fn();
+    render(
+      <SessionDetailModal
+        {...baseProps}
+        session={makeSession()}
+        refresh={refresh}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Edit session'));
+    fireEvent.click(screen.getByText('Save session'));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(writeSessionMeta).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('marking not on water patches only the cancelled flag, so a concurrent edit to other fields survives', async () => {
+    render(<SessionDetailModal {...baseProps} session={makeSession()} />);
+
+    fireEvent.click(screen.getByText('Not on water this week'));
+    fireEvent.click(screen.getByRole('button', { name: 'Not on water' }));
+
+    await waitFor(() => expect(writeSessionMeta).toHaveBeenCalledTimes(1));
+    expect(writeSessionMeta).toHaveBeenCalledWith(expect.objectContaining({
+      metaPatch: { c: 1 },
+    }));
   });
 
   it('blocks putting on the water without a picked identity', async () => {

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -10,8 +10,8 @@ import logger, { LOG_CATEGORIES } from '../../../../shared/services/utils/logger
 import { fetchProgrammeMeetings } from '../../services/programmeService.js';
 import { getTerms } from '../../../../shared/services/api/api/index.js';
 import { createOrCompleteRota, writeRotaConfig } from '../../services/rotaSetupService.js';
-import { loadRota, prefillRegulars } from '../../services/rotaService.js';
-import { ACTIVITY_PRESETS, DEFAULT_PERMIT_HOLDERS, DEFAULT_SESSION_TIMES, guessActivityFromTitle, looksLikeWaterSession } from '../../services/rotaTemplates.js';
+import { discoverRotaRecords, findHostSection, loadRota, prefillRegulars } from '../../services/rotaService.js';
+import { ACTIVITY_PRESETS, DEFAULT_PERMIT_HOLDERS, DEFAULT_SESSION_TIMES, guessActivityFromTitle, looksLikeWaterSession, seasonBucketForRange } from '../../services/rotaTemplates.js';
 import { buildSessionColumnName, parseSessionColumnName } from '../../services/rotaEncoding.js';
 import { expandWeeklySlot, generateSessionsFromProgramme, bucketSessionsByWeek } from '../../utils/rotaDates.js';
 import { buildSessionOverrides } from '../../utils/rotaSetupPlan.js';
@@ -25,7 +25,7 @@ const WEEKDAYS = [
 ];
 
 /**
- * Default per-section plan used until the leader adjusts it.
+ * Default plan used until the leader adjusts it.
  *
  * @returns {Object} Plan defaults
  */
@@ -45,16 +45,16 @@ function defaultPlan() {
 }
 
 /**
- * Build session descriptors for one section from its plan: programme
- * meetings (minus unticked ones) when the programme has any, otherwise the
- * weekly slot fallback.
+ * Build session descriptors for the planning section from its plan:
+ * programme meetings (minus unticked ones) when the programme has any,
+ * otherwise the weekly slot fallback.
  *
  * @param {Object} section - {sid, sname}
- * @param {Object} plan - Per-section plan state
+ * @param {Object} plan - Plan state
  * @param {{start: string, end: string}} range - Rota date range
  * @returns {Array} Session descriptors
  */
-function sessionsForSection(section, plan, range) {
+function sessionsForPlan(section, plan, range) {
   const sectionCfg = { sid: section.sid, sname: section.sname, act: plan.act, st: plan.st, en: plan.en };
   if (plan.meetings && plan.meetings.length > 0) {
     // Every programme meeting becomes a session; onWater (checkbox) decides
@@ -72,11 +72,24 @@ function sessionsForSection(section, plan, range) {
 }
 
 /**
- * Three-step wizard creating the yearly rota record: (1) host section,
- * participating sections, and date range; (2) programme review with
- * on-water checkboxes per meeting (weekly-slot fallback for sections with
- * an empty programme); (3) preview and resumable creation, followed by the
- * initial plan-config write attributed to the resolved identity.
+ * Sections that never plan their own rota: waiting lists (no programme) and
+ * the Adults host itself (it only ever hosts other sections' records).
+ *
+ * @param {Object} section - Cached section
+ * @returns {boolean} True when the section is a waiting list
+ */
+function isWaitingList(section) {
+  return /waiting/i.test(`${section.section ?? ''} ${section.sectiontype ?? ''} ${section.sectionname ?? ''}`);
+}
+
+/**
+ * Three-step wizard creating (or completing) ONE planning section's own rota
+ * record, hosted in the Adults section: (1) section + its own term + date
+ * range; (2) programme review for that section only, with on-water
+ * checkboxes per meeting (weekly-slot fallback for an empty programme); (3)
+ * preview and resumable creation, followed by the plan-config write and
+ * regular pre-fill. Re-running against a section/term that already has a
+ * record seeds the wizard from its existing config.
  *
  * @returns {JSX.Element} Setup wizard page
  */
@@ -86,98 +99,155 @@ function RotaSetupWizard() {
 
   const [step, setStep] = useState(1);
   const [sections, setSections] = useState(null);
-  const [hostSectionId, setHostSectionId] = useState(null);
-  const [selectedIds, setSelectedIds] = useState({});
+  const [descriptors, setDescriptors] = useState([]);
+  const [sectionId, setSectionId] = useState(null);
   const [range, setRange] = useState({ start: '', end: '' });
   const [terms, setTerms] = useState(null);
   const [selectedTermId, setSelectedTermId] = useState('');
-  const [plans, setPlans] = useState({});
+  const [plan, setPlan] = useState(defaultPlan());
   const [loadingProgramme, setLoadingProgramme] = useState(false);
   const [creating, setCreating] = useState(false);
   const [creationErrors, setCreationErrors] = useState([]);
-  const [activeSectionSid, setActiveSectionSid] = useState(null);
-  const seededFromConfig = useRef(false);
+  const seededKeyRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
     async function init() {
       const cached = (await databaseService.getSections()) || [];
+      const discovered = await discoverRotaRecords(token).catch((error) => {
+        logger.warn('Setup: could not check for existing rota records', {
+          error: error.message,
+        }, LOG_CATEGORIES.APP);
+        return [];
+      });
       if (cancelled) {
         return;
       }
       setSections(cached);
-      const isWaitingList = (section) =>
-        /waiting/i.test(`${section.section ?? ''} ${section.sectiontype ?? ''} ${section.sectionname ?? ''}`);
-      const isAdults = (section) =>
-        `${section.section ?? ''} ${section.sectionname ?? ''}`.toLowerCase().includes('adult');
-
-      const adults = cached.find(isAdults);
-      if (adults) {
-        setHostSectionId(String(adults.sectionid));
-      }
-      // Auto-select the youth sections that actually run programmes — not the
-      // Adults host, and not waiting lists (which have no meetings and would
-      // otherwise generate a full year of weekly-slot sessions).
-      const youthSections = cached.filter(
-        (section) => !isAdults(section) && !isWaitingList(section),
+      setDescriptors(discovered);
+      const host = findHostSection(cached);
+      const firstYouth = cached.find(
+        (section) => (!host || section.sectionid !== host.sectionid) && !isWaitingList(section),
       );
-      setSelectedIds(Object.fromEntries(youthSections.map((section) => [String(section.sectionid), true])));
+      if (firstYouth) {
+        setSectionId(String(firstYouth.sectionid));
+      }
     }
     init();
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // On "Edit plan", seed the wizard from the existing rota so prior choices
-  // (regulars, section defaults, date range, not-on-water weeks) are not lost.
+  const hostSection = useMemo(() => findHostSection(sections ?? []), [sections]);
+
+  const section = useMemo(() => {
+    if (!sectionId || !sections) {
+      return null;
+    }
+    const found = sections.find((s) => String(s.sectionid) === sectionId);
+    return found ? { sid: sectionId, sname: found.sectionname } : null;
+  }, [sectionId, sections]);
+
+  const existingDescriptor = useMemo(
+    () => descriptors.find((d) => d.sectionId === sectionId && d.termId === selectedTermId) ?? null,
+    [descriptors, sectionId, selectedTermId],
+  );
+
+  // Load the planning section's own terms, defaulting the selection + range
+  // to its current active term. Switching sections re-picks from scratch.
+  useEffect(() => {
+    let cancelled = false;
+    async function loadTermsForSection() {
+      if (!sectionId) {
+        return;
+      }
+      setSelectedTermId('');
+      setRange({ start: '', end: '' });
+      seededKeyRef.current = null;
+      let list = [];
+      try {
+        const all = await getTerms(token);
+        list = (all?.[sectionId] ?? [])
+          .filter((term) => term.startdate && term.enddate)
+          .sort((a, b) => a.startdate.localeCompare(b.startdate));
+      } catch {
+        /* offline or fetch failed — the leader can still type dates below */
+      }
+      if (cancelled) {
+        return;
+      }
+      setTerms(list);
+      if (list.length === 0) {
+        return;
+      }
+      let current = null;
+      try {
+        current = await CurrentActiveTermsService.getCurrentActiveTerm(sectionId);
+      } catch {
+        /* no cached current term — fall back to the latest term */
+      }
+      const chosen = list.find((term) => String(term.termid) === String(current?.currentTermId))
+        ?? list[list.length - 1];
+      if (!cancelled && chosen) {
+        setSelectedTermId(String(chosen.termid));
+        setRange({ start: chosen.startdate.slice(0, 10), end: chosen.enddate.slice(0, 10) });
+      }
+    }
+    loadTermsForSection();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sectionId]);
+
+  // Re-edit: seed the wizard from the existing record's config when the
+  // chosen (section, term) already has one, so prior choices aren't lost.
   useEffect(() => {
     let cancelled = false;
     async function seedFromExisting() {
-      if (!sections || seededFromConfig.current) {
+      if (!existingDescriptor) {
+        return;
+      }
+      const seedKey = `${existingDescriptor.sectionId}.${existingDescriptor.termId}`;
+      if (seededKeyRef.current === seedKey) {
         return;
       }
       try {
-        const existing = await loadRota(new Date().getFullYear(), token);
+        const existing = await loadRota(existingDescriptor, token);
         const cfg = existing?.config?.cfg;
-        if (cancelled || !cfg || !Array.isArray(cfg.sections) || cfg.sections.length === 0) {
+        if (cancelled) {
           return;
         }
-        seededFromConfig.current = true;
-
-        if (existing.hostSection) {
-          setHostSectionId(String(existing.hostSection.sectionid));
+        seededKeyRef.current = seedKey;
+        if (!cfg) {
+          return;
         }
         if (cfg.start && cfg.end) {
           setRange({ start: cfg.start.slice(0, 10), end: cfg.end.slice(0, 10) });
         }
-        setSelectedIds(Object.fromEntries(cfg.sections.map((s) => [String(s.sid), true])));
-
         // Reconstruct which meeting dates were marked not-on-water (config
         // holds those as {c:1}); on-water weeks were columns, not in config.
-        const offBySection = {};
+        const excluded = {};
         for (const [colName, override] of Object.entries(cfg.sessions ?? {})) {
           if (override?.c === 1) {
             const parsed = parseSessionColumnName(colName);
             if (parsed) {
-              (offBySection[parsed.sectionId] ??= {})[parsed.date] = true;
+              excluded[parsed.date] = true;
             }
           }
         }
-
-        setPlans(Object.fromEntries(cfg.sections.map((s) => [
-          String(s.sid),
-          {
-            ...defaultPlan(),
-            act: s.act ?? ACTIVITY_PRESETS[0],
-            st: s.st ?? DEFAULT_SESSION_TIMES.start,
-            en: s.en ?? DEFAULT_SESSION_TIMES.end,
-            k: s.k ?? null,
-            p: s.p ?? DEFAULT_PERMIT_HOLDERS,
-            regulars: Array.isArray(s.regulars) ? s.regulars : [],
-            excluded: offBySection[String(s.sid)] ?? {},
-          },
-        ])));
+        setPlan((previous) => ({
+          ...previous,
+          act: cfg.act ?? previous.act,
+          st: cfg.st ?? previous.st,
+          en: cfg.en ?? previous.en,
+          k: cfg.k ?? previous.k,
+          p: cfg.p ?? previous.p,
+          regulars: Array.isArray(cfg.regulars) ? cfg.regulars : previous.regulars,
+          excluded,
+        }));
       } catch (error) {
         logger.warn('Setup: no existing rota to seed from', {
           error: error.message,
@@ -188,141 +258,82 @@ function RotaSetupWizard() {
     return () => {
       cancelled = true;
     };
-  }, [sections]);
+  }, [existingDescriptor, token]);
 
-  const hostSection = useMemo(
-    () => (sections ?? []).find((section) => String(section.sectionid) === hostSectionId) ?? null,
-    [sections, hostSectionId],
+  const { counts: ypCounts } = useSectionYPCounts(sectionId ? [sectionId] : []);
+  const { candidates: leaderCandidates } = useSectionLeaders(
+    sectionId ? [sectionId] : [],
+    hostSection?.sectionid ?? null,
   );
-
-  const participating = useMemo(
-    () =>
-      (sections ?? [])
-        .filter((section) => selectedIds[String(section.sectionid)])
-        .map((section) => ({ sid: String(section.sectionid), sname: section.sectionname })),
-    [sections, selectedIds],
-  );
-
-  const rangeSourceSid = participating[0]?.sid ?? hostSectionId;
-
-  // Load the range-source section's terms for the picker, and default the
-  // selection + week range to its current active term — the youth section's
-  // term is the real school term, unlike the Adults host term which often
-  // spans a full year. A seeded range (re-run of an existing rota) is kept.
-  useEffect(() => {
-    let cancelled = false;
-    async function loadTerms() {
-      if (!rangeSourceSid) {
-        return;
-      }
-      let list = [];
-      try {
-        const all = await getTerms(token);
-        list = (all?.[String(rangeSourceSid)] ?? [])
-          .filter((term) => term.startdate && term.enddate)
-          .sort((a, b) => a.startdate.localeCompare(b.startdate));
-      } catch {
-        /* offline or fetch failed — the leader can still type dates below */
-      }
-      if (cancelled) {
-        return;
-      }
-      setTerms(list);
-      if (selectedTermId || list.length === 0) {
-        return;
-      }
-      let current = null;
-      try {
-        current = await CurrentActiveTermsService.getCurrentActiveTerm(rangeSourceSid);
-      } catch {
-        /* no cached current term — fall back to the latest term */
-      }
-      const chosen = list.find((term) => String(term.termid) === String(current?.currentTermId))
-        ?? list[list.length - 1];
-      if (!cancelled && chosen) {
-        setSelectedTermId(String(chosen.termid));
-        if (!range.start) {
-          setRange({ start: chosen.startdate.slice(0, 10), end: chosen.enddate.slice(0, 10) });
-        }
-      }
-    }
-    loadTerms();
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rangeSourceSid]);
-
-  const participatingSids = useMemo(() => participating.map((section) => section.sid), [participating]);
-  const { counts: ypCounts } = useSectionYPCounts(participatingSids);
-  const { candidates: leaderCandidates } = useSectionLeaders(participatingSids, hostSectionId);
-
-  const activeSid = participating.some((s) => s.sid === activeSectionSid)
-    ? activeSectionSid
-    : participating[0]?.sid ?? null;
-  const activeSection = participating.find((s) => s.sid === activeSid) ?? null;
+  const ypCount = sectionId ? ypCounts[sectionId] : undefined;
+  const regularCandidates = sectionId ? leaderCandidates[sectionId] ?? [] : [];
 
   const allSessions = useMemo(
-    () =>
-      participating.flatMap((section) =>
-        plans[section.sid] ? sessionsForSection(section, plans[section.sid], range) : [],
-      ),
-    [participating, plans, range],
+    () => (section ? sessionsForPlan(section, plan, range) : []),
+    [section, plan, range],
   );
   // Only water sessions get signup columns; not-on-water weeks live in config.
   const waterSessions = useMemo(() => allSessions.filter((s) => s.onWater !== false), [allSessions]);
 
-  const year = range.start ? Number(range.start.slice(0, 4)) : new Date().getFullYear();
+  const hasProgramme = plan.meetings && plan.meetings.length > 0;
+  const visibleMeetings = (plan.meetings ?? []).filter(
+    (meeting) => meeting.date >= range.start && meeting.date <= range.end,
+  );
+
+  const seasonBucket = range.start && range.end ? seasonBucketForRange(range.start, range.end) : null;
 
   const startProgrammeReview = async () => {
     setLoadingProgramme(true);
-    const nextPlans = {};
-    for (const section of participating) {
-      const plan = plans[section.sid] ?? defaultPlan();
-      const withKids = { ...plan, k: plan.k ?? ypCounts[section.sid] ?? null };
-      try {
-        const term = await CurrentActiveTermsService.getCurrentActiveTerm(section.sid);
-        const meetings = term?.currentTermId
-          ? await fetchProgrammeMeetings(section.sid, term.currentTermId, token)
-          : [];
-        // Pre-select only the water nights: most programme meetings are not
-        // on the water, so default non-water meetings to excluded rather than
-        // making the leader untick ~10 of 14. On re-edit, the config's saved
-        // not-on-water dates (seeded into plan.excluded) win over the heuristic.
-        const heuristicExcluded = Object.fromEntries(
-          meetings
-            .filter((meeting) => !looksLikeWaterSession(meeting.title))
-            .map((meeting) => [meeting.date, true]),
-        );
-        const excluded = seededFromConfig.current
-          ? { ...heuristicExcluded, ...(plan.excluded ?? {}) }
-          : heuristicExcluded;
-        nextPlans[section.sid] = { ...withKids, meetings, excluded };
-      } catch (error) {
-        logger.warn('Programme fetch failed during setup', {
-          sectionId: section.sid,
-          error: error.message,
-        }, LOG_CATEGORIES.API);
-        nextPlans[section.sid] = { ...withKids, meetings: [] };
-      }
+    try {
+      // Fetch the programme under the exact term chosen in step 1 — the
+      // record's own planning term, not a fresh "current active term" lookup.
+      const meetings = selectedTermId
+        ? await fetchProgrammeMeetings(sectionId, selectedTermId, token)
+        : [];
+      // Pre-select only the water nights: most programme meetings are not on
+      // the water, so default non-water meetings to excluded rather than
+      // making the leader untick most of them. On re-edit, the config's saved
+      // not-on-water dates (seeded into plan.excluded) win over the heuristic.
+      const heuristicExcluded = Object.fromEntries(
+        meetings
+          .filter((meeting) => !looksLikeWaterSession(meeting.title))
+          .map((meeting) => [meeting.date, true]),
+      );
+      const excluded = existingDescriptor
+        ? { ...heuristicExcluded, ...(plan.excluded ?? {}) }
+        : heuristicExcluded;
+      setPlan((previous) => ({ ...previous, k: previous.k ?? ypCount ?? null, meetings, excluded }));
+    } catch (error) {
+      logger.warn('Programme fetch failed during setup', {
+        sectionId,
+        error: error.message,
+      }, LOG_CATEGORIES.API);
+      setPlan((previous) => ({ ...previous, k: previous.k ?? ypCount ?? null, meetings: [] }));
     }
-    setPlans(nextPlans);
     setLoadingProgramme(false);
     setStep(2);
   };
 
-  const updatePlan = (sid, patch) => {
-    setPlans((previous) => ({ ...previous, [sid]: { ...previous[sid], ...patch } }));
+  const updatePlan = (patch) => {
+    setPlan((previous) => ({ ...previous, ...patch }));
   };
 
   const handleCreate = async () => {
     setCreating(true);
     setCreationErrors([]);
     try {
+      const hostTerm = await CurrentActiveTermsService.getCurrentActiveTerm(hostSection.sectionid);
+      const hostTermId = hostTerm?.currentTermId;
+      if (!hostTermId) {
+        setCreationErrors([{ field: '_meta', error: 'No active term found for the host section' }]);
+        return;
+      }
+
+      const record = { sectionId: section.sid, sectionName: section.sname, termId: selectedTermId, seasonBucket };
       const result = await createOrCompleteRota({
         hostSection,
-        year,
-        termId: (await CurrentActiveTermsService.getCurrentActiveTerm(hostSectionId))?.currentTermId,
+        hostTermId,
+        record,
         sessions: waterSessions,
         token,
       });
@@ -332,7 +343,8 @@ function RotaSetupWizard() {
         return;
       }
 
-      const rota = await loadRota(year, token);
+      const descriptor = { recordId: result.flexirecordid, hostSection, ...record };
+      const rota = await loadRota(descriptor, token, { forceRefresh: true });
       if (!rota) {
         setCreationErrors([{ field: '_meta', error: 'Record created but could not be re-loaded' }]);
         return;
@@ -349,51 +361,45 @@ function RotaSetupWizard() {
       }
 
       const by = (await getCurrentUserName()) ?? 'Setup';
-      const sectionDefaults = participating.map((section) => {
-        const plan = plans[section.sid];
-        return {
-          sid: section.sid,
-          sname: section.sname,
-          act: plan.act,
-          st: plan.st,
-          en: plan.en,
-          k: plan.k ?? ypCounts[section.sid] ?? 0,
-          p: plan.p ?? DEFAULT_PERMIT_HOLDERS,
-          regulars: plan.regulars ?? [],
-        };
-      });
+      const sectionDefault = {
+        sid: section.sid,
+        sname: section.sname,
+        act: plan.act,
+        st: plan.st,
+        en: plan.en,
+        k: plan.k ?? ypCount ?? 0,
+        p: plan.p ?? DEFAULT_PERMIT_HOLDERS,
+        regulars: plan.regulars ?? [],
+      };
       await writeRotaConfig({
         hostSection,
-        recordId: result.flexirecordid,
+        recordId: rota.recordId,
         termId: rota.termId,
         scoutid: configRow.scoutid,
         by,
-        // Merge this run's sections into the shared config rather than
-        // replacing it — section leaders set up their own section, so a save
-        // must not delete the others. The rota-wide range grows to cover it.
-        mergeSections: true,
         cfg: {
+          ...sectionDefault,
           start: range.start,
           end: range.end,
-          sections: sectionDefaults,
-          sessions: buildSessionOverrides(allSessions, sectionDefaults),
+          sessions: buildSessionOverrides(allSessions, [sectionDefault]),
         },
         token,
       });
 
-      // Pre-fill each section's regulars as confirmed signups — but only on
+      // Pre-fill the section's regulars as confirmed signups — but only on
       // sessions whose column was just created this run. Re-touching existing
       // sessions would clobber people's withdrawals on a plan re-edit.
-      const regularsBySection = Object.fromEntries(
-        participating.map((section) => [section.sid, plans[section.sid]?.regulars ?? []]),
-      );
       const newlyAdded = new Set(result.addedFields ?? []);
       const newSessions = rota.sessions.filter(
-        (session) => session.fieldId && newlyAdded.has(buildSessionColumnName(session.date, session.sectionId)),
+        (s) => s.fieldId && newlyAdded.has(buildSessionColumnName(s.date, s.sectionId)),
       );
-      const hasRegulars = Object.values(regularsBySection).some((list) => list.length > 0);
-      if (hasRegulars && newSessions.length > 0) {
-        const { errors } = await prefillRegulars({ rota, regularsBySection, token, sessions: newSessions });
+      if ((plan.regulars ?? []).length > 0 && newSessions.length > 0) {
+        const { errors } = await prefillRegulars({
+          rota,
+          regularsBySection: { [section.sid]: plan.regulars ?? [] },
+          token,
+          sessions: newSessions,
+        });
         if (errors.length > 0) {
           notifyError(`Rota saved, but ${errors.length} session${errors.length === 1 ? '' : 's'} couldn't be pre-filled with regulars — open them to add manually.`);
         }
@@ -411,6 +417,18 @@ function RotaSetupWizard() {
 
   if (!sections) {
     return <LoadingScreen message="Loading sections..." />;
+  }
+
+  if (!hostSection) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-5">
+        <h1 className="text-lg font-semibold text-gray-900">Set up the water rota</h1>
+        <p className="mt-3 rounded-lg border border-scout-red bg-scout-red/5 p-3 text-sm text-scout-red">
+          No Adults section was found. The rota needs an Adults section to host the roster every permit
+          holder signs up from — ask an admin to check your section access.
+        </p>
+      </div>
+    );
   }
 
   const stepBadge = (n, label) => (
@@ -436,47 +454,32 @@ function RotaSetupWizard() {
           <div>
             <label className="block text-sm font-medium text-gray-700">Host section</label>
             <p className="text-xs text-gray-500">
-              The rota lives in this section — pick one all your permit holders belong to
-              (usually Adults).
+              Every rota record lives here so any permit holder can sign up for any section&apos;s sessions.
             </p>
-            <select
-              value={hostSectionId ?? ''}
-              onChange={(event) => setHostSectionId(event.target.value)}
-              className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-scout-blue focus:outline-none"
-              aria-label="Host section"
-            >
-              <option value="" disabled>Choose a section…</option>
-              {sections.map((section) => (
-                <option key={section.sectionid} value={String(section.sectionid)}>
-                  {section.sectionname}
-                </option>
-              ))}
-            </select>
+            <p className="mt-2 text-sm font-medium text-gray-900">{hostSection.sectionname}</p>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700">Sections going on the water</label>
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {sections.map((section) => {
-                const sid = String(section.sectionid);
-                const active = Boolean(selectedIds[sid]);
-                return (
-                  <button
-                    key={sid}
-                    type="button"
-                    aria-pressed={active}
-                    onClick={() => setSelectedIds((previous) => ({ ...previous, [sid]: !previous[sid] }))}
-                    className={`px-3 py-1.5 rounded-full text-xs font-semibold border ${
-                      active
-                        ? sectionChipClass(section.sectionname) + ' border-transparent'
-                        : 'bg-white border-gray-300 text-gray-500'
-                    }`}
-                  >
-                    {section.sectionname}
-                  </button>
-                );
-              })}
-            </div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="rota-section">Section</label>
+            <p className="text-xs text-gray-500">Sets up (or completes) this section&apos;s own rota record only.</p>
+            <select
+              id="rota-section"
+              value={sectionId ?? ''}
+              onChange={(event) => setSectionId(event.target.value)}
+              className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-scout-blue focus:outline-none"
+            >
+              <option value="" disabled>Choose a section…</option>
+              {sections.map((s) => (
+                <option key={s.sectionid} value={String(s.sectionid)}>
+                  {s.sectionname}
+                </option>
+              ))}
+            </select>
+            {existingDescriptor && (
+              <p className="mt-1.5 text-xs text-scout-blue">
+                This section already has a rota for this term — continuing will edit it.
+              </p>
+            )}
           </div>
 
           {terms && terms.length > 0 && (
@@ -530,238 +533,207 @@ function RotaSetupWizard() {
 
           <button
             type="button"
-            disabled={!hostSection || participating.length === 0 || !range.start || !range.end || range.end < range.start || loadingProgramme}
+            disabled={!section || !selectedTermId || !range.start || !range.end || range.end < range.start || loadingProgramme}
             onClick={startProgrammeReview}
             className="w-full py-2.5 rounded-md bg-scout-blue text-white text-sm font-semibold hover:bg-scout-blue-dark disabled:opacity-50"
           >
-            {loadingProgramme ? 'Reading programmes…' : 'Next: review programmes'}
+            {loadingProgramme ? 'Reading programme…' : 'Next: review programme'}
           </button>
         </div>
       )}
 
-      {step === 2 && (
+      {step === 2 && section && (
         <div className="mt-5 space-y-6">
-          <div className="flex flex-wrap gap-1.5">
-            {participating.map((section) => {
-              const active = section.sid === activeSid;
-              return (
-                <button
-                  key={section.sid}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => setActiveSectionSid(section.sid)}
-                  className={`px-3 py-1.5 rounded-full text-xs font-semibold border ${
-                    active
-                      ? sectionChipClass(section.sname) + ' border-transparent'
-                      : 'bg-white border-gray-300 text-gray-500'
-                  }`}
+          <section className="rounded-lg border border-gray-200 p-4">
+            <h2 className="flex items-center gap-2">
+              <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${sectionChipClass(section.sname)}`}>
+                {section.sname}
+              </span>
+              <span className="text-xs text-gray-500">
+                {hasProgramme
+                  ? `${visibleMeetings.filter((m) => !plan.excluded[m.date]).length} water night${
+                    visibleMeetings.filter((m) => !plan.excluded[m.date]).length === 1 ? '' : 's'
+                  } selected of ${visibleMeetings.length} programme meetings`
+                  : 'No programme found — using a weekly slot'}
+              </span>
+            </h2>
+            {hasProgramme && (
+              <p className="mt-1 text-xs text-gray-400">
+                Water nights are auto-picked from the meeting name; tick or untick any.
+                Times aren&apos;t in the OSM programme, so the section time below is used.
+              </p>
+            )}
+
+            <div className="mt-3 flex flex-wrap items-end gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Default activity</label>
+                <select
+                  value={plan.act}
+                  onChange={(event) => updatePlan({ act: event.target.value })}
+                  className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
                 >
-                  {section.sname}
-                </button>
-              );
-            })}
-          </div>
+                  {ACTIVITY_PRESETS.map((preset) => (
+                    <option key={preset} value={preset}>{preset}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Start</label>
+                <input
+                  type="time"
+                  value={plan.st}
+                  onChange={(event) => updatePlan({ st: event.target.value })}
+                  className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600">End</label>
+                <input
+                  type="time"
+                  value={plan.en}
+                  onChange={(event) => updatePlan({ en: event.target.value })}
+                  className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
+                />
+              </div>
+              {!hasProgramme && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-600">Evening</label>
+                  <select
+                    value={plan.slotWeekday}
+                    onChange={(event) => updatePlan({ slotWeekday: Number(event.target.value) })}
+                    className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
+                  >
+                    {WEEKDAYS.map(([value, label]) => (
+                      <option key={value} value={value}>{label}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Expected YP</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={plan.k ?? ypCount ?? 0}
+                  onChange={(event) => updatePlan({ k: Math.max(0, Number(event.target.value) || 0) })}
+                  className="mt-1 w-20 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
+                  aria-label={`Expected young people for ${section.sname}`}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600">Permit holders</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={plan.p}
+                  onChange={(event) => updatePlan({ p: Math.max(0, Number(event.target.value) || 0) })}
+                  className="mt-1 w-20 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
+                  aria-label={`Permit holders needed for ${section.sname}`}
+                />
+              </div>
+            </div>
 
-          {activeSection && plans[activeSection.sid] && (() => {
-            const section = activeSection;
-            const plan = plans[section.sid];
-            const hasProgramme = plan.meetings && plan.meetings.length > 0;
-            const visibleMeetings = (plan.meetings ?? []).filter(
-              (meeting) => meeting.date >= range.start && meeting.date <= range.end,
-            );
-            return (
-              <section key={section.sid} className="rounded-lg border border-gray-200 p-4">
-                <h2 className="flex items-center gap-2">
-                  <span className={`px-2 py-0.5 rounded-full text-xs font-semibold ${sectionChipClass(section.sname)}`}>
-                    {section.sname}
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    {hasProgramme
-                      ? `${visibleMeetings.filter((m) => !plan.excluded[m.date]).length} water night${
-                        visibleMeetings.filter((m) => !plan.excluded[m.date]).length === 1 ? '' : 's'
-                      } selected of ${visibleMeetings.length} programme meetings`
-                      : 'No programme found — using a weekly slot'}
-                  </span>
-                </h2>
-                {hasProgramme && (
-                  <p className="mt-1 text-xs text-gray-400">
-                    Water nights are auto-picked from the meeting name; tick or untick any.
-                    Times aren&apos;t in the OSM programme, so the section time below is used.
-                  </p>
-                )}
-
-                <div className="mt-3 flex flex-wrap items-end gap-3">
-                  <div>
-                    <label className="block text-xs font-medium text-gray-600">Default activity</label>
-                    <select
-                      value={plan.act}
-                      onChange={(event) => updatePlan(section.sid, { act: event.target.value })}
-                      className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
-                    >
-                      {ACTIVITY_PRESETS.map((preset) => (
-                        <option key={preset} value={preset}>{preset}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-600">Start</label>
-                    <input
-                      type="time"
-                      value={plan.st}
-                      onChange={(event) => updatePlan(section.sid, { st: event.target.value })}
-                      className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-600">End</label>
-                    <input
-                      type="time"
-                      value={plan.en}
-                      onChange={(event) => updatePlan(section.sid, { en: event.target.value })}
-                      className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
-                    />
-                  </div>
-                  {!hasProgramme && (
-                    <div>
-                      <label className="block text-xs font-medium text-gray-600">Evening</label>
-                      <select
-                        value={plan.slotWeekday}
-                        onChange={(event) => updatePlan(section.sid, { slotWeekday: Number(event.target.value) })}
-                        className="mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
+            <div className="mt-3">
+              <label className="block text-xs font-medium text-gray-600">
+                Regular permit holders
+                <span className="ml-1 font-normal text-gray-400">
+                  (pre-filled as confirmed on every session; gaps = extras you still need)
+                </span>
+              </label>
+              {regularCandidates.length === 0 ? (
+                <p className="mt-1 text-xs text-gray-400 italic">
+                  No leaders found in both {section.sname} and the host section.
+                </p>
+              ) : (
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {regularCandidates.map((candidate) => {
+                    const on = (plan.regulars ?? []).includes(candidate.scoutid);
+                    return (
+                      <button
+                        key={candidate.scoutid}
+                        type="button"
+                        aria-pressed={on}
+                        onClick={() =>
+                          updatePlan({
+                            regulars: on
+                              ? (plan.regulars ?? []).filter((id) => id !== candidate.scoutid)
+                              : [...(plan.regulars ?? []), candidate.scoutid],
+                          })
+                        }
+                        className={`px-3 py-1 rounded-full text-xs font-medium border ${
+                          on
+                            ? 'bg-scout-blue border-scout-blue text-white'
+                            : 'bg-white border-gray-300 text-gray-700 hover:border-scout-blue'
+                        }`}
                       >
-                        {WEEKDAYS.map(([value, label]) => (
-                          <option key={value} value={value}>{label}</option>
+                        {on ? '✓ ' : ''}{candidate.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {hasProgramme && (
+              <ul className="mt-3 divide-y divide-gray-100">
+                {visibleMeetings.map((meeting) => {
+                  const included = !plan.excluded[meeting.date];
+                  const activity = plan.meetingActivity?.[meeting.date]
+                    ?? guessActivityFromTitle(meeting.title)
+                    ?? plan.act;
+                  const isCustomActivity = !ACTIVITY_PRESETS.includes(activity);
+                  return (
+                    <li key={meeting.date} className="flex items-center gap-3 py-2">
+                      <input
+                        type="checkbox"
+                        id={`meeting-${meeting.date}`}
+                        checked={included}
+                        onChange={(event) =>
+                          updatePlan({
+                            excluded: { ...plan.excluded, [meeting.date]: !event.target.checked },
+                          })
+                        }
+                        className="h-4 w-4 rounded border-gray-300 text-scout-blue focus:ring-scout-blue"
+                      />
+                      <label
+                        htmlFor={`meeting-${meeting.date}`}
+                        className="min-w-0 flex-1 text-sm text-gray-700"
+                      >
+                        <span className="flex items-baseline gap-2 whitespace-nowrap">
+                          <span className="font-medium">{format(parseISO(meeting.date), 'EEE d MMM')}</span>
+                          {meeting.startTime && (
+                            <span className="text-gray-500">
+                              {meeting.startTime}
+                              {meeting.endTime ? `–${meeting.endTime}` : ''}
+                            </span>
+                          )}
+                        </span>
+                        {meeting.title && (
+                          <span className="block text-xs text-gray-500 truncate">{meeting.title}</span>
+                        )}
+                      </label>
+                      <select
+                        value={activity}
+                        disabled={!included}
+                        onChange={(event) =>
+                          updatePlan({
+                            meetingActivity: { ...plan.meetingActivity, [meeting.date]: event.target.value },
+                          })
+                        }
+                        className="ml-auto w-36 rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-scout-blue focus:outline-none disabled:opacity-40"
+                        aria-label={`Activity for ${format(parseISO(meeting.date), 'd MMM')}`}
+                      >
+                        {isCustomActivity && <option value={activity}>{activity}</option>}
+                        {ACTIVITY_PRESETS.map((preset) => (
+                          <option key={preset} value={preset}>{preset}</option>
                         ))}
                       </select>
-                    </div>
-                  )}
-                  <div>
-                    <label className="block text-xs font-medium text-gray-600">Expected YP</label>
-                    <input
-                      type="number"
-                      min="0"
-                      value={plan.k ?? ypCounts[section.sid] ?? 0}
-                      onChange={(event) => updatePlan(section.sid, { k: Math.max(0, Number(event.target.value) || 0) })}
-                      className="mt-1 w-20 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
-                      aria-label={`Expected young people for ${section.sname}`}
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-600">Permit holders</label>
-                    <input
-                      type="number"
-                      min="0"
-                      value={plan.p}
-                      onChange={(event) => updatePlan(section.sid, { p: Math.max(0, Number(event.target.value) || 0) })}
-                      className="mt-1 w-20 rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-scout-blue focus:outline-none"
-                      aria-label={`Permit holders needed for ${section.sname}`}
-                    />
-                  </div>
-                </div>
-
-                <div className="mt-3">
-                  <label className="block text-xs font-medium text-gray-600">
-                    Regular permit holders
-                    <span className="ml-1 font-normal text-gray-400">
-                      (pre-filled as confirmed on every session; gaps = extras you still need)
-                    </span>
-                  </label>
-                  {(leaderCandidates[section.sid] ?? []).length === 0 ? (
-                    <p className="mt-1 text-xs text-gray-400 italic">
-                      No leaders found in both {section.sname} and the host section.
-                    </p>
-                  ) : (
-                    <div className="mt-1.5 flex flex-wrap gap-1.5">
-                      {(leaderCandidates[section.sid] ?? []).map((candidate) => {
-                        const on = (plan.regulars ?? []).includes(candidate.scoutid);
-                        return (
-                          <button
-                            key={candidate.scoutid}
-                            type="button"
-                            aria-pressed={on}
-                            onClick={() =>
-                              updatePlan(section.sid, {
-                                regulars: on
-                                  ? (plan.regulars ?? []).filter((id) => id !== candidate.scoutid)
-                                  : [...(plan.regulars ?? []), candidate.scoutid],
-                              })
-                            }
-                            className={`px-3 py-1 rounded-full text-xs font-medium border ${
-                              on
-                                ? 'bg-scout-blue border-scout-blue text-white'
-                                : 'bg-white border-gray-300 text-gray-700 hover:border-scout-blue'
-                            }`}
-                          >
-                            {on ? '✓ ' : ''}{candidate.name}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                {hasProgramme && (
-                  <ul className="mt-3 divide-y divide-gray-100">
-                    {visibleMeetings.map((meeting) => {
-                      const included = !plan.excluded[meeting.date];
-                      const activity = plan.meetingActivity?.[meeting.date]
-                        ?? guessActivityFromTitle(meeting.title)
-                        ?? plan.act;
-                      const isCustomActivity = !ACTIVITY_PRESETS.includes(activity);
-                      return (
-                        <li key={meeting.date} className="flex items-center gap-3 py-2">
-                          <input
-                            type="checkbox"
-                            id={`meeting-${section.sid}-${meeting.date}`}
-                            checked={included}
-                            onChange={(event) =>
-                              updatePlan(section.sid, {
-                                excluded: { ...plan.excluded, [meeting.date]: !event.target.checked },
-                              })
-                            }
-                            className="h-4 w-4 rounded border-gray-300 text-scout-blue focus:ring-scout-blue"
-                          />
-                          <label
-                            htmlFor={`meeting-${section.sid}-${meeting.date}`}
-                            className="min-w-0 flex-1 text-sm text-gray-700"
-                          >
-                            <span className="flex items-baseline gap-2 whitespace-nowrap">
-                              <span className="font-medium">{format(parseISO(meeting.date), 'EEE d MMM')}</span>
-                              {meeting.startTime && (
-                                <span className="text-gray-500">
-                                  {meeting.startTime}
-                                  {meeting.endTime ? `–${meeting.endTime}` : ''}
-                                </span>
-                              )}
-                            </span>
-                            {meeting.title && (
-                              <span className="block text-xs text-gray-500 truncate">{meeting.title}</span>
-                            )}
-                          </label>
-                          <select
-                            value={activity}
-                            disabled={!included}
-                            onChange={(event) =>
-                              updatePlan(section.sid, {
-                                meetingActivity: { ...plan.meetingActivity, [meeting.date]: event.target.value },
-                              })
-                            }
-                            className="ml-auto w-36 rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-scout-blue focus:outline-none disabled:opacity-40"
-                            aria-label={`Activity for ${format(parseISO(meeting.date), 'd MMM')}`}
-                          >
-                            {isCustomActivity && <option value={activity}>{activity}</option>}
-                            {ACTIVITY_PRESETS.map((preset) => (
-                              <option key={preset} value={preset}>{preset}</option>
-                            ))}
-                          </select>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </section>
-            );
-          })()}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
 
           <div className="flex gap-3">
             <button
@@ -783,13 +755,12 @@ function RotaSetupWizard() {
         </div>
       )}
 
-      {step === 3 && (
+      {step === 3 && section && (
         <div className="mt-5 space-y-5">
           <p className="text-sm text-gray-700">
             This creates <span className="font-semibold">{waterSessions.length} water session{waterSessions.length === 1 ? '' : 's'}</span> permit holders can sign up to, across{' '}
-            <span className="font-semibold">{bucketSessionsByWeek(waterSessions).length} weeks</span> in{' '}
-            <span className="font-semibold">{hostSection?.sectionname}</span>&apos;s{' '}
-            <span className="font-mono text-xs">Viking Water Rota {year}</span> record.
+            <span className="font-semibold">{bucketSessionsByWeek(waterSessions).length} weeks</span> for{' '}
+            <span className="font-semibold">{section.sname}</span>&apos;s <span className="font-semibold">{seasonBucket}</span> rota.
             {allSessions.length > waterSessions.length && (
               <> The other <span className="font-semibold">{allSessions.length - waterSessions.length}</span> programme
               weeks show as not-on-water. Sessions can be edited later, but signup columns can&apos;t be deleted.</>
@@ -801,7 +772,7 @@ function RotaSetupWizard() {
               <li key={weekStart} className="px-3 py-2">
                 <span className="font-medium text-gray-700">Week of {format(parseISO(weekStart), 'd MMM')}</span>
                 <span className="ml-2 text-gray-500">
-                  {weekSessions.map((session) => `${session.sectionName} ${format(parseISO(session.date), 'EEE')}`).join(' · ')}
+                  {weekSessions.map((s) => format(parseISO(s.date), 'EEE')).join(' · ')}
                 </span>
               </li>
             ))}

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -72,11 +72,13 @@ function sessionsForPlan(section, plan, range) {
 }
 
 /**
- * Sections that never plan their own rota: waiting lists (no programme) and
- * the Adults host itself (it only ever hosts other sections' records).
+ * Waiting-list sections never plan their own rota (no programme to build one
+ * from) — detected by name/type matching /waiting/i. The Adults host section
+ * is excluded separately by each call site (comparing against
+ * findHostSection's id), not by this check.
  *
  * @param {Object} section - Cached section
- * @returns {boolean} True when the section is a waiting list
+ * @returns {boolean} True when the section looks like a waiting list
  */
 function isWaitingList(section) {
   return /waiting/i.test(`${section.section ?? ''} ${section.sectiontype ?? ''} ${section.sectionname ?? ''}`);
@@ -107,47 +109,63 @@ function RotaSetupWizard() {
   const [sectionId, setSectionId] = useState(null);
   const [range, setRange] = useState({ start: '', end: '' });
   const [terms, setTerms] = useState(null);
+  const [termsError, setTermsError] = useState(null);
+  const [termsRetryCount, setTermsRetryCount] = useState(0);
   const [selectedTermId, setSelectedTermId] = useState('');
   const [plan, setPlan] = useState(defaultPlan());
   const [loadingProgramme, setLoadingProgramme] = useState(false);
   const [creating, setCreating] = useState(false);
   const [creationErrors, setCreationErrors] = useState([]);
+  const [initError, setInitError] = useState(null);
+  const [initAttempt, setInitAttempt] = useState(0);
+  const [seedError, setSeedError] = useState(null);
+  const [seedRetryCount, setSeedRetryCount] = useState(0);
   const seededKeyRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
     async function init() {
-      const cached = (await databaseService.getSections()) || [];
-      const discovered = await discoverRotaRecords(token).catch((error) => {
-        logger.warn('Setup: could not check for existing rota records', {
+      setInitError(null);
+      try {
+        const cached = (await databaseService.getSections()) || [];
+        const discovered = await discoverRotaRecords(token);
+        if (cancelled) {
+          return;
+        }
+        setSections(cached);
+        setDescriptors(discovered);
+        const host = findHostSection(cached);
+        // A hand-crafted ?section= naming the host (Adults) or a waiting-list
+        // section must not pre-select an invalid planning section — only a
+        // real youth section is eligible, same filter as the default below.
+        const requestedSectionId = searchParams.get('section');
+        const requested = requestedSectionId
+          && cached.find((section) =>
+            String(section.sectionid) === requestedSectionId
+            && (!host || section.sectionid !== host.sectionid)
+            && !isWaitingList(section));
+        if (requested) {
+          setSectionId(String(requested.sectionid));
+          return;
+        }
+        const firstYouth = cached.find(
+          (section) => (!host || section.sectionid !== host.sectionid) && !isWaitingList(section),
+        );
+        if (firstYouth) {
+          setSectionId(String(firstYouth.sectionid));
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        // Either read (sections or the existing-rota discovery) can fail —
+        // both leave the wizard unable to proceed safely: a swallowed
+        // discovery failure would read as "no existing rota" and a later
+        // save would overwrite the section's real config with defaults.
+        logger.error('Setup: failed to load sections or existing rota records', {
           error: error.message,
         }, LOG_CATEGORIES.APP);
-        return [];
-      });
-      if (cancelled) {
-        return;
-      }
-      setSections(cached);
-      setDescriptors(discovered);
-      const host = findHostSection(cached);
-      // A hand-crafted ?section= naming the host (Adults) or a waiting-list
-      // section must not pre-select an invalid planning section — only a
-      // real youth section is eligible, same filter as the default below.
-      const requestedSectionId = searchParams.get('section');
-      const requested = requestedSectionId
-        && cached.find((section) =>
-          String(section.sectionid) === requestedSectionId
-          && (!host || section.sectionid !== host.sectionid)
-          && !isWaitingList(section));
-      if (requested) {
-        setSectionId(String(requested.sectionid));
-        return;
-      }
-      const firstYouth = cached.find(
-        (section) => (!host || section.sectionid !== host.sectionid) && !isWaitingList(section),
-      );
-      if (firstYouth) {
-        setSectionId(String(firstYouth.sectionid));
+        setInitError(error.message || 'Something went wrong loading setup data');
       }
     }
     init();
@@ -155,7 +173,7 @@ function RotaSetupWizard() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initAttempt]);
 
   const hostSection = useMemo(() => findHostSection(sections ?? []), [sections]);
 
@@ -174,6 +192,9 @@ function RotaSetupWizard() {
 
   // Load the planning section's own terms, defaulting the selection + range
   // to its current active term. Switching sections re-picks from scratch.
+  // Terms are mandatory under the term model (a record's identity pins a
+  // term), so a fetch failure here must be visible and retryable rather than
+  // silently leaving "Next: review programme" disabled with no explanation.
   useEffect(() => {
     let cancelled = false;
     async function loadTermsForSection() {
@@ -182,6 +203,8 @@ function RotaSetupWizard() {
       }
       setSelectedTermId('');
       setRange({ start: '', end: '' });
+      setTerms(null);
+      setTermsError(null);
       seededKeyRef.current = null;
       let list = [];
       try {
@@ -189,8 +212,17 @@ function RotaSetupWizard() {
         list = (all?.[sectionId] ?? [])
           .filter((term) => term.startdate && term.enddate)
           .sort((a, b) => a.startdate.localeCompare(b.startdate));
-      } catch {
-        /* offline or fetch failed — the leader can still type dates below */
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        logger.error('Setup: failed to load terms for section', {
+          sectionId,
+          error: error.message,
+        }, LOG_CATEGORIES.APP);
+        setTerms([]);
+        setTermsError(error.message || 'Could not load terms');
+        return;
       }
       if (cancelled) {
         return;
@@ -217,20 +249,26 @@ function RotaSetupWizard() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sectionId]);
+  }, [sectionId, termsRetryCount]);
 
   // Re-edit: seed the wizard from the existing record's config when the
   // chosen (section, term) already has one, so prior choices aren't lost.
+  // This effect only ever runs when a record already exists, so any failure
+  // here is a real load failure, not "no existing rota" — proceeding to
+  // create() on defaultPlan() would write replace:true defaults over the
+  // section's real plan, so the create path stays blocked until it succeeds.
   useEffect(() => {
     let cancelled = false;
     async function seedFromExisting() {
       if (!existingDescriptor) {
+        setSeedError(null);
         return;
       }
       const seedKey = `${existingDescriptor.sectionId}.${existingDescriptor.termId}`;
       if (seededKeyRef.current === seedKey) {
         return;
       }
+      setSeedError(null);
       try {
         const existing = await loadRota(existingDescriptor, token);
         const cfg = existing?.config?.cfg;
@@ -266,16 +304,23 @@ function RotaSetupWizard() {
           excluded,
         }));
       } catch (error) {
-        logger.warn('Setup: no existing rota to seed from', {
+        if (cancelled) {
+          return;
+        }
+        logger.error('Setup: failed to load existing rota to seed the wizard', {
+          sectionId: existingDescriptor.sectionId,
+          termId: existingDescriptor.termId,
           error: error.message,
         }, LOG_CATEGORIES.APP);
+        notifyError('Couldn\'t load this section\'s existing plan — retry before editing');
+        setSeedError(error.message || 'Could not load the existing plan');
       }
     }
     seedFromExisting();
     return () => {
       cancelled = true;
     };
-  }, [existingDescriptor, token]);
+  }, [existingDescriptor, token, seedRetryCount]);
 
   const { counts: ypCounts } = useSectionYPCounts(sectionId ? [sectionId] : []);
   const { candidates: leaderCandidates } = useSectionLeaders(
@@ -324,15 +369,20 @@ function RotaSetupWizard() {
         ? { ...heuristicExcluded, ...(plan.excluded ?? {}) }
         : heuristicExcluded;
       setPlan((previous) => ({ ...previous, k: previous.k ?? ypCount ?? null, meetings, excluded }));
+      setStep(2);
     } catch (error) {
-      logger.warn('Programme fetch failed during setup', {
+      // A fetch failure is not the same as a genuinely-empty programme: it
+      // must not fall through to the "no programme — using a weekly slot"
+      // fallback, since that shapes an immutable record (OSM has no column
+      // delete) from data that was never actually read.
+      logger.error('Programme fetch failed during setup', {
         sectionId,
         error: error.message,
       }, LOG_CATEGORIES.API);
-      setPlan((previous) => ({ ...previous, k: previous.k ?? ypCount ?? null, meetings: [] }));
+      notifyError('Couldn\'t read the programme — try again');
+    } finally {
+      setLoadingProgramme(false);
     }
-    setLoadingProgramme(false);
-    setStep(2);
   };
 
   const updatePlan = (patch) => {
@@ -354,6 +404,13 @@ function RotaSetupWizard() {
   };
 
   const handleCreate = async () => {
+    if (seedError) {
+      // Defense in depth alongside the disabled Create button below: the
+      // existing plan failed to load, so defaultPlan() is not the section's
+      // real config and must never be written with replace:true.
+      setCreationErrors([{ field: '_meta', error: 'Couldn\'t load this section\'s existing plan — retry before creating' }]);
+      return;
+    }
     setCreating(true);
     setCreationErrors([]);
     try {
@@ -364,7 +421,20 @@ function RotaSetupWizard() {
         return;
       }
 
-      const record = { sectionId: section.sid, sectionName: section.sname, termId: selectedTermId, seasonBucket };
+      // On re-edit, the record's identity must match the ORIGINAL record's
+      // name (sectionName/seasonBucket parsed from it by the descriptor) —
+      // sourcing them from the live section/range instead would build a
+      // different name if the section was renamed in OSM or the date range
+      // was nudged across a season boundary, missing createOrCompleteRota's
+      // exact-name match and creating a duplicate orphan record.
+      const record = existingDescriptor
+        ? {
+          sectionId: section.sid,
+          sectionName: existingDescriptor.sectionName,
+          termId: selectedTermId,
+          seasonBucket: existingDescriptor.seasonBucket,
+        }
+        : { sectionId: section.sid, sectionName: section.sname, termId: selectedTermId, seasonBucket };
       const result = await createOrCompleteRota({
         hostSection,
         hostTermId,
@@ -454,6 +524,24 @@ function RotaSetupWizard() {
     }
   };
 
+  if (initError) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-5">
+        <h1 className="text-lg font-semibold text-gray-900">Set up the water rota</h1>
+        <p className="mt-3 rounded-lg border border-scout-red bg-scout-red/5 p-3 text-sm text-scout-red">
+          Couldn&apos;t load setup data — {initError}
+        </p>
+        <button
+          type="button"
+          onClick={() => setInitAttempt((n) => n + 1)}
+          className="mt-3 px-4 py-2 rounded-md bg-scout-blue text-white text-sm font-medium hover:bg-scout-blue-dark"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
   if (!sections) {
     return <LoadingScreen message="Loading sections..." />;
   }
@@ -514,36 +602,67 @@ function RotaSetupWizard() {
                 </option>
               ))}
             </select>
-            {existingDescriptor && (
+            {existingDescriptor && !seedError && (
               <p className="mt-1.5 text-xs text-scout-blue">
                 This section already has a rota for this term — continuing will edit it.
               </p>
             )}
+            {seedError && (
+              <div className="mt-1.5 rounded-md border border-scout-red bg-scout-red/5 p-2 text-xs text-scout-red">
+                <p>Couldn&apos;t load this section&apos;s existing plan — retry before editing.</p>
+                <button
+                  type="button"
+                  onClick={() => setSeedRetryCount((n) => n + 1)}
+                  className="mt-1 font-medium underline"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
           </div>
 
-          {terms && terms.length > 0 && (
+          {sectionId && terms !== null && (
             <div>
               <label className="block text-sm font-medium text-gray-700" htmlFor="rota-term">Term</label>
-              <select
-                id="rota-term"
-                value={selectedTermId}
-                onChange={(event) => {
-                  const id = event.target.value;
-                  setSelectedTermId(id);
-                  const term = terms.find((entry) => String(entry.termid) === id);
-                  if (term) {
-                    setRange({ start: term.startdate.slice(0, 10), end: term.enddate.slice(0, 10) });
-                  }
-                }}
-                className="mt-1.5 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-scout-blue focus:outline-none"
-              >
-                {terms.map((term) => (
-                  <option key={term.termid} value={term.termid}>
-                    {term.name}
-                  </option>
-                ))}
-              </select>
-              <p className="mt-1 text-xs text-gray-500">Picks the weeks below — fine-tune them if the rota runs a shorter span.</p>
+              {termsError ? (
+                <div className="mt-1.5 rounded-md border border-scout-red bg-scout-red/5 p-2 text-xs text-scout-red">
+                  <p>Couldn&apos;t load terms for this section — {termsError}</p>
+                  <button
+                    type="button"
+                    onClick={() => setTermsRetryCount((n) => n + 1)}
+                    className="mt-1 font-medium underline"
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : terms.length === 0 ? (
+                <p className="mt-1.5 text-xs text-gray-500">
+                  This section has no terms set up in OSM yet — add one there before setting up its rota.
+                </p>
+              ) : (
+                <>
+                  <select
+                    id="rota-term"
+                    value={selectedTermId}
+                    onChange={(event) => {
+                      const id = event.target.value;
+                      setSelectedTermId(id);
+                      const term = terms.find((entry) => String(entry.termid) === id);
+                      if (term) {
+                        setRange({ start: term.startdate.slice(0, 10), end: term.enddate.slice(0, 10) });
+                      }
+                    }}
+                    className="mt-1.5 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-scout-blue focus:outline-none"
+                  >
+                    {terms.map((term) => (
+                      <option key={term.termid} value={term.termid}>
+                        {term.name}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-xs text-gray-500">Picks the weeks below — fine-tune them if the rota runs a shorter span.</p>
+                </>
+              )}
             </div>
           )}
 
@@ -830,6 +949,21 @@ function RotaSetupWizard() {
             </div>
           )}
 
+          {seedError && (
+            <div className="rounded-lg border border-scout-red bg-scout-red/5 p-3 text-sm">
+              <p className="font-medium text-scout-red">
+                Couldn&apos;t load this section&apos;s existing plan — creating is blocked until that succeeds.
+              </p>
+              <button
+                type="button"
+                onClick={() => setSeedRetryCount((n) => n + 1)}
+                className="mt-1 text-xs font-medium text-scout-red underline"
+              >
+                Retry loading the existing plan
+              </button>
+            </div>
+          )}
+
           <div className="flex gap-3">
             <button
               type="button"
@@ -841,7 +975,7 @@ function RotaSetupWizard() {
             </button>
             <button
               type="button"
-              disabled={creating}
+              disabled={creating || Boolean(seedError)}
               onClick={handleCreate}
               className="flex-1 py-2.5 rounded-md bg-scout-blue text-white text-sm font-semibold hover:bg-scout-blue-dark disabled:opacity-50"
             >

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -129,14 +129,20 @@ function RotaSetupWizard() {
       }
       setSections(cached);
       setDescriptors(discovered);
+      const host = findHostSection(cached);
+      // A hand-crafted ?section= naming the host (Adults) or a waiting-list
+      // section must not pre-select an invalid planning section — only a
+      // real youth section is eligible, same filter as the default below.
       const requestedSectionId = searchParams.get('section');
       const requested = requestedSectionId
-        && cached.find((section) => String(section.sectionid) === requestedSectionId);
+        && cached.find((section) =>
+          String(section.sectionid) === requestedSectionId
+          && (!host || section.sectionid !== host.sectionid)
+          && !isWaitingList(section));
       if (requested) {
         setSectionId(String(requested.sectionid));
         return;
       }
-      const host = findHostSection(cached);
       const firstYouth = cached.find(
         (section) => (!host || section.sectionid !== host.sectionid) && !isWaitingList(section),
       );
@@ -398,6 +404,10 @@ function RotaSetupWizard() {
           end: range.end,
           sessions: buildSessionOverrides(allSessions, [sectionDefault]),
         },
+        // Re-running setup is an intentional full-plan replace — a patch
+        // merge would leave stale session overrides (e.g. a week no longer
+        // excluded) behind in the live sessions map.
+        replace: true,
         token,
       });
 

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -339,6 +339,20 @@ function RotaSetupWizard() {
     setPlan((previous) => ({ ...previous, ...patch }));
   };
 
+  /**
+   * Switch the planning section, discarding the previous section's plan
+   * (regulars, activity, times, expected YP, programme picks) so nothing
+   * leaks between per-section setup runs, and re-allowing the seed-from-
+   * existing-config pass for the newly chosen section.
+   *
+   * @param {string} nextSectionId - The newly selected planning section id
+   */
+  const handleSectionChange = (nextSectionId) => {
+    setSectionId(nextSectionId);
+    setPlan(defaultPlan());
+    seededKeyRef.current = null;
+  };
+
   const handleCreate = async () => {
     setCreating(true);
     setCreationErrors([]);
@@ -490,7 +504,7 @@ function RotaSetupWizard() {
             <select
               id="rota-section"
               value={sectionId ?? ''}
-              onChange={(event) => setSectionId(event.target.value)}
+              onChange={(event) => handleSectionChange(event.target.value)}
               className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-scout-blue focus:outline-none"
             >
               <option value="" disabled>Choose a section…</option>

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { format, parseISO } from 'date-fns';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import databaseService from '../../../../shared/services/storage/database.js';
 import { CurrentActiveTermsService } from '../../../../shared/services/storage/currentActiveTermsService.js';
 import { getToken } from '../../../../shared/services/auth/tokenService.js';
@@ -89,12 +89,16 @@ function isWaitingList(section) {
  * checkboxes per meeting (weekly-slot fallback for an empty programme); (3)
  * preview and resumable creation, followed by the plan-config write and
  * regular pre-fill. Re-running against a section/term that already has a
- * record seeds the wizard from its existing config.
+ * record seeds the wizard from its existing config. A `?section=<sectionid>`
+ * query param (as set by the board's "Edit plan" link) pre-selects that
+ * section on load when it's one of the leader's cached sections; otherwise
+ * the usual first-youth-section default applies.
  *
  * @returns {JSX.Element} Setup wizard page
  */
 function RotaSetupWizard() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const token = getToken();
 
   const [step, setStep] = useState(1);
@@ -125,6 +129,13 @@ function RotaSetupWizard() {
       }
       setSections(cached);
       setDescriptors(discovered);
+      const requestedSectionId = searchParams.get('section');
+      const requested = requestedSectionId
+        && cached.find((section) => String(section.sectionid) === requestedSectionId);
+      if (requested) {
+        setSectionId(String(requested.sectionid));
+        return;
+      }
       const host = findHostSection(cached);
       const firstYouth = cached.find(
         (section) => (!host || section.sectionid !== host.sectionid) && !isWaitingList(section),

--- a/src/features/water-rota/components/setup/RotaSetupWizard.jsx
+++ b/src/features/water-rota/components/setup/RotaSetupWizard.jsx
@@ -269,7 +269,11 @@ function RotaSetupWizard() {
   const regularCandidates = sectionId ? leaderCandidates[sectionId] ?? [] : [];
 
   const allSessions = useMemo(
-    () => (section ? sessionsForPlan(section, plan, range) : []),
+    // section can resolve a render before the term-loading effect populates
+    // range (both setSectionId and the term fetch fire off the same init
+    // effect), so guard against computing sessions off an empty date range —
+    // expandWeeklySlot/generateSessionsFromProgramme throw on invalid dates.
+    () => (section && range.start && range.end ? sessionsForPlan(section, plan, range) : []),
     [section, plan, range],
   );
   // Only water sessions get signup columns; not-on-water weeks live in config.

--- a/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
+++ b/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
@@ -178,6 +178,8 @@ describe('RotaSetupWizard — single-section create', () => {
         scoutid: '100',
         by: 'Test Leader',
         cfg: expect.objectContaining({ sid: String(YOUTH_SECTION.sectionid), sname: 'Scouts', start: '2026-04-01', end: '2026-08-31' }),
+        // Re-running setup is an intentional full-plan replace, not a patch.
+        replace: true,
       }),
     );
 
@@ -217,6 +219,23 @@ describe('RotaSetupWizard — single-section create', () => {
 
   it('falls back to the default section when ?section= names a section the leader can\'t see', async () => {
     renderWizard(['/water-rota/setup?section=999999']);
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+  });
+
+  it('falls back to the default section when ?section= names the Adults host section', async () => {
+    renderWizard([`/water-rota/setup?section=${HOST_SECTION.sectionid}`]);
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+  });
+
+  it('falls back to the default section when ?section= names a waiting-list section', async () => {
+    const waitingList = { sectionid: 55555, sectionname: 'Scouts Waiting List', section: 'scouts' };
+    databaseService.getSections.mockResolvedValue([HOST_SECTION, waitingList, YOUTH_SECTION]);
+
+    renderWizard([`/water-rota/setup?section=${waitingList.sectionid}`]);
 
     await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
     await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));

--- a/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
+++ b/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
@@ -68,10 +68,11 @@ import RotaSetupWizard from '../RotaSetupWizard.jsx';
 
 const HOST_SECTION = { sectionid: 11107, sectionname: 'Adults', section: 'adults' };
 const YOUTH_SECTION = { sectionid: 49097, sectionname: 'Scouts', section: 'scouts' };
+const OTHER_YOUTH_SECTION = { sectionid: 23456, sectionname: 'Cubs', section: 'cubs' };
 
-function renderWizard() {
+function renderWizard(initialEntries = ['/water-rota/setup']) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <RotaSetupWizard />
     </MemoryRouter>,
   );
@@ -181,5 +182,43 @@ describe('RotaSetupWizard — single-section create', () => {
     );
 
     await waitFor(() => expect(notifySuccess).toHaveBeenCalledWith('Water rota saved'));
+  });
+
+  it('pre-selects the section named in ?section= (as set by the board\'s "Edit plan" link)', async () => {
+    databaseService.getSections.mockResolvedValue([HOST_SECTION, YOUTH_SECTION, OTHER_YOUTH_SECTION]);
+    getTerms.mockResolvedValue({
+      [String(YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-49097', name: 'Summer 2026', startdate: '2026-04-01', enddate: '2026-08-31' },
+      ],
+      [String(OTHER_YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-23456', name: 'Summer 2026', startdate: '2026-04-06', enddate: '2026-08-24' },
+      ],
+    });
+    CurrentActiveTermsService.getCurrentActiveTerm.mockImplementation(async (sectionId) => {
+      if (String(sectionId) === String(YOUTH_SECTION.sectionid)) {
+        return { currentTermId: 'T-49097' };
+      }
+      if (String(sectionId) === String(OTHER_YOUTH_SECTION.sectionid)) {
+        return { currentTermId: 'T-23456' };
+      }
+      if (String(sectionId) === String(HOST_SECTION.sectionid)) {
+        return { currentTermId: 'HOST-T1' };
+      }
+      return null;
+    });
+
+    renderWizard([`/water-rota/setup?section=${OTHER_YOUTH_SECTION.sectionid}`]);
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(OTHER_YOUTH_SECTION.sectionid)));
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-23456'));
+    expect(screen.getByLabelText('First week').value).toBe('2026-04-06');
+    expect(screen.getByLabelText('Last week').value).toBe('2026-08-24');
+  });
+
+  it('falls back to the default section when ?section= names a section the leader can\'t see', async () => {
+    renderWizard(['/water-rota/setup?section=999999']);
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
   });
 });

--- a/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
+++ b/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
@@ -64,8 +64,9 @@ import { CurrentActiveTermsService } from '../../../../../shared/services/storag
 import { getTerms } from '../../../../../shared/services/api/api/index.js';
 import { fetchProgrammeMeetings } from '../../../services/programmeService.js';
 import { createOrCompleteRota, writeRotaConfig } from '../../../services/rotaSetupService.js';
-import { discoverRotaRecords, findHostSection, loadRota } from '../../../services/rotaService.js';
-import { notifySuccess } from '../../../../../shared/utils/notifications.js';
+import { discoverRotaRecords, findHostSection, loadRota, prefillRegulars } from '../../../services/rotaService.js';
+import { notifyError, notifySuccess } from '../../../../../shared/utils/notifications.js';
+import { buildSessionColumnName } from '../../../services/rotaEncoding.js';
 import RotaSetupWizard from '../RotaSetupWizard.jsx';
 
 const HOST_SECTION = { sectionid: 11107, sectionname: 'Adults', section: 'adults' };
@@ -123,6 +124,7 @@ beforeEach(() => {
     ],
   });
   writeRotaConfig.mockResolvedValue(undefined);
+  prefillRegulars.mockResolvedValue({ errors: [] });
 });
 
 describe('RotaSetupWizard — single-section create', () => {
@@ -187,6 +189,41 @@ describe('RotaSetupWizard — single-section create', () => {
     );
 
     await waitFor(() => expect(notifySuccess).toHaveBeenCalledWith('Water rota saved'));
+  });
+
+  it('picks the anchor row by lexicographic (not numeric) scoutid order — mixed-width ids', async () => {
+    // '99' sorts AFTER '100' lexicographically ('1' < '9'), the opposite of
+    // numeric order — this pins that the deterministic anchor-row choice is
+    // a string sort (String.prototype.localeCompare), not a numeric one.
+    loadRota.mockResolvedValue({
+      recordId: 'REC1',
+      hostSection: HOST_SECTION,
+      termId: 'HOST-T1',
+      sectionId: String(YOUTH_SECTION.sectionid),
+      planningTermId: 'T-49097',
+      seasonBucket: 'Summer 2026',
+      configFieldId: 'f_1',
+      config: null,
+      sessions: [],
+      members: [
+        { scoutid: '99', name: 'Numerically First' },
+        { scoutid: '100', name: 'Lexicographically First' },
+      ],
+    });
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+    await screen.findByText('No programme found — using a weekly slot');
+    fireEvent.click(screen.getByRole('button', { name: 'Next: preview' }));
+    await screen.findByRole('button', { name: 'Create rota' });
+    fireEvent.click(screen.getByRole('button', { name: 'Create rota' }));
+
+    await waitFor(() => expect(writeRotaConfig).toHaveBeenCalledTimes(1));
+    expect(writeRotaConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ scoutid: '100' }),
+    );
   });
 
   it('drops the previous section\'s regulars and plan when the planning section changes', async () => {
@@ -286,5 +323,336 @@ describe('RotaSetupWizard — single-section create', () => {
 
     await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
     await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+  });
+});
+
+describe('RotaSetupWizard — re-edit record identity (B1)', () => {
+  it('sources sectionName and seasonBucket from the existing descriptor, not the live section name/range, on re-edit', async () => {
+    // The section was renamed in OSM since the record was created, and the
+    // live date range recomputes to a different season bucket than the one
+    // baked into the original record's name.
+    const renamedSection = { sectionid: YOUTH_SECTION.sectionid, sectionname: 'Scouts Renamed', section: 'scouts' };
+    databaseService.getSections.mockResolvedValue([HOST_SECTION, renamedSection]);
+    const existingDescriptor = {
+      sectionId: String(renamedSection.sectionid),
+      termId: 'T-49097',
+      sectionName: 'Scouts',
+      seasonBucket: 'Spring 2026',
+      recordId: 'REC-EXIST',
+      hostSection: HOST_SECTION,
+    };
+    discoverRotaRecords.mockResolvedValue([existingDescriptor]);
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+    await screen.findByText('No programme found — using a weekly slot');
+    fireEvent.click(screen.getByRole('button', { name: 'Next: preview' }));
+    await screen.findByRole('button', { name: 'Create rota' });
+    fireEvent.click(screen.getByRole('button', { name: 'Create rota' }));
+
+    await waitFor(() => expect(createOrCompleteRota).toHaveBeenCalledTimes(1));
+    expect(createOrCompleteRota).toHaveBeenCalledWith(
+      expect.objectContaining({
+        record: {
+          sectionId: String(renamedSection.sectionid),
+          sectionName: 'Scouts',
+          termId: 'T-49097',
+          seasonBucket: 'Spring 2026',
+        },
+      }),
+    );
+  });
+});
+
+describe('RotaSetupWizard — init failure recovery (B2/B6)', () => {
+  it('shows a retryable error (not "no existing rota") when discovery fails, and retry recovers', async () => {
+    discoverRotaRecords.mockRejectedValueOnce(new Error('network down'));
+
+    renderWizard();
+
+    await screen.findByText(/Couldn.t load setup data/);
+    expect(screen.getByText(/network down/)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Section')).not.toBeInTheDocument();
+
+    discoverRotaRecords.mockResolvedValueOnce([]);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+  });
+
+  it('shows the same retryable error state when getSections() fails (init has no unhandled path)', async () => {
+    databaseService.getSections.mockRejectedValueOnce(new Error('db closed'));
+
+    renderWizard();
+
+    await screen.findByText(/Couldn.t load setup data/);
+    expect(screen.getByText(/db closed/)).toBeInTheDocument();
+  });
+});
+
+describe('RotaSetupWizard — seed-from-existing failure blocks create (B3)', () => {
+  it('disables Create when the existing plan fails to load, and a successful retry unblocks it', async () => {
+    const existingDescriptor = {
+      sectionId: String(YOUTH_SECTION.sectionid),
+      termId: 'T-49097',
+      sectionName: 'Scouts',
+      seasonBucket: 'Summer 2026',
+      recordId: 'REC-EXIST',
+      hostSection: HOST_SECTION,
+    };
+    discoverRotaRecords.mockResolvedValue([existingDescriptor]);
+    loadRota.mockRejectedValueOnce(new Error('read failed'));
+
+    renderWizard();
+
+    await screen.findByText(/Couldn.t load this section.s existing plan/);
+    expect(notifyError).toHaveBeenCalledWith('Couldn\'t load this section\'s existing plan — retry before editing');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+    await screen.findByText('No programme found — using a weekly slot');
+    fireEvent.click(screen.getByRole('button', { name: 'Next: preview' }));
+    await screen.findByRole('button', { name: 'Create rota' });
+    expect(screen.getByRole('button', { name: 'Create rota' })).toBeDisabled();
+    expect(createOrCompleteRota).not.toHaveBeenCalled();
+
+    loadRota.mockResolvedValue({
+      recordId: 'REC-EXIST',
+      hostSection: HOST_SECTION,
+      termId: 'HOST-T1',
+      sectionId: String(YOUTH_SECTION.sectionid),
+      planningTermId: 'T-49097',
+      seasonBucket: 'Summer 2026',
+      config: null,
+      sessions: [],
+      members: [
+        { scoutid: '200', name: 'Later Member' },
+        { scoutid: '100', name: 'Anchor Member' },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading the existing plan' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create rota' })).not.toBeDisabled());
+  });
+});
+
+describe('RotaSetupWizard — term loading (B4)', () => {
+  it('shows a retryable error when the term fetch fails, distinct from "this section has no terms"', async () => {
+    getTerms.mockRejectedValueOnce(new Error('OSM down'));
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+    await screen.findByText(/Couldn.t load terms for this section/);
+    expect(screen.getByText(/OSM down/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next: review programme' })).toBeDisabled();
+
+    getTerms.mockResolvedValueOnce({
+      [String(YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-49097', name: 'Summer 2026', startdate: '2026-04-01', enddate: '2026-08-31' },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+  });
+
+  it('shows an explanatory "no terms" message (not a silently-disabled button) when the section genuinely has none', async () => {
+    getTerms.mockResolvedValue({ [String(YOUTH_SECTION.sectionid)]: [] });
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+    await screen.findByText(/This section has no terms set up in OSM/);
+    expect(screen.getByRole('button', { name: 'Next: review programme' })).toBeDisabled();
+  });
+});
+
+describe('RotaSetupWizard — programme fetch failure stays on step 1 (B5)', () => {
+  it('does not advance to step 2 on a programme fetch failure, and never claims "no programme found"', async () => {
+    fetchProgrammeMeetings.mockRejectedValueOnce(new Error('rate limited'));
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledWith('Couldn\'t read the programme — try again'));
+    expect(screen.queryByText('No programme found — using a weekly slot')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next: review programme' })).toBeInTheDocument();
+  });
+});
+
+describe('RotaSetupWizard — re-edit seeding (T1)', () => {
+  it('seeds range/act/st/en/k/p/regulars and reconstructs excluded overrides from {c:1}; saved excluded wins over the heuristic; switching section away and back re-seeds', async () => {
+    databaseService.getSections.mockResolvedValue([HOST_SECTION, YOUTH_SECTION, OTHER_YOUTH_SECTION]);
+    getTerms.mockResolvedValue({
+      [String(YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-49097', name: 'Summer 2026', startdate: '2026-04-01', enddate: '2026-08-31' },
+      ],
+      [String(OTHER_YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-23456', name: 'Summer 2026', startdate: '2026-04-06', enddate: '2026-08-24' },
+      ],
+    });
+    CurrentActiveTermsService.getCurrentActiveTerm.mockImplementation(async (sectionId) => {
+      if (String(sectionId) === String(YOUTH_SECTION.sectionid)) {
+        return { currentTermId: 'T-49097' };
+      }
+      if (String(sectionId) === String(OTHER_YOUTH_SECTION.sectionid)) {
+        return { currentTermId: 'T-23456' };
+      }
+      if (String(sectionId) === String(HOST_SECTION.sectionid)) {
+        return { currentTermId: 'HOST-T1' };
+      }
+      return null;
+    });
+
+    const existingDescriptor = {
+      sectionId: String(YOUTH_SECTION.sectionid),
+      termId: 'T-49097',
+      sectionName: 'Scouts',
+      seasonBucket: 'Summer 2026',
+      recordId: 'REC-EXIST',
+      hostSection: HOST_SECTION,
+    };
+    discoverRotaRecords.mockResolvedValue([existingDescriptor]);
+    leaderState.candidates = {
+      [String(YOUTH_SECTION.sectionid)]: [{ scoutid: '300', name: 'Reg Leader' }],
+      [String(OTHER_YOUTH_SECTION.sectionid)]: [{ scoutid: '300', name: 'Reg Leader' }],
+    };
+    const excludedColumn = buildSessionColumnName('2026-04-16', String(YOUTH_SECTION.sectionid));
+    loadRota.mockImplementation(async (descriptor) => {
+      if (String(descriptor.sectionId) === String(YOUTH_SECTION.sectionid) && descriptor.termId === 'T-49097') {
+        return {
+          recordId: 'REC-EXIST',
+          hostSection: HOST_SECTION,
+          termId: 'HOST-T1',
+          sectionId: String(YOUTH_SECTION.sectionid),
+          planningTermId: 'T-49097',
+          seasonBucket: 'Summer 2026',
+          config: {
+            cfg: {
+              start: '2026-04-08',
+              end: '2026-08-20',
+              act: 'Canoeing',
+              st: '17:45',
+              en: '19:15',
+              k: 18,
+              p: 4,
+              regulars: ['300'],
+              sessions: { [excludedColumn]: { c: 1 } },
+            },
+          },
+          sessions: [],
+          members: [
+            { scoutid: '200', name: 'Later Member' },
+            { scoutid: '100', name: 'Anchor Member' },
+          ],
+        };
+      }
+      return { config: null, sessions: [], members: [] };
+    });
+    fetchProgrammeMeetings.mockImplementation(async (sectionId) => {
+      if (String(sectionId) === String(YOUTH_SECTION.sectionid)) {
+        // Looks like a water session by title, so the heuristic alone would
+        // include it — the seeded config's {c:1} override must still win.
+        return [{ date: '2026-04-16', title: 'Kayaking practice', startTime: '18:00', endTime: '19:30' }];
+      }
+      return [];
+    });
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('First week').value).toBe('2026-04-08'));
+    expect(screen.getByLabelText('Last week').value).toBe('2026-08-20');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+
+    const toggle = await screen.findByRole('button', { name: /Reg Leader/ });
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByDisplayValue('Canoeing')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('17:45')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('19:15')).toBeInTheDocument();
+    expect(screen.getByLabelText(`Expected young people for ${YOUTH_SECTION.sectionname}`).value).toBe('18');
+    expect(screen.getByLabelText(`Permit holders needed for ${YOUTH_SECTION.sectionname}`).value).toBe('4');
+    expect(screen.getByLabelText(/Kayaking practice/)).not.toBeChecked();
+
+    // Switch away — plan resets to defaults for the newly chosen section.
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    fireEvent.change(screen.getByLabelText('Section'), { target: { value: String(OTHER_YOUTH_SECTION.sectionid) } });
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-23456'));
+    expect(screen.getByLabelText('First week').value).toBe('2026-04-06');
+
+    // Switch back — seededKeyRef was cleared by handleSectionChange, so the
+    // seed pass re-runs instead of leaving the section's plan at defaults.
+    fireEvent.change(screen.getByLabelText('Section'), { target: { value: String(YOUTH_SECTION.sectionid) } });
+    await waitFor(() => expect(screen.getByLabelText('First week').value).toBe('2026-04-08'));
+    expect(screen.getByLabelText('Last week').value).toBe('2026-08-20');
+  });
+});
+
+describe('RotaSetupWizard — prefill routing (T2)', () => {
+  it('prefills regulars on exactly the newly-added subset of sessions, and surfaces a partial pre-fill failure', async () => {
+    const YOUTH_SID = String(YOUTH_SECTION.sectionid);
+    const dateA = '2026-04-07';
+    const dateB = '2026-04-14';
+    const colA = buildSessionColumnName(dateA, YOUTH_SID);
+
+    fetchProgrammeMeetings.mockResolvedValue([
+      { date: dateA, title: 'Kayaking Night' },
+      { date: dateB, title: 'Canoe Night' },
+    ]);
+    leaderState.candidates = { [YOUTH_SID]: [{ scoutid: '300', name: 'Reg Leader' }] };
+    createOrCompleteRota.mockResolvedValue({
+      success: true,
+      flexirecordid: 'REC1',
+      errors: [],
+      // Only dateA's column was newly created this run (dateB pre-existed).
+      addedFields: [colA],
+    });
+    const reloadedSessions = [
+      { fieldId: 'f_10', date: dateA, sectionId: YOUTH_SID },
+      { fieldId: 'f_11', date: dateB, sectionId: YOUTH_SID },
+    ];
+    loadRota.mockResolvedValue({
+      recordId: 'REC1',
+      hostSection: HOST_SECTION,
+      termId: 'HOST-T1',
+      sectionId: YOUTH_SID,
+      planningTermId: 'T-49097',
+      seasonBucket: 'Summer 2026',
+      config: null,
+      sessions: reloadedSessions,
+      members: [
+        { scoutid: '200', name: 'Later Member' },
+        { scoutid: '100', name: 'Anchor Member' },
+      ],
+    });
+    prefillRegulars.mockResolvedValue({ errors: [{ fieldId: 'f_10', error: 'write failed' }] });
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+    const toggle = await screen.findByRole('button', { name: /Reg Leader/ });
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: 'Next: preview' }));
+    await screen.findByRole('button', { name: 'Create rota' });
+    fireEvent.click(screen.getByRole('button', { name: 'Create rota' }));
+
+    await waitFor(() => expect(prefillRegulars).toHaveBeenCalledTimes(1));
+    expect(prefillRegulars).toHaveBeenCalledWith({
+      rota: expect.objectContaining({ recordId: 'REC1' }),
+      regularsBySection: { [YOUTH_SID]: ['300'] },
+      token: 'test-token',
+      // Exactly the strict subset named in addedFields — dateB's existing
+      // session must not be re-touched (would clobber withdrawals).
+      sessions: [reloadedSessions[0]],
+    });
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledWith(
+      'Rota saved, but 1 session couldn\'t be pre-filled with regulars — open them to add manually.',
+    ));
   });
 });

--- a/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
+++ b/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../../../shared/services/storage/database.js', () => ({
+  default: { getSections: vi.fn() },
+}));
+
+vi.mock('../../../../../shared/services/storage/currentActiveTermsService.js', () => ({
+  CurrentActiveTermsService: { getCurrentActiveTerm: vi.fn() },
+}));
+
+vi.mock('../../../../../shared/services/auth/tokenService.js', () => ({
+  getToken: vi.fn(() => 'test-token'),
+}));
+
+vi.mock('../../../../../shared/utils/notifications.js', () => ({
+  notifyError: vi.fn(),
+  notifySuccess: vi.fn(),
+}));
+
+vi.mock('../../../../../shared/services/utils/logger.js', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  LOG_CATEGORIES: { APP: 'APP', API: 'API' },
+}));
+
+vi.mock('../../../../../shared/services/api/api/index.js', () => ({
+  getTerms: vi.fn(),
+}));
+
+vi.mock('../../../services/programmeService.js', () => ({
+  fetchProgrammeMeetings: vi.fn(),
+}));
+
+vi.mock('../../../services/rotaSetupService.js', () => ({
+  createOrCompleteRota: vi.fn(),
+  writeRotaConfig: vi.fn(),
+}));
+
+vi.mock('../../../services/rotaService.js', () => ({
+  discoverRotaRecords: vi.fn(),
+  findHostSection: vi.fn(),
+  loadRota: vi.fn(),
+  prefillRegulars: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useRotaIdentity.js', () => ({
+  getCurrentUserName: vi.fn(async () => 'Test Leader'),
+}));
+
+vi.mock('../../../hooks/useSectionYPCounts.js', () => ({
+  useSectionYPCounts: () => ({ counts: {}, loading: false }),
+}));
+
+vi.mock('../../../hooks/useSectionLeaders.js', () => ({
+  useSectionLeaders: () => ({ candidates: {}, loading: false }),
+}));
+
+import databaseService from '../../../../../shared/services/storage/database.js';
+import { CurrentActiveTermsService } from '../../../../../shared/services/storage/currentActiveTermsService.js';
+import { getTerms } from '../../../../../shared/services/api/api/index.js';
+import { fetchProgrammeMeetings } from '../../../services/programmeService.js';
+import { createOrCompleteRota, writeRotaConfig } from '../../../services/rotaSetupService.js';
+import { discoverRotaRecords, findHostSection, loadRota } from '../../../services/rotaService.js';
+import { notifySuccess } from '../../../../../shared/utils/notifications.js';
+import RotaSetupWizard from '../RotaSetupWizard.jsx';
+
+const HOST_SECTION = { sectionid: 11107, sectionname: 'Adults', section: 'adults' };
+const YOUTH_SECTION = { sectionid: 49097, sectionname: 'Scouts', section: 'scouts' };
+
+function renderWizard() {
+  return render(
+    <MemoryRouter>
+      <RotaSetupWizard />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  databaseService.getSections.mockResolvedValue([HOST_SECTION, YOUTH_SECTION]);
+  findHostSection.mockImplementation((sections) => sections.find((s) => s.sectionid === HOST_SECTION.sectionid) ?? null);
+  discoverRotaRecords.mockResolvedValue([]);
+  getTerms.mockResolvedValue({
+    [String(YOUTH_SECTION.sectionid)]: [
+      { termid: 'T-49097', name: 'Summer 2026', startdate: '2026-04-01', enddate: '2026-08-31' },
+    ],
+  });
+  CurrentActiveTermsService.getCurrentActiveTerm.mockImplementation(async (sectionId) => {
+    if (String(sectionId) === String(YOUTH_SECTION.sectionid)) {
+      return { currentTermId: 'T-49097' };
+    }
+    if (String(sectionId) === String(HOST_SECTION.sectionid)) {
+      return { currentTermId: 'HOST-T1' };
+    }
+    return null;
+  });
+  fetchProgrammeMeetings.mockResolvedValue([]);
+  createOrCompleteRota.mockResolvedValue({
+    success: true,
+    flexirecordid: 'REC1',
+    errors: [],
+    addedFields: [],
+  });
+  loadRota.mockResolvedValue({
+    recordId: 'REC1',
+    hostSection: HOST_SECTION,
+    termId: 'HOST-T1',
+    sectionId: String(YOUTH_SECTION.sectionid),
+    planningTermId: 'T-49097',
+    seasonBucket: 'Summer 2026',
+    configFieldId: 'f_1',
+    config: null,
+    sessions: [],
+    members: [
+      { scoutid: '200', name: 'Later Member' },
+      { scoutid: '100', name: 'Anchor Member' },
+    ],
+  });
+  writeRotaConfig.mockResolvedValue(undefined);
+});
+
+describe('RotaSetupWizard — single-section create', () => {
+  it('defaults step 1 to the first youth section and its own current term', async () => {
+    renderWizard();
+
+    // "Adults" also appears as a section-picker option, so disambiguate the
+    // read-only host-section paragraph specifically.
+    await waitFor(() => expect(screen.getAllByText('Adults').some((el) => el.tagName === 'P')).toBe(true));
+    await waitFor(() => expect(screen.getByLabelText('Section').value).toBe(String(YOUTH_SECTION.sectionid)));
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+    expect(screen.getByLabelText('First week').value).toBe('2026-04-01');
+    expect(screen.getByLabelText('Last week').value).toBe('2026-08-31');
+  });
+
+  it('creates the section\'s own record with the right identity and writes its config to the anchor row', async () => {
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+    await waitFor(() => expect(fetchProgrammeMeetings).toHaveBeenCalledWith(
+      String(YOUTH_SECTION.sectionid), 'T-49097', 'test-token',
+    ));
+
+    await screen.findByText('No programme found — using a weekly slot');
+    fireEvent.click(screen.getByRole('button', { name: 'Next: preview' }));
+
+    await screen.findByRole('button', { name: 'Create rota' });
+    fireEvent.click(screen.getByRole('button', { name: 'Create rota' }));
+
+    await waitFor(() => expect(createOrCompleteRota).toHaveBeenCalledTimes(1));
+    expect(createOrCompleteRota).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostSection: HOST_SECTION,
+        hostTermId: 'HOST-T1',
+        record: {
+          sectionId: String(YOUTH_SECTION.sectionid),
+          sectionName: 'Scouts',
+          termId: 'T-49097',
+          seasonBucket: 'Summer 2026',
+        },
+        token: 'test-token',
+      }),
+    );
+    expect(createOrCompleteRota.mock.calls[0][0].sessions.length).toBeGreaterThan(0);
+
+    await waitFor(() => expect(writeRotaConfig).toHaveBeenCalledTimes(1));
+    expect(writeRotaConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostSection: HOST_SECTION,
+        recordId: 'REC1',
+        termId: 'HOST-T1',
+        // The plan config is written to the deterministic anchor row (lowest
+        // scoutid), not the operator's own row.
+        scoutid: '100',
+        by: 'Test Leader',
+        cfg: expect.objectContaining({ sid: String(YOUTH_SECTION.sectionid), sname: 'Scouts', start: '2026-04-01', end: '2026-08-31' }),
+      }),
+    );
+
+    await waitFor(() => expect(notifySuccess).toHaveBeenCalledWith('Water rota saved'));
+  });
+});

--- a/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
+++ b/src/features/water-rota/components/setup/__tests__/RotaSetupWizard.test.jsx
@@ -53,8 +53,10 @@ vi.mock('../../../hooks/useSectionYPCounts.js', () => ({
   useSectionYPCounts: () => ({ counts: {}, loading: false }),
 }));
 
+const leaderState = vi.hoisted(() => ({ candidates: {} }));
+
 vi.mock('../../../hooks/useSectionLeaders.js', () => ({
-  useSectionLeaders: () => ({ candidates: {}, loading: false }),
+  useSectionLeaders: () => ({ candidates: leaderState.candidates, loading: false }),
 }));
 
 import databaseService from '../../../../../shared/services/storage/database.js';
@@ -80,6 +82,7 @@ function renderWizard(initialEntries = ['/water-rota/setup']) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  leaderState.candidates = {};
   databaseService.getSections.mockResolvedValue([HOST_SECTION, YOUTH_SECTION]);
   findHostSection.mockImplementation((sections) => sections.find((s) => s.sectionid === HOST_SECTION.sectionid) ?? null);
   discoverRotaRecords.mockResolvedValue([]);
@@ -184,6 +187,50 @@ describe('RotaSetupWizard — single-section create', () => {
     );
 
     await waitFor(() => expect(notifySuccess).toHaveBeenCalledWith('Water rota saved'));
+  });
+
+  it('drops the previous section\'s regulars and plan when the planning section changes', async () => {
+    databaseService.getSections.mockResolvedValue([HOST_SECTION, YOUTH_SECTION, OTHER_YOUTH_SECTION]);
+    getTerms.mockResolvedValue({
+      [String(YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-49097', name: 'Summer 2026', startdate: '2026-04-01', enddate: '2026-08-31' },
+      ],
+      [String(OTHER_YOUTH_SECTION.sectionid)]: [
+        { termid: 'T-23456', name: 'Summer 2026', startdate: '2026-04-06', enddate: '2026-08-24' },
+      ],
+    });
+    CurrentActiveTermsService.getCurrentActiveTerm.mockImplementation(async (sectionId) => {
+      if (String(sectionId) === String(YOUTH_SECTION.sectionid)) {
+        return { currentTermId: 'T-49097' };
+      }
+      if (String(sectionId) === String(OTHER_YOUTH_SECTION.sectionid)) {
+        return { currentTermId: 'T-23456' };
+      }
+      if (String(sectionId) === String(HOST_SECTION.sectionid)) {
+        return { currentTermId: 'HOST-T1' };
+      }
+      return null;
+    });
+    leaderState.candidates = {
+      [String(YOUTH_SECTION.sectionid)]: [{ scoutid: '300', name: 'Reg Leader' }],
+      [String(OTHER_YOUTH_SECTION.sectionid)]: [{ scoutid: '300', name: 'Reg Leader' }],
+    };
+
+    renderWizard();
+
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-49097'));
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+    const toggle = await screen.findByRole('button', { name: /Reg Leader/ });
+    fireEvent.click(toggle);
+    expect(screen.getByRole('button', { name: /Reg Leader/ }).getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    fireEvent.change(screen.getByLabelText('Section'), { target: { value: String(OTHER_YOUTH_SECTION.sectionid) } });
+    await waitFor(() => expect(screen.getByLabelText('Term').value).toBe('T-23456'));
+    fireEvent.click(screen.getByRole('button', { name: 'Next: review programme' }));
+
+    const freshToggle = await screen.findByRole('button', { name: /Reg Leader/ });
+    expect(freshToggle.getAttribute('aria-pressed')).toBe('false');
   });
 
   it('pre-selects the section named in ?section= (as set by the board\'s "Edit plan" link)', async () => {

--- a/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
@@ -123,6 +123,17 @@ describe('useRotaIdentity', () => {
     expect(screen.getByTestId('picker')).toHaveTextContent('false');
   });
 
+  it('falls through to name-matching when the stored scoutid is no longer in members (not kept dead)', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
+    // A member who left the roster since the choice was stored.
+    localStorage.setItem('viking_rota_identity_555', '999');
+
+    render(<Harness rota={ROTA_GROUP} />);
+
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+    expect(screen.getByTestId('picker')).toHaveTextContent('false');
+  });
+
   it('clear() drops the stored choice and re-opens the picker', async () => {
     safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
 

--- a/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
@@ -17,23 +17,26 @@ import { safeGetSessionItem } from '../../../../shared/utils/storageUtils.js';
 import { IndexedDBService } from '../../../../shared/services/storage/indexedDBService.js';
 import { useRotaIdentity } from '../useRotaIdentity.js';
 
-const ROTA = {
-  recordId: 777,
-  members: [
-    { scoutid: '10', name: 'Simon Clark' },
-    { scoutid: '11', name: 'Alice Smith' },
-    { scoutid: '12', name: 'Alice Smith' },
-  ],
+const MEMBERS = [
+  { scoutid: '10', name: 'Simon Clark' },
+  { scoutid: '11', name: 'Alice Smith' },
+  { scoutid: '12', name: 'Alice Smith' },
+];
+
+const ROTA_GROUP = {
+  hostSection: { sectionid: 555 },
+  members: MEMBERS,
 };
 
 function Harness({ rota }) {
-  const { identity, needsPicker, resolving, choose } = useRotaIdentity(rota);
+  const { identity, needsPicker, resolving, choose, clear } = useRotaIdentity(rota);
   return (
     <div>
       <span data-testid="identity">{identity ? identity.name : 'none'}</span>
       <span data-testid="picker">{String(needsPicker)}</span>
       <span data-testid="resolving">{String(resolving)}</span>
       <button onClick={() => choose('11')}>choose</button>
+      <button onClick={() => clear()}>clear</button>
     </div>
   );
 }
@@ -48,17 +51,17 @@ describe('useRotaIdentity', () => {
   it('auto-matches a unique full name from session user info', async () => {
     safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
 
-    render(<Harness rota={ROTA} />);
+    render(<Harness rota={ROTA_GROUP} />);
 
     await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
     expect(screen.getByTestId('picker')).toHaveTextContent('false');
-    expect(localStorage.getItem('viking_rota_identity_777')).toBe('10');
+    expect(localStorage.getItem('viking_rota_identity_555')).toBe('10');
   });
 
   it('asks for the picker when the name is ambiguous', async () => {
     safeGetSessionItem.mockReturnValue({ firstname: 'Alice', lastname: 'Smith' });
 
-    render(<Harness rota={ROTA} />);
+    render(<Harness rota={ROTA_GROUP} />);
 
     await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
     expect(screen.getByTestId('identity')).toHaveTextContent('none');
@@ -68,16 +71,16 @@ describe('useRotaIdentity', () => {
     safeGetSessionItem.mockReturnValue({});
     IndexedDBService.get.mockResolvedValue(null);
 
-    render(<Harness rota={ROTA} />);
+    render(<Harness rota={ROTA_GROUP} />);
 
     await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
   });
 
   it('prefers a previously confirmed choice over name matching', async () => {
     safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
-    localStorage.setItem('viking_rota_identity_777', '11');
+    localStorage.setItem('viking_rota_identity_555', '11');
 
-    render(<Harness rota={ROTA} />);
+    render(<Harness rota={ROTA_GROUP} />);
 
     await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
   });
@@ -85,20 +88,51 @@ describe('useRotaIdentity', () => {
   it('persists an explicit choice', async () => {
     safeGetSessionItem.mockReturnValue({ firstname: 'Alice', lastname: 'Smith' });
 
-    render(<Harness rota={ROTA} />);
+    render(<Harness rota={ROTA_GROUP} />);
     await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
 
     fireEvent.click(screen.getByText('choose'));
     await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
-    expect(localStorage.getItem('viking_rota_identity_777')).toBe('11');
+    expect(localStorage.getItem('viking_rota_identity_555')).toBe('11');
   });
 
   it('falls back to cached startup globals for the name', async () => {
     safeGetSessionItem.mockReturnValue({});
     IndexedDBService.get.mockResolvedValue({ globals: { firstname: 'Simon', lastname: 'Clark' } });
 
-    render(<Harness rota={ROTA} />);
+    render(<Harness rota={ROTA_GROUP} />);
 
     await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+  });
+
+  it('resolves the same identity across two rota groups that share a host section', async () => {
+    safeGetSessionItem.mockReturnValue({});
+
+    const { unmount } = render(<Harness rota={ROTA_GROUP} />);
+    await waitFor(() => expect(screen.getByTestId('picker')).toHaveTextContent('true'));
+    fireEvent.click(screen.getByText('choose'));
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
+    unmount();
+
+    // A second group aggregated for a different season bucket, but hosted in
+    // the same Adults section — new object identity, same hostSectionId.
+    const otherGroup = { hostSection: { sectionid: 555 }, members: MEMBERS };
+    render(<Harness rota={otherGroup} />);
+
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
+    expect(screen.getByTestId('picker')).toHaveTextContent('false');
+  });
+
+  it('clear() drops the stored choice and re-opens the picker', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
+
+    render(<Harness rota={ROTA_GROUP} />);
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+
+    fireEvent.click(screen.getByText('clear'));
+
+    expect(screen.getByTestId('identity')).toHaveTextContent('none');
+    expect(screen.getByTestId('picker')).toHaveTextContent('true');
+    expect(localStorage.getItem('viking_rota_identity_555')).toBeNull();
   });
 });

--- a/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useRotaIdentity.test.jsx
@@ -135,4 +135,42 @@ describe('useRotaIdentity', () => {
     expect(screen.getByTestId('picker')).toHaveTextContent('true');
     expect(localStorage.getItem('viking_rota_identity_555')).toBeNull();
   });
+
+  it('clear() blocks a concurrent refresh from auto-re-selecting a unique name match out from under the open picker', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
+
+    const { rerender } = render(<Harness rota={ROTA_GROUP} />);
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+
+    fireEvent.click(screen.getByText('clear'));
+    expect(screen.getByTestId('picker')).toHaveTextContent('true');
+
+    // A refresh() landing before the user picks re-renders with a new members
+    // array (same host section) — the unique full-name match must not
+    // silently re-select and close the picker out from under the user.
+    const refreshedGroup = { hostSection: { sectionid: 555 }, members: [...MEMBERS] };
+    rerender(<Harness rota={refreshedGroup} />);
+
+    await waitFor(() => expect(screen.getByTestId('resolving')).toHaveTextContent('false'));
+    expect(screen.getByTestId('identity')).toHaveTextContent('none');
+    expect(screen.getByTestId('picker')).toHaveTextContent('true');
+    expect(localStorage.getItem('viking_rota_identity_555')).toBeNull();
+  });
+
+  it('choose() after clear() clears the sticky flag and resumes normal resolution on the next refresh', async () => {
+    safeGetSessionItem.mockReturnValue({ firstname: 'Simon', lastname: 'Clark' });
+
+    const { rerender } = render(<Harness rota={ROTA_GROUP} />);
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Simon Clark'));
+
+    fireEvent.click(screen.getByText('clear'));
+    fireEvent.click(screen.getByText('choose'));
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
+    expect(localStorage.getItem('viking_rota_identity_555')).toBe('11');
+
+    const refreshedGroup = { hostSection: { sectionid: 555 }, members: [...MEMBERS] };
+    rerender(<Harness rota={refreshedGroup} />);
+    await waitFor(() => expect(screen.getByTestId('identity')).toHaveTextContent('Alice Smith'));
+    expect(screen.getByTestId('picker')).toHaveTextContent('false');
+  });
 });

--- a/src/features/water-rota/hooks/__tests__/useRotaSignup.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useRotaSignup.test.jsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../../../shared/services/auth/tokenService.js', () => ({
+  getToken: vi.fn(() => 'test-token'),
+}));
+
+vi.mock('../../../../shared/utils/notifications.js', () => ({
+  notifyError: vi.fn(),
+  notifySuccess: vi.fn(),
+}));
+
+vi.mock('../../services/rotaService.js', () => ({
+  writeSignup: vi.fn(),
+}));
+
+import { writeSignup } from '../../services/rotaService.js';
+import { notifyError, notifySuccess } from '../../../../shared/utils/notifications.js';
+import { useRotaSignup } from '../useRotaSignup.js';
+import { SIGNUP_STATUS } from '../../services/rotaEncoding.js';
+
+const RECORD_A = { recordId: 'a', hostSection: { sectionid: '1' } };
+const RECORD_B = { recordId: 'b', hostSection: { sectionid: '1' } };
+
+// Two sessions sharing the same fieldId ("f_1" repeats across records — PRD
+// §5.3) but with distinct, globally-unique keys and owning records.
+const SESSION_A = { key: 'S_20260714_49097', fieldId: 'f_1', record: RECORD_A };
+const SESSION_B = { key: 'S_20260714_49098', fieldId: 'f_1', record: RECORD_B };
+
+const ROTA = { seasonBucket: 'Summer 2026' };
+const IDENTITY = { scoutid: '10', name: 'Simon Clark' };
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useRotaSignup', () => {
+  it('routes the write to the session\'s owning record, not the group', async () => {
+    writeSignup.mockResolvedValue(undefined);
+    const refresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useRotaSignup(ROTA, IDENTITY, refresh));
+
+    await act(async () => {
+      await result.current.setSignup(SESSION_A, SIGNUP_STATUS.IN);
+    });
+
+    expect(writeSignup).toHaveBeenCalledWith({
+      rota: RECORD_A,
+      fieldId: 'f_1',
+      scoutid: '10',
+      status: SIGNUP_STATUS.IN,
+      token: 'test-token',
+    });
+    expect(notifySuccess).toHaveBeenCalledWith('You\'re in');
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('keys pending state on the session key, not the field id', async () => {
+    const write = deferred();
+    writeSignup.mockReturnValue(write.promise);
+    const refresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useRotaSignup(ROTA, IDENTITY, refresh));
+
+    let settle;
+    act(() => {
+      settle = result.current.setSignup(SESSION_A, SIGNUP_STATUS.IN);
+    });
+
+    await waitFor(() => expect(result.current.pendingKey).toBe(SESSION_A.key));
+    // Same fieldId, different record/key — must NOT read as pending.
+    expect(result.current.pendingKey).not.toBe(SESSION_B.key);
+
+    await act(async () => {
+      write.resolve(undefined);
+      await settle;
+    });
+
+    expect(result.current.pendingKey).toBeNull();
+  });
+
+  it('two same-fieldId sessions in different records do not cross-trigger pending state', async () => {
+    const write = deferred();
+    writeSignup.mockReturnValue(write.promise);
+    const refresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useRotaSignup(ROTA, IDENTITY, refresh));
+
+    act(() => {
+      result.current.setSignup(SESSION_A, SIGNUP_STATUS.IN);
+    });
+
+    await waitFor(() => expect(result.current.pendingKey).toBe(SESSION_A.key));
+    const sessionAPending = result.current.pendingKey === SESSION_A.key;
+    const sessionBPending = result.current.pendingKey === SESSION_B.key;
+    expect(sessionAPending).toBe(true);
+    expect(sessionBPending).toBe(false);
+
+    await act(async () => {
+      write.resolve(undefined);
+    });
+  });
+
+  it('surfaces an offline-specific message for WRITE_UNAVAILABLE', async () => {
+    const error = Object.assign(new Error('offline'), { code: 'WRITE_UNAVAILABLE' });
+    writeSignup.mockRejectedValue(error);
+    const refresh = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useRotaSignup(ROTA, IDENTITY, refresh));
+
+    await act(async () => {
+      await result.current.setSignup(SESSION_A, SIGNUP_STATUS.IN);
+    });
+
+    expect(notifyError).toHaveBeenCalledWith('You\'re offline — connect to change your signup.');
+    expect(result.current.pendingKey).toBeNull();
+  });
+
+  it('does nothing without a loaded rota, identity, or session', async () => {
+    const refresh = vi.fn(async () => undefined);
+    const { result, rerender } = renderHook(
+      ({ rota, identity }) => useRotaSignup(rota, identity, refresh),
+      { initialProps: { rota: null, identity: IDENTITY } },
+    );
+
+    await act(async () => {
+      await result.current.setSignup(SESSION_A, SIGNUP_STATUS.IN);
+    });
+    expect(writeSignup).not.toHaveBeenCalled();
+
+    rerender({ rota: ROTA, identity: null });
+    await act(async () => {
+      await result.current.setSignup(SESSION_A, SIGNUP_STATUS.IN);
+    });
+    expect(writeSignup).not.toHaveBeenCalled();
+
+    rerender({ rota: ROTA, identity: IDENTITY });
+    await act(async () => {
+      await result.current.setSignup(null, SIGNUP_STATUS.IN);
+    });
+    expect(writeSignup).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -167,6 +167,33 @@ describe('useWaterRota', () => {
     expect(discoverRotaRecords).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps the requested ?season= bucket on a cold-cache deep link (buckets not yet discovered), and loads it once reference data is ready', async () => {
+    dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });
+    discoverRotaRecords.mockResolvedValueOnce([]);
+    loadRotaGroup.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useWaterRota('Summer 2025'));
+
+    // Cold cache: discovery finds no records yet, but the requested bucket
+    // must still drive the load (not the unresolvable default) — this is
+    // the defended path at useWaterRota.js ~123-125.
+    await waitFor(() => expect(loadRotaGroup).toHaveBeenCalledWith('Summer 2025', 'test-token', { priority: 5 }));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.rota).toBeNull();
+
+    discoverRotaRecords.mockResolvedValueOnce([{ seasonBucket: 'Summer 2025' }]);
+    loadRotaGroup.mockResolvedValueOnce(GROUP);
+    await act(async () => {
+      markReferenceDataReady();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.rota).toBe(GROUP);
+    // Still the requested bucket, not re-derived from the newly discovered
+    // buckets list.
+    expect(loadRotaGroup).toHaveBeenLastCalledWith('Summer 2025', 'test-token', { priority: 5 });
+  });
+
   it('recovers to an empty board when the bootstrap settles without reference ever becoming ready (reference load failed)', async () => {
     const settled = deferred();
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -11,7 +11,8 @@ vi.mock('../../../../shared/services/auth/tokenService.js', () => ({
 }));
 
 vi.mock('../../services/rotaService.js', () => ({
-  loadRota: vi.fn(),
+  discoverRotaRecords: vi.fn(),
+  loadRotaGroup: vi.fn(),
 }));
 
 vi.mock('../../../../shared/services/data/dataLoadingService.js', () => ({
@@ -23,15 +24,15 @@ vi.mock('../../../../shared/services/data/dataLoadingService.js', () => ({
   },
 }));
 
-import { loadRota } from '../../services/rotaService.js';
+import { discoverRotaRecords, loadRotaGroup } from '../../services/rotaService.js';
 import dataLoadingService from '../../../../shared/services/data/dataLoadingService.js';
 import {
   markReferenceDataReady,
   resetReferenceDataReady,
 } from '../../../../shared/services/data/referenceDataReady.js';
-import { useWaterRota } from '../useWaterRota.js';
+import { useWaterRota, uniqueSeasonBuckets, defaultSeasonBucket } from '../useWaterRota.js';
 
-const ROTA = { year: 2026, sessions: [], members: [] };
+const GROUP = { seasonBucket: 'Summer 2026', sessions: [], members: [] };
 
 /** Manually-resolvable promise for ordering-sensitive tests. */
 function deferred() {
@@ -51,71 +52,121 @@ beforeEach(() => {
   dataLoadingService.whenAllDataSettled.mockReturnValue(new Promise(() => {}));
 });
 
-describe('useWaterRota', () => {
-  it('loads the rota on mount from a warm cache, at deep-link priority', async () => {
-    loadRota.mockResolvedValue(ROTA);
-
-    const { result } = renderHook(() => useWaterRota(2026));
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.rota).toBe(ROTA);
-    expect(loadRota).toHaveBeenCalledWith(2026, 'test-token', { priority: 5 });
+describe('uniqueSeasonBuckets', () => {
+  it('dedupes descriptors to their distinct season buckets', () => {
+    expect(uniqueSeasonBuckets([
+      { seasonBucket: 'Summer 2026' },
+      { seasonBucket: 'Spring 2026' },
+      { seasonBucket: 'Summer 2026' },
+    ])).toEqual(['Summer 2026', 'Spring 2026']);
   });
 
-  it('shows an empty board (not loading) when reference is ready but no rota exists', async () => {
-    markReferenceDataReady();
-    loadRota.mockResolvedValue(null);
+  it('is empty for no descriptors', () => {
+    expect(uniqueSeasonBuckets([])).toEqual([]);
+    expect(uniqueSeasonBuckets(undefined)).toEqual([]);
+  });
+});
 
-    const { result } = renderHook(() => useWaterRota(2026));
+describe('defaultSeasonBucket', () => {
+  it('returns null for an empty bucket list', () => {
+    expect(defaultSeasonBucket([])).toBeNull();
+  });
+
+  it('picks the bucket whose season window contains today', () => {
+    expect(defaultSeasonBucket(['Spring 2026', 'Summer 2026', 'Autumn 2026'], '2026-06-15')).toBe('Summer 2026');
+  });
+
+  it('falls back to the latest year when today is not covered', () => {
+    expect(defaultSeasonBucket(['Autumn 2025', 'Spring 2026'], '2026-06-15')).toBe('Spring 2026');
+  });
+
+  it('falls back to the latest season order within the latest year when today is not covered', () => {
+    expect(defaultSeasonBucket(['Autumn 2026', 'Spring 2026'], '2025-01-01')).toBe('Autumn 2026');
+  });
+});
+
+describe('useWaterRota', () => {
+  it('discovers buckets and loads the resolved default bucket, at deep-link priority', async () => {
+    const descriptors = [{ seasonBucket: 'Summer 2026' }, { seasonBucket: 'Spring 2026' }];
+    discoverRotaRecords.mockResolvedValue(descriptors);
+    loadRotaGroup.mockResolvedValue(GROUP);
+
+    const { result } = renderHook(() => useWaterRota());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(discoverRotaRecords).toHaveBeenCalledWith('test-token', 5);
+    const expectedBucket = defaultSeasonBucket(uniqueSeasonBuckets(descriptors));
+    expect(loadRotaGroup).toHaveBeenCalledWith(expectedBucket, 'test-token', { priority: 5 });
+    expect(result.current.rota).toBe(GROUP);
+    expect(result.current.seasonBucket).toBe(expectedBucket);
+    expect(result.current.buckets).toEqual(['Summer 2026', 'Spring 2026']);
+  });
+
+  it('loads an explicitly requested season bucket instead of the default', async () => {
+    discoverRotaRecords.mockResolvedValue([{ seasonBucket: 'Summer 2025' }]);
+    loadRotaGroup.mockResolvedValue(GROUP);
+
+    const { result } = renderHook(() => useWaterRota('Summer 2025'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(loadRotaGroup).toHaveBeenCalledWith('Summer 2025', 'test-token', { priority: 5 });
+    expect(result.current.seasonBucket).toBe('Summer 2025');
+  });
+
+  it('shows an empty board (not loading) when reference is ready but no rota exists anywhere', async () => {
+    markReferenceDataReady();
+    discoverRotaRecords.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWaterRota());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.rota).toBeNull();
+    expect(result.current.buckets).toEqual([]);
+    expect(loadRotaGroup).not.toHaveBeenCalled();
   });
 
   it('shows an empty board when no rota exists and no load is in progress (no stuck spinner)', async () => {
-    loadRota.mockResolvedValue(null);
+    discoverRotaRecords.mockResolvedValue([]);
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
 
-    const { result } = renderHook(() => useWaterRota(2026));
+    const { result } = renderHook(() => useWaterRota());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.rota).toBeNull();
   });
 
-  it('stays in loading on a cold cache, then fills in when reference data becomes ready', async () => {
+  it('stays in loading on a cold cache (no buckets discovered yet), then fills in when reference data becomes ready', async () => {
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });
-    loadRota.mockResolvedValueOnce(null);
+    discoverRotaRecords.mockResolvedValueOnce([]);
 
-    const { result } = renderHook(() => useWaterRota(2026));
+    const { result } = renderHook(() => useWaterRota());
 
-    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(discoverRotaRecords).toHaveBeenCalledTimes(1));
     expect(result.current.loading).toBe(true);
     expect(result.current.rota).toBeNull();
 
-    loadRota.mockResolvedValueOnce(ROTA);
+    discoverRotaRecords.mockResolvedValueOnce([{ seasonBucket: 'Summer 2026' }]);
+    loadRotaGroup.mockResolvedValueOnce(GROUP);
     await act(async () => {
       markReferenceDataReady();
     });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.rota).toBe(ROTA);
-    expect(loadRota).toHaveBeenCalledTimes(2);
+    expect(result.current.rota).toBe(GROUP);
+    expect(discoverRotaRecords).toHaveBeenCalledTimes(2);
   });
 
   it('recovers to an empty board when the bootstrap settles without reference ever becoming ready (reference load failed)', async () => {
-    // Cold cache with a bootstrap running; reference load will fail so the
-    // ready signal never fires. The board must not spin forever.
     const settled = deferred();
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: true });
     dataLoadingService.whenAllDataSettled.mockReturnValue(settled.promise);
-    loadRota.mockResolvedValue(null);
+    discoverRotaRecords.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useWaterRota(2026));
+    const { result } = renderHook(() => useWaterRota());
 
-    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(discoverRotaRecords).toHaveBeenCalledTimes(1));
     expect(result.current.loading).toBe(true);
 
-    // Bootstrap finishes without success: isLoadingAll flips false, settle resolves.
     dataLoadingService.getLoadingStatus.mockReturnValue({ isLoadingAll: false });
     await act(async () => {
       settled.resolve();
@@ -126,56 +177,56 @@ describe('useWaterRota', () => {
   });
 
   it('does not let a slower stale load clobber a newer result (epoch guard)', async () => {
-    // Mount load is slow and resolves null; the ready-signal load resolves ROTA
-    // first. The later null must not overwrite the loaded board.
+    discoverRotaRecords.mockResolvedValue([{ seasonBucket: 'Summer 2026' }]);
     const mountLoad = deferred();
     const signalLoad = deferred();
-    loadRota
+    loadRotaGroup
       .mockReturnValueOnce(mountLoad.promise)
       .mockReturnValueOnce(signalLoad.promise);
 
-    const { result } = renderHook(() => useWaterRota(2026));
-    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(1));
+    const { result } = renderHook(() => useWaterRota());
+    await waitFor(() => expect(loadRotaGroup).toHaveBeenCalledTimes(1));
 
     // Reference becomes ready -> a second (newer) load starts.
     await act(async () => {
       markReferenceDataReady();
     });
-    await waitFor(() => expect(loadRota).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(loadRotaGroup).toHaveBeenCalledTimes(2));
 
-    // Newer load resolves first with the rota...
+    // Newer load resolves first with the group...
     await act(async () => {
-      signalLoad.resolve(ROTA);
+      signalLoad.resolve(GROUP);
     });
-    await waitFor(() => expect(result.current.rota).toBe(ROTA));
+    await waitFor(() => expect(result.current.rota).toBe(GROUP));
 
     // ...then the stale mount load resolves null and must be ignored.
     await act(async () => {
       mountLoad.resolve(null);
     });
-    expect(result.current.rota).toBe(ROTA);
+    expect(result.current.rota).toBe(GROUP);
     expect(result.current.loading).toBe(false);
   });
 
   it('stops re-running after unmount', async () => {
-    loadRota.mockResolvedValue(ROTA);
+    discoverRotaRecords.mockResolvedValue([{ seasonBucket: 'Summer 2026' }]);
+    loadRotaGroup.mockResolvedValue(GROUP);
 
-    const { result, unmount } = renderHook(() => useWaterRota(2026));
+    const { result, unmount } = renderHook(() => useWaterRota());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    loadRota.mockClear();
+    discoverRotaRecords.mockClear();
     unmount();
     await act(async () => {
       markReferenceDataReady();
     });
 
-    expect(loadRota).not.toHaveBeenCalled();
+    expect(discoverRotaRecords).not.toHaveBeenCalled();
   });
 
   it('surfaces load errors', async () => {
-    loadRota.mockRejectedValue(new Error('nope'));
+    discoverRotaRecords.mockRejectedValue(new Error('nope'));
 
-    const { result } = renderHook(() => useWaterRota(2026));
+    const { result } = renderHook(() => useWaterRota());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBeInstanceOf(Error);

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -113,6 +113,17 @@ describe('useWaterRota', () => {
     expect(result.current.seasonBucket).toBe('Summer 2025');
   });
 
+  it('falls back to the resolved default bucket when the requested season bucket does not exist (stale/invalid ?season=)', async () => {
+    discoverRotaRecords.mockResolvedValue([{ seasonBucket: 'Summer 2026' }]);
+    loadRotaGroup.mockResolvedValue(GROUP);
+
+    const { result } = renderHook(() => useWaterRota('Nonexistent Bucket 1999'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(loadRotaGroup).toHaveBeenCalledWith('Summer 2026', 'test-token', { priority: 5 });
+    expect(result.current.seasonBucket).toBe('Summer 2026');
+  });
+
   it('shows an empty board (not loading) when reference is ready but no rota exists anywhere', async () => {
     markReferenceDataReady();
     discoverRotaRecords.mockResolvedValue([]);

--- a/src/features/water-rota/hooks/useRotaIdentity.js
+++ b/src/features/water-rota/hooks/useRotaIdentity.js
@@ -12,7 +12,7 @@
  * @module useRotaIdentity
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { safeGetSessionItem } from '../../../shared/utils/storageUtils.js';
 import { IndexedDBService } from '../../../shared/services/storage/indexedDBService.js';
 
@@ -58,6 +58,11 @@ function identityStorageKey(hostSectionId) {
  */
 export function useRotaIdentity(rotaGroup) {
   const [state, setState] = useState({ identity: null, needsPicker: false, resolving: true });
+  // Sticky across a refresh: once the user explicitly clears their identity,
+  // a concurrent refresh() landing before they re-pick must not auto-select
+  // a unique name match out from under the open picker. An explicit choose()
+  // is the only thing that clears it.
+  const explicitlyClearedRef = useRef(false);
 
   const members = useMemo(() => rotaGroup?.members ?? [], [rotaGroup]);
   const hostSectionId = rotaGroup?.hostSection?.sectionid;
@@ -76,6 +81,13 @@ export function useRotaIdentity(rotaGroup) {
       if (stored) {
         if (!cancelled) {
           setState({ identity: stored, needsPicker: false, resolving: false });
+        }
+        return;
+      }
+
+      if (explicitlyClearedRef.current) {
+        if (!cancelled) {
+          setState({ identity: null, needsPicker: true, resolving: false });
         }
         return;
       }
@@ -107,6 +119,7 @@ export function useRotaIdentity(rotaGroup) {
       if (!member || !hostSectionId) {
         return;
       }
+      explicitlyClearedRef.current = false;
       localStorage.setItem(identityStorageKey(hostSectionId), member.scoutid);
       setState({ identity: member, needsPicker: false, resolving: false });
     },
@@ -114,6 +127,7 @@ export function useRotaIdentity(rotaGroup) {
   );
 
   const clear = useCallback(() => {
+    explicitlyClearedRef.current = true;
     if (hostSectionId) {
       localStorage.removeItem(identityStorageKey(hostSectionId));
     }

--- a/src/features/water-rota/hooks/useRotaIdentity.js
+++ b/src/features/water-rota/hooks/useRotaIdentity.js
@@ -2,10 +2,12 @@
  * Resolves which host-section member row belongs to the current user, so
  * signups write to the right row.
  *
- * Resolution order: a previously confirmed choice (persisted per record) →
- * unique full-name match against the rota members → otherwise the caller
- * shows the identity picker. The chosen identity is stored per record id,
- * so a new year's rota re-resolves.
+ * Resolution order: a previously confirmed choice (persisted per host
+ * section) → unique full-name match against the rota members → otherwise
+ * the caller shows the identity picker. Every rota record hosted in the same
+ * Adults section shares one roster, so the choice is stored once per host
+ * section rather than once per record — a leader isn't re-prompted for
+ * every planning section's record in the season bucket.
  *
  * @module useRotaIdentity
  */
@@ -39,37 +41,37 @@ export async function getCurrentUserName() {
 }
 
 /**
- * Storage key for the confirmed identity on one rota record.
+ * Storage key for the confirmed identity on one host section's roster.
  *
- * @param {string|number} recordId - FlexiRecord id
+ * @param {string|number} hostSectionId - Host (Adults) section id
  * @returns {string} localStorage key
  */
-function identityStorageKey(recordId) {
-  return `viking_rota_identity_${recordId}`;
+function identityStorageKey(hostSectionId) {
+  return `viking_rota_identity_${hostSectionId}`;
 }
 
 /**
  * Resolve the current user's member row in the rota host section.
  *
- * @param {import('../services/rotaService.js').LoadedRota|null} rota - Loaded rota (null while loading)
+ * @param {import('../services/rotaService.js').RotaGroup|null} rotaGroup - Loaded rota group (null while loading)
  * @returns {{identity: {scoutid: string, name: string}|null, needsPicker: boolean, resolving: boolean, choose: Function, clear: Function}} Identity state
  */
-export function useRotaIdentity(rota) {
+export function useRotaIdentity(rotaGroup) {
   const [state, setState] = useState({ identity: null, needsPicker: false, resolving: true });
 
-  const members = useMemo(() => rota?.members ?? [], [rota]);
-  const recordId = rota?.recordId;
+  const members = useMemo(() => rotaGroup?.members ?? [], [rotaGroup]);
+  const hostSectionId = rotaGroup?.hostSection?.sectionid;
 
   useEffect(() => {
     let cancelled = false;
 
     async function resolve() {
-      if (!recordId || members.length === 0) {
-        setState({ identity: null, needsPicker: false, resolving: !recordId });
+      if (!hostSectionId || members.length === 0) {
+        setState({ identity: null, needsPicker: false, resolving: !hostSectionId });
         return;
       }
 
-      const storedId = localStorage.getItem(identityStorageKey(recordId));
+      const storedId = localStorage.getItem(identityStorageKey(hostSectionId));
       const stored = members.find((member) => member.scoutid === storedId);
       if (stored) {
         if (!cancelled) {
@@ -85,7 +87,7 @@ export function useRotaIdentity(rota) {
 
       if (!cancelled) {
         if (matches.length === 1) {
-          localStorage.setItem(identityStorageKey(recordId), matches[0].scoutid);
+          localStorage.setItem(identityStorageKey(hostSectionId), matches[0].scoutid);
           setState({ identity: matches[0], needsPicker: false, resolving: false });
         } else {
           setState({ identity: null, needsPicker: true, resolving: false });
@@ -97,26 +99,26 @@ export function useRotaIdentity(rota) {
     return () => {
       cancelled = true;
     };
-  }, [recordId, members]);
+  }, [hostSectionId, members]);
 
   const choose = useCallback(
     (scoutid) => {
       const member = members.find((entry) => entry.scoutid === String(scoutid));
-      if (!member || !recordId) {
+      if (!member || !hostSectionId) {
         return;
       }
-      localStorage.setItem(identityStorageKey(recordId), member.scoutid);
+      localStorage.setItem(identityStorageKey(hostSectionId), member.scoutid);
       setState({ identity: member, needsPicker: false, resolving: false });
     },
-    [members, recordId],
+    [members, hostSectionId],
   );
 
   const clear = useCallback(() => {
-    if (recordId) {
-      localStorage.removeItem(identityStorageKey(recordId));
+    if (hostSectionId) {
+      localStorage.removeItem(identityStorageKey(hostSectionId));
     }
     setState({ identity: null, needsPicker: true, resolving: false });
-  }, [recordId]);
+  }, [hostSectionId]);
 
   return { ...state, choose, clear };
 }

--- a/src/features/water-rota/hooks/useRotaSignup.js
+++ b/src/features/water-rota/hooks/useRotaSignup.js
@@ -24,26 +24,32 @@ function successMessage(status) {
 }
 
 /**
- * Perform signup changes against a loaded rota.
+ * Perform signup changes against a loaded rota group. Pending state is keyed
+ * on the session's column-name key (globally unique across every record in
+ * the group), not its field id — field ids like "f_1" repeat across records,
+ * so two same-fieldId sessions in different records must not cross-trigger
+ * pending state. Each write routes to the session's own owning record
+ * ({@link import('../services/rotaService.js').SessionView.record}) rather
+ * than the group.
  *
- * @param {import('../services/rotaService.js').LoadedRota|null} rota - Loaded rota
+ * @param {import('../services/rotaService.js').RotaGroup|null} rota - Loaded rota group
  * @param {{scoutid: string}|null} identity - Resolved member identity
  * @param {Function} refresh - Re-load the rota after a successful write
- * @returns {{setSignup: Function, pendingFieldId: string|null}} Signup API
+ * @returns {{setSignup: Function, pendingKey: string|null}} Signup API
  */
 export function useRotaSignup(rota, identity, refresh) {
-  const [pendingFieldId, setPendingFieldId] = useState(null);
+  const [pendingKey, setPendingKey] = useState(null);
 
   const setSignup = useCallback(
-    async (fieldId, status) => {
-      if (!rota || !identity) {
+    async (session, status) => {
+      if (!rota || !identity || !session) {
         return;
       }
-      setPendingFieldId(fieldId);
+      setPendingKey(session.key);
       try {
         await writeSignup({
-          rota,
-          fieldId,
+          rota: session.record,
+          fieldId: session.fieldId,
           scoutid: identity.scoutid,
           status,
           token: getToken(),
@@ -57,11 +63,11 @@ export function useRotaSignup(rota, identity, refresh) {
           notifyError(`Signup failed: ${error.message}`);
         }
       } finally {
-        setPendingFieldId(null);
+        setPendingKey(null);
       }
     },
     [rota, identity, refresh],
   );
 
-  return { setSignup, pendingFieldId };
+  return { setSignup, pendingKey };
 }

--- a/src/features/water-rota/hooks/useRotaSignup.js
+++ b/src/features/water-rota/hooks/useRotaSignup.js
@@ -29,7 +29,7 @@ function successMessage(status) {
  * the group), not its field id — field ids like "f_1" repeat across records,
  * so two same-fieldId sessions in different records must not cross-trigger
  * pending state. Each write routes to the session's own owning record
- * ({@link import('../services/rotaService.js').SessionView.record}) rather
+ * ({@link import('../utils/rotaDisplay.js').SessionView.record}) rather
  * than the group.
  *
  * @param {import('../services/rotaService.js').RotaGroup|null} rota - Loaded rota group

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -116,7 +116,13 @@ export function useWaterRota(seasonBucket) {
         return;
       }
       const buckets = uniqueSeasonBuckets(descriptors);
-      const activeBucket = seasonBucket || defaultSeasonBucket(buckets);
+      // A well-formed but non-existent bucket (e.g. a stale shared link)
+      // must not stick — fall back to the resolved default once buckets are
+      // known. While discovery hasn't populated buckets yet (cold-cache
+      // deep link), keep the requested bucket so that path still works.
+      const activeBucket = buckets.length === 0
+        ? seasonBucket
+        : (seasonBucket && buckets.includes(seasonBucket) ? seasonBucket : defaultSeasonBucket(buckets));
       const rota = activeBucket
         ? await loadRotaGroup(activeBucket, token, { priority: DEEP_LINK_PRIORITY })
         : null;

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -1,25 +1,28 @@
 /**
- * Loads and exposes the current year's water rota.
+ * Discovers the season buckets that have rota records and loads one bucket's
+ * aggregated group view.
  *
- * Reads ride the flexi cache underneath loadRota, so a previously loaded
- * board renders offline; refresh() re-runs discovery and the live grid
- * fetch.
+ * Reads ride the flexi cache underneath discoverRotaRecords/loadRotaGroup, so
+ * a previously loaded board renders offline; refresh() re-runs discovery and
+ * every record's live grid fetch.
  *
  * Deep-link fast path: on a cold cache (a shared-link recipient who just
- * signed in) loadRota cannot discover the record until the post-login
- * bootstrap has cached sections/terms/members. This hook therefore (a) waits
- * in the loading state rather than flashing "no rota" while reference data is
- * still loading, (b) re-runs once {@link subscribeReferenceDataReady} fires or
- * the bootstrap otherwise settles (so a reference *failure* resolves to the
- * empty/error state instead of hanging), and (c) loads at a raised rate-limit
- * priority so the rota jumps ahead of the background sync's flood of requests.
- * A per-request epoch guard ensures a slower stale load can't clobber the
- * result of a newer one.
+ * signed in) discovery cannot find any record until the post-login bootstrap
+ * has cached sections/terms/members, so this hook (a) waits in the loading
+ * state rather than flashing "no rota" while reference data is still
+ * loading, (b) re-runs once {@link subscribeReferenceDataReady} fires or the
+ * bootstrap otherwise settles (so a reference *failure* resolves to the
+ * empty/error state instead of hanging), and (c) loads at a raised
+ * rate-limit priority so the rota jumps ahead of the background sync. A
+ * per-request epoch guard ensures a slower stale load can't clobber the
+ * result of a newer one. The same ready-signal gating covers the season
+ * picker's bucket list, since discovery is what produces it.
  *
  * @module useWaterRota
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { format } from 'date-fns';
 import { getToken } from '../../../shared/services/auth/tokenService.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import dataLoadingService from '../../../shared/services/data/dataLoadingService.js';
@@ -27,22 +30,75 @@ import {
   isReferenceDataReady,
   subscribeReferenceDataReady,
 } from '../../../shared/services/data/referenceDataReady.js';
-import { loadRota } from '../services/rotaService.js';
+import { discoverRotaRecords, loadRotaGroup } from '../services/rotaService.js';
+import { seasonBucketForRange } from '../services/rotaTemplates.js';
 
 // Queue priority for the landing/deep-link rota load: above the background
 // post-login reads (0), below writes (10), so a shared-link recipient's board
 // loads ahead of the whole-app sync.
 const DEEP_LINK_PRIORITY = 5;
 
+const SEASON_ORDER = { Spring: 0, Summer: 1, Autumn: 2 };
+
 /**
- * Load the water rota for a year.
+ * Parse a season bucket label into its comparable parts.
  *
- * @param {number} [year] - Calendar year; defaults to the current year
- * @returns {{loading: boolean, rota: Object|null, error: Error|null, refresh: Function, year: number}} Rota state
+ * @param {string} bucket - Season bucket label, e.g. "Summer 2026"
+ * @returns {{season: string, year: number}|null} Parts, or null when unparseable
  */
-export function useWaterRota(year) {
-  const targetYear = year ?? new Date().getFullYear();
-  const [state, setState] = useState({ loading: true, rota: null, error: null });
+function parseSeasonBucket(bucket) {
+  const match = /^(Spring|Summer|Autumn) (\d{4})$/.exec(String(bucket ?? '').trim());
+  return match ? { season: match[1], year: Number(match[2]) } : null;
+}
+
+/**
+ * Every distinct season bucket a set of discovered records belongs to.
+ *
+ * @param {Array<{seasonBucket: string}>} descriptors - Discovered rota descriptors
+ * @returns {string[]} Unique season buckets, unordered
+ */
+export function uniqueSeasonBuckets(descriptors) {
+  return [...new Set((descriptors ?? []).map((descriptor) => descriptor.seasonBucket))];
+}
+
+/**
+ * Pick the season picker's default bucket (PRD §3.4): the bucket whose
+ * season window contains today, else the latest bucket by (year, season
+ * order).
+ *
+ * @param {string[]} buckets - Available season buckets
+ * @param {string} [todayISO] - Today's date (yyyy-mm-dd), injectable for tests
+ * @returns {string|null} The default bucket, or null when there are none
+ */
+export function defaultSeasonBucket(buckets, todayISO = format(new Date(), 'yyyy-MM-dd')) {
+  if (!buckets || buckets.length === 0) {
+    return null;
+  }
+  const currentBucket = seasonBucketForRange(todayISO, todayISO);
+  if (buckets.includes(currentBucket)) {
+    return currentBucket;
+  }
+  return [...buckets].sort((a, b) => {
+    const pa = parseSeasonBucket(a);
+    const pb = parseSeasonBucket(b);
+    if (!pa || !pb) {
+      return String(a).localeCompare(String(b));
+    }
+    return pa.year - pb.year || SEASON_ORDER[pa.season] - SEASON_ORDER[pb.season];
+  }).at(-1);
+}
+
+/**
+ * Load the water rota for a season bucket, aggregating every discovered
+ * planning section's record in that bucket.
+ *
+ * @param {string} [seasonBucket] - Season bucket to load, e.g. "Summer 2026"; defaults to {@link defaultSeasonBucket}
+ * @returns {{loading: boolean, rota: import('../services/rotaService.js').RotaGroup|null, error: Error|null, refresh: Function, seasonBucket: string|null, buckets: string[]}} Rota state
+ */
+export function useWaterRota(seasonBucket) {
+  const [state, setState] = useState({
+    loading: true, rota: null, error: null, seasonBucket: null, buckets: [],
+  });
   const requestIdRef = useRef(0);
   const mountedRef = useRef(true);
 
@@ -55,21 +111,32 @@ export function useWaterRota(year) {
     setState((previous) => ({ ...previous, loading: true, error: null }));
     try {
       const token = getToken();
-      const rota = await loadRota(targetYear, token, { priority: DEEP_LINK_PRIORITY });
+      const descriptors = await discoverRotaRecords(token, DEEP_LINK_PRIORITY);
       if (!isCurrent()) {
         return;
       }
+      const buckets = uniqueSeasonBuckets(descriptors);
+      const activeBucket = seasonBucket || defaultSeasonBucket(buckets);
+      const rota = activeBucket
+        ? await loadRotaGroup(activeBucket, token, { priority: DEEP_LINK_PRIORITY })
+        : null;
+      if (!isCurrent()) {
+        return;
+      }
+
       if (
         !rota &&
+        buckets.length === 0 &&
         !isReferenceDataReady() &&
         dataLoadingService.getLoadingStatus().isLoadingAll
       ) {
         // Cold-cache deep link with the post-login bootstrap still running:
-        // sections aren't cached yet, so a null result means "not loaded" not
-        // "no rota exists". Stay in loading and let the reference-ready signal
-        // re-run this once the cache is warm. Gated on an in-progress load so a
-        // warm-cache/offline user viewing a year with genuinely no rota falls
-        // through to the empty state below instead of spinning forever.
+        // sections aren't cached yet, so discovery finding nothing means "not
+        // loaded" not "no rota exists". Stay in loading and let the
+        // reference-ready signal re-run this once the cache is warm. Gated
+        // on an in-progress load so a warm-cache/offline user viewing a
+        // bucket with genuinely no rota falls through to the empty state
+        // below instead of spinning forever.
         setState((previous) => ({ ...previous, loading: true }));
         // Safety net: if the bootstrap settles WITHOUT caching reference data
         // (reference load failed), the ready signal never fires — re-run once
@@ -83,18 +150,18 @@ export function useWaterRota(year) {
         });
         return;
       }
-      setState({ loading: false, rota, error: null });
+      setState({ loading: false, rota, error: null, seasonBucket: activeBucket, buckets });
     } catch (error) {
       if (!isCurrent()) {
         return;
       }
       logger.error('Water rota load failed', {
-        year: targetYear,
+        seasonBucket,
         error: error.message,
       }, LOG_CATEGORIES.ERROR);
-      setState({ loading: false, rota: null, error });
+      setState({ loading: false, rota: null, error, seasonBucket: null, buckets: [] });
     }
-  }, [targetYear]);
+  }, [seasonBucket]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -115,5 +182,5 @@ export function useWaterRota(year) {
     });
   }, [refresh]);
 
-  return { ...state, refresh, year: targetYear };
+  return { ...state, refresh };
 }

--- a/src/features/water-rota/services/__tests__/rotaEncoding.test.js
+++ b/src/features/water-rota/services/__tests__/rotaEncoding.test.js
@@ -9,6 +9,7 @@ import {
   encodeSignup,
   mergeLwwConfig,
   mergeSessionColumn,
+  parseConfigCell,
   parseSessionCell,
   parseSessionColumnName,
 } from '../rotaEncoding.js';
@@ -30,9 +31,13 @@ const CONFIG = {
   at: '2026-06-01T09:00:00Z',
   by: 'Simon Clark',
   cfg: {
+    sid: '49097',
+    sname: 'Cubs',
+    act: 'Kayaking',
+    st: '18:15',
+    en: '19:30',
     start: '2026-06-01',
     end: '2026-08-31',
-    sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
   },
 };
 
@@ -182,8 +187,14 @@ describe('encodeConfig', () => {
     expect(mergeLwwConfig([raw])).toEqual(CONFIG);
   });
 
-  it('rejects config without sections', () => {
-    expect(() => encodeConfig({ ...CONFIG, cfg: { start: '2026-06-01', end: '2026-08-31' } })).toThrow();
+  it('rejects config missing the required sid', () => {
+    const { sid: _sid, ...rest } = CONFIG.cfg;
+    expect(() => encodeConfig({ ...CONFIG, cfg: rest })).toThrow();
+  });
+
+  it('rejects config missing the required act', () => {
+    const { act: _act, ...rest } = CONFIG.cfg;
+    expect(() => encodeConfig({ ...CONFIG, cfg: rest })).toThrow();
   });
 
   it('round-trips a per-session overrides map', () => {
@@ -198,25 +209,23 @@ describe('encodeConfig', () => {
     expect(decoded.cfg.sessions.S_20260714_49097).toEqual({ act: 'Powerboats', st: '18:00', en: '19:00' });
   });
 
-  it('round-trips per-section regulars (scoutids)', () => {
-    const cfg = {
-      ...CONFIG,
-      cfg: {
-        ...CONFIG.cfg,
-        sections: [{ ...CONFIG.cfg.sections[0], regulars: ['10', '11'] }],
-      },
-    };
-    expect(mergeLwwConfig([encodeConfig(cfg)]).cfg.sections[0].regulars).toEqual(['10', '11']);
+  it('round-trips regulars (scoutids)', () => {
+    const cfg = { ...CONFIG, cfg: { ...CONFIG.cfg, regulars: ['10', '11'] } };
+    expect(mergeLwwConfig([encodeConfig(cfg)]).cfg.regulars).toEqual(['10', '11']);
   });
 
-  it('accepts optional per-section kids/permits defaults', () => {
-    const cfg = {
-      ...CONFIG,
-      cfg: {
-        ...CONFIG.cfg,
-        sections: [{ ...CONFIG.cfg.sections[0], k: 22, p: 2 }],
-      },
-    };
-    expect(mergeLwwConfig([encodeConfig(cfg)]).cfg.sections[0]).toMatchObject({ k: 22, p: 2 });
+  it('accepts optional kids/permits defaults', () => {
+    const cfg = { ...CONFIG, cfg: { ...CONFIG.cfg, k: 22, p: 2 } };
+    expect(mergeLwwConfig([encodeConfig(cfg)]).cfg).toMatchObject({ k: 22, p: 2 });
+  });
+
+  it('keeps unknown fields for forward-compatibility', () => {
+    const cfg = { ...CONFIG, cfg: { ...CONFIG.cfg, futureField: 'x' } };
+    expect(mergeLwwConfig([encodeConfig(cfg)]).cfg).toMatchObject({ futureField: 'x' });
+  });
+
+  it('treats a corrupt config cell as empty', () => {
+    expect(mergeLwwConfig(['{not json'])).toBeNull();
+    expect(parseConfigCell('not json')).toBeNull();
   });
 });

--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -37,18 +37,31 @@ import {
 import databaseService from '../../../../shared/services/storage/database.js';
 import { CurrentActiveTermsService } from '../../../../shared/services/storage/currentActiveTermsService.js';
 import {
-  discoverRotaRecord,
-  loadRota,
-  prefillRegulars,
-  writeSignup,
-  writeSessionMeta,
+  assembleGroupConfig,
+  assembleRotaGroup,
   assignSignup,
+  discoverRotaRecords,
+  findHostSection,
+  loadRota,
+  loadRotaGroup,
+  prefillRegulars,
+  writeSessionMeta,
+  writeSignup,
 } from '../rotaService.js';
 import { SIGNUP_STATUS } from '../rotaEncoding.js';
 
 const HOST_SECTION = { sectionid: 900, sectionname: 'Adults', section: 'adults' };
 const OTHER_SECTION = { sectionid: 901, sectionname: 'Cubs', section: 'cubs' };
 const TOKEN = 'tok';
+
+const DESCRIPTOR = {
+  sectionName: 'Cubs',
+  seasonBucket: 'Summer 2026',
+  sectionId: '49097',
+  termId: '924956',
+  recordId: 777,
+  hostSection: HOST_SECTION,
+};
 
 const STRUCTURE = {
   config: JSON.stringify([
@@ -93,43 +106,76 @@ beforeEach(() => {
   CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: 'T1' });
 });
 
-describe('discoverRotaRecord', () => {
-  it('finds the rota record across the user sections', async () => {
-    getFlexiRecords.mockImplementation(async (sectionId) =>
-      sectionId === HOST_SECTION.sectionid
-        ? { items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] }
-        : { items: [{ name: 'Viking Event Mgmt', extraid: 1 }] },
-    );
-
-    const result = await discoverRotaRecord(2026, TOKEN);
-    expect(result).toEqual({ hostSection: HOST_SECTION, recordId: 777 });
+describe('findHostSection', () => {
+  it('finds the Adults section by name', () => {
+    expect(findHostSection([OTHER_SECTION, HOST_SECTION])).toBe(HOST_SECTION);
   });
 
-  it('returns null when no section has the record', async () => {
-    getFlexiRecords.mockResolvedValue({ items: [] });
-    expect(await discoverRotaRecord(2026, TOKEN)).toBeNull();
+  it('returns null when no section looks like Adults', () => {
+    expect(findHostSection([OTHER_SECTION])).toBeNull();
+    expect(findHostSection([])).toBeNull();
+    expect(findHostSection(undefined)).toBeNull();
   });
+});
 
-  it('skips sections whose flexi list read fails', async () => {
-    getFlexiRecords.mockImplementation(async (sectionId) => {
-      if (sectionId === OTHER_SECTION.sectionid) {
-        throw new Error('boom');
-      }
-      return { items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] };
+describe('discoverRotaRecords', () => {
+  it('makes ONE getFlexiRecords call on the host section when Adults exists', async () => {
+    getFlexiRecords.mockResolvedValue({
+      items: [{ name: 'Viking Water Rota Cubs Summer 2026 [49097.924956]', extraid: 777 }],
     });
 
-    const result = await discoverRotaRecord(2026, TOKEN);
-    expect(result?.recordId).toBe(777);
+    const result = await discoverRotaRecords(TOKEN);
+
+    expect(getFlexiRecords).toHaveBeenCalledTimes(1);
+    expect(getFlexiRecords).toHaveBeenCalledWith(HOST_SECTION.sectionid, TOKEN, 'n', false, 0);
+    expect(result).toEqual([{
+      sectionName: 'Cubs', seasonBucket: 'Summer 2026', sectionId: '49097', termId: '924956',
+      recordId: 777, hostSection: HOST_SECTION,
+    }]);
+  });
+
+  it('falls back to scanning every section when no Adults section is visible', async () => {
+    databaseService.getSections.mockResolvedValue([OTHER_SECTION]);
+    getFlexiRecords.mockResolvedValue({
+      items: [{ name: 'Viking Water Rota Cubs Summer 2026 [49097.924956]', extraid: 777 }],
+    });
+
+    const result = await discoverRotaRecords(TOKEN);
+
+    expect(getFlexiRecords).toHaveBeenCalledWith(OTHER_SECTION.sectionid, TOKEN, 'n', false, 0);
+    expect(result).toHaveLength(1);
+  });
+
+  it('ignores non-rota names', async () => {
+    getFlexiRecords.mockResolvedValue({
+      items: [{ name: 'Viking Event Mgmt', extraid: 1 }, { name: 'Viking Water Rota 2026', extraid: 2 }],
+    });
+
+    expect(await discoverRotaRecords(TOKEN)).toEqual([]);
+  });
+
+  it('dedupes same-identity duplicates by NUMERIC lowest extraid', async () => {
+    getFlexiRecords.mockResolvedValue({
+      items: [
+        { name: 'Viking Water Rota Cubs Summer 2026 [49097.924956]', extraid: 10 },
+        { name: 'Viking Water Rota Cubs Summer 2026 [49097.924956]', extraid: 9 },
+      ],
+    });
+
+    const result = await discoverRotaRecords(TOKEN);
+    expect(result).toHaveLength(1);
+    expect(result[0].recordId).toBe(9);
+  });
+
+  it('threads priority into the flexi-list read', async () => {
+    getFlexiRecords.mockResolvedValue({ items: [] });
+    await discoverRotaRecords(TOKEN, 5);
+    expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 5);
   });
 });
 
 describe('loadRota', () => {
   beforeEach(() => {
-    getFlexiRecords.mockImplementation(async (sectionId) =>
-      sectionId === HOST_SECTION.sectionid
-        ? { items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] }
-        : { items: [] },
-    );
     getFlexiStructure.mockResolvedValue(STRUCTURE);
   });
 
@@ -145,10 +191,13 @@ describe('loadRota', () => {
       { scoutid: 11, firstname: 'Alice', lastname: 'Smith', f_1: '', f_2: '' },
     ]));
 
-    const rota = await loadRota(2026, TOKEN);
+    const rota = await loadRota(DESCRIPTOR, TOKEN);
 
     expect(rota.recordId).toBe(777);
     expect(rota.termId).toBe('T1');
+    expect(rota.sectionId).toBe('49097');
+    expect(rota.planningTermId).toBe('924956');
+    expect(rota.seasonBucket).toBe('Summer 2026');
     expect(rota.config.cfg.start).toBe('2026-06-01');
     expect(rota.sessions).toHaveLength(1);
     expect(rota.sessions[0]).toMatchObject({
@@ -169,14 +218,32 @@ describe('loadRota', () => {
     expect(rota.sectionNames).toEqual({ '900': 'Adults', '901': 'Cubs' });
   });
 
+  it('resolves the host read-termid once and threads it consistently into every read/cache call', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: CONFIG_CELL, f_2: '' },
+    ]));
+
+    await loadRota(DESCRIPTOR, TOKEN);
+
+    expect(CurrentActiveTermsService.getCurrentActiveTerm).toHaveBeenCalledWith(HOST_SECTION.sectionid);
+    expect(getFlexiStructure).toHaveBeenCalledWith(777, 900, 'T1', TOKEN, false, 0);
+    expect(getSingleFlexiRecord).toHaveBeenCalledWith(777, 900, 'T1', TOKEN, 0);
+    expect(databaseService.saveFlexiData).toHaveBeenCalledWith(777, 900, 'T1', expect.any(Array));
+  });
+
+  it('errors cleanly when no host term is cached', async () => {
+    CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue(null);
+    await expect(loadRota(DESCRIPTOR, TOKEN)).rejects.toThrow(/No active term/);
+    expect(getFlexiStructure).not.toHaveBeenCalled();
+  });
+
   it('threads the priority option into every flexi read (deep-link fast path)', async () => {
     getSingleFlexiRecord.mockResolvedValue(gridWith([
       { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: CONFIG_CELL, f_2: '' },
     ]));
 
-    await loadRota(2026, TOKEN, { priority: 5 });
+    await loadRota(DESCRIPTOR, TOKEN, { priority: 5 });
 
-    expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 5);
     expect(getFlexiStructure).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, false, 5);
     expect(getSingleFlexiRecord).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, 5);
   });
@@ -186,9 +253,8 @@ describe('loadRota', () => {
       { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: CONFIG_CELL, f_2: '' },
     ]));
 
-    await loadRota(2026, TOKEN);
+    await loadRota(DESCRIPTOR, TOKEN);
 
-    expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 0);
     expect(getFlexiStructure).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, false, 0);
     expect(getSingleFlexiRecord).toHaveBeenLastCalledWith(777, 900, 'T1', TOKEN, 0);
   });
@@ -209,7 +275,7 @@ describe('loadRota', () => {
       { scoutid: 11, photo_guid: 'def-456' },
     ]);
 
-    const rota = await loadRota(2026, TOKEN);
+    const rota = await loadRota(DESCRIPTOR, TOKEN);
 
     expect(databaseService.getMembers).toHaveBeenCalledWith([900]);
     expect(rota.members).toEqual([
@@ -234,7 +300,7 @@ describe('loadRota', () => {
       { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: configWithOff, f_2: '' },
     ]));
 
-    const rota = await loadRota(2026, TOKEN);
+    const rota = await loadRota(DESCRIPTOR, TOKEN);
     // f_2 column session (14 Jul) + config-only not-on-water session (21 Jul)
     expect(rota.sessions).toHaveLength(2);
     const configOnly = rota.sessions.find((s) => s.fieldId === null);
@@ -247,15 +313,10 @@ describe('loadRota', () => {
       { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: '', f_2: JSON.stringify({ s: 'I', sat: '2026-07-02T10:00:00Z' }) },
     ]));
 
-    const rota = await loadRota(2026, TOKEN);
+    const rota = await loadRota(DESCRIPTOR, TOKEN);
     expect(rota.config).toBeNull();
     expect(rota.sessions[0].signups).toHaveLength(1);
     expect(rota.configFieldId).toBe('f_1');
-  });
-
-  it('returns null when no rota record exists', async () => {
-    getFlexiRecords.mockResolvedValue({ items: [] });
-    expect(await loadRota(2026, TOKEN)).toBeNull();
   });
 
   it('throws when the record structure is missing RotaConfig', async () => {
@@ -264,7 +325,112 @@ describe('loadRota', () => {
     });
     getSingleFlexiRecord.mockResolvedValue(gridWith([]));
 
-    await expect(loadRota(2026, TOKEN)).rejects.toThrow(/RotaConfig/);
+    await expect(loadRota(DESCRIPTOR, TOKEN)).rejects.toThrow(/RotaConfig/);
+  });
+});
+
+describe('assembleGroupConfig', () => {
+  it('aggregates N records into sections[] and a merged sessions{} map', () => {
+    const records = [
+      { config: { cfg: { sid: '10', sname: 'Beavers', act: 'Kayaking', st: '18:00', en: '19:00', start: '2026-06-01', end: '2026-07-31', sessions: { S_20260603_10: { pt: 'x' } } } } },
+      { config: { cfg: { sid: '20', sname: 'Cubs', act: 'Canoeing', st: '18:15', en: '19:30', start: '2026-05-15', end: '2026-08-31', sessions: { S_20260605_20: { pt: 'y' } } } } },
+    ];
+
+    const assembled = assembleGroupConfig(records);
+    expect(assembled.cfg.sections).toEqual([
+      { sid: '10', sname: 'Beavers', act: 'Kayaking', st: '18:00', en: '19:00', k: undefined, p: undefined, regulars: [] },
+      { sid: '20', sname: 'Cubs', act: 'Canoeing', st: '18:15', en: '19:30', k: undefined, p: undefined, regulars: [] },
+    ]);
+    expect(assembled.cfg.sessions).toEqual({ S_20260603_10: { pt: 'x' }, S_20260605_20: { pt: 'y' } });
+    expect(assembled.cfg.start).toBe('2026-05-15');
+    expect(assembled.cfg.end).toBe('2026-08-31');
+  });
+
+  it('skips configless records', () => {
+    const records = [
+      { config: null },
+      { config: { cfg: { sid: '20', sname: 'Cubs', act: 'Canoeing', st: '18:15', en: '19:30' } } },
+    ];
+    expect(assembleGroupConfig(records).cfg.sections).toHaveLength(1);
+  });
+
+  it('returns null when every record is configless', () => {
+    expect(assembleGroupConfig([{ config: null }, { config: null }])).toBeNull();
+  });
+});
+
+describe('assembleRotaGroup', () => {
+  it('gives every aggregated session a record back-reference and takes members from the first record', () => {
+    const recordA = {
+      hostSection: HOST_SECTION,
+      config: { cfg: { sid: '10', sname: 'Beavers', act: 'Kayaking', st: '18:00', en: '19:00' } },
+      sessions: [{ fieldId: 'f_2', date: '2026-06-03', sectionId: '10' }],
+      members: [{ scoutid: '1', name: 'A' }],
+      sectionNames: { 10: 'Beavers' },
+    };
+    const recordB = {
+      hostSection: HOST_SECTION,
+      config: null,
+      sessions: [{ fieldId: 'f_3', date: '2026-06-05', sectionId: '20' }],
+      members: [{ scoutid: '1', name: 'A' }],
+      sectionNames: { 10: 'Beavers', 20: 'Cubs' },
+    };
+
+    const group = assembleRotaGroup('Summer 2026', [recordA, recordB]);
+    expect(group.seasonBucket).toBe('Summer 2026');
+    expect(group.hostSection).toBe(HOST_SECTION);
+    expect(group.records).toEqual([recordA, recordB]);
+    expect(group.sessions).toEqual([
+      { fieldId: 'f_2', date: '2026-06-03', sectionId: '10', record: recordA },
+      { fieldId: 'f_3', date: '2026-06-05', sectionId: '20', record: recordB },
+    ]);
+    expect(group.members).toEqual([{ scoutid: '1', name: 'A' }]);
+    expect(group.config.cfg.sections).toHaveLength(1);
+  });
+});
+
+describe('loadRotaGroup', () => {
+  beforeEach(() => {
+    getFlexiStructure.mockResolvedValue(STRUCTURE);
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, firstname: 'Simon', lastname: 'Clark', f_1: CONFIG_CELL, f_2: '' },
+    ]));
+  });
+
+  it('filters discovered records by season bucket and aggregates them', async () => {
+    getFlexiRecords.mockResolvedValue({
+      items: [
+        { name: 'Viking Water Rota Cubs Summer 2026 [49097.924956]', extraid: 777 },
+        { name: 'Viking Water Rota Scouts Autumn 2026 [49099.900001]', extraid: 778 },
+      ],
+    });
+
+    const group = await loadRotaGroup('Summer 2026', TOKEN);
+    expect(group.seasonBucket).toBe('Summer 2026');
+    expect(group.records).toHaveLength(1);
+    expect(group.records[0].recordId).toBe(777);
+  });
+
+  it('returns null when the bucket has no records', async () => {
+    getFlexiRecords.mockResolvedValue({ items: [] });
+    expect(await loadRotaGroup('Summer 2026', TOKEN)).toBeNull();
+  });
+
+  it('fails the whole group load when a single record read fails', async () => {
+    getFlexiRecords.mockResolvedValue({
+      items: [
+        { name: 'Viking Water Rota Cubs Summer 2026 [49097.924956]', extraid: 777 },
+        { name: 'Viking Water Rota Scouts Summer 2026 [49099.900001]', extraid: 778 },
+      ],
+    });
+    getFlexiStructure.mockImplementation(async (recordId) => {
+      if (recordId === 778) {
+        throw new Error('boom');
+      }
+      return STRUCTURE;
+    });
+
+    await expect(loadRotaGroup('Summer 2026', TOKEN)).rejects.toThrow(/boom/);
   });
 });
 
@@ -361,6 +527,36 @@ describe('writeSignup', () => {
     ]);
 
     expect(order).toEqual(['fetch', 'update', 'fetch', 'update']);
+  });
+
+  it('routes a write to the session\'s owning record and the lock still serializes across records', async () => {
+    // Aggregated sessions carry a `record` back-reference (assembleRotaGroup);
+    // callers pass session.record as the `rota` argument so the write lands
+    // on the record that actually owns the column.
+    const recordA = { hostSection: HOST_SECTION, recordId: 777, termId: 'T1' };
+    const recordB = { hostSection: HOST_SECTION, recordId: 888, termId: 'T1' };
+    const sessionA = { fieldId: 'f_2', record: recordA };
+    const sessionB = { fieldId: 'f_2', record: recordB };
+
+    const order = [];
+    getSingleFlexiRecord.mockImplementation(async (recordId) => {
+      order.push(`fetch-${recordId}`);
+      return gridWith([{ scoutid: 10, f_2: '' }]);
+    });
+    updateFlexiRecord.mockImplementation(async (_sectionid, _scoutid, recordId) => {
+      order.push(`update-${recordId}`);
+      return { ok: true };
+    });
+
+    await Promise.all([
+      writeSignup({ rota: sessionA.record, fieldId: sessionA.fieldId, scoutid: 10, status: SIGNUP_STATUS.IN, token: TOKEN }),
+      writeSignup({ rota: sessionB.record, fieldId: sessionB.fieldId, scoutid: 10, status: SIGNUP_STATUS.IN, token: TOKEN }),
+    ]);
+
+    expect(updateFlexiRecord.mock.calls.map((call) => call[2])).toEqual(expect.arrayContaining([777, 888]));
+    // The module-level lock is per-module, not per-record — it serializes
+    // even though the two writes target different records.
+    expect(order).toEqual(['fetch-777', 'update-777', 'fetch-888', 'update-888']);
   });
 });
 
@@ -480,5 +676,34 @@ describe('prefillRegulars', () => {
     });
     expect(multiUpdateFlexiRecord).toHaveBeenCalledTimes(1);
     expect(multiUpdateFlexiRecord.mock.calls[0][3]).toBe('f_9');
+  });
+
+  it('throttles 300ms between successive multi-update calls', async () => {
+    vi.useFakeTimers();
+    try {
+      multiUpdateFlexiRecord.mockResolvedValue({ ok: true });
+      const promise = prefillRegulars({
+        rota,
+        regularsBySection: { '49097': ['10', '11'], '49099': ['12'] },
+        token: TOKEN,
+      });
+
+      // First call fires without any throttle delay.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(multiUpdateFlexiRecord).toHaveBeenCalledTimes(1);
+
+      // Second call is held back until the 300ms throttle elapses.
+      await vi.advanceTimersByTimeAsync(299);
+      expect(multiUpdateFlexiRecord).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(multiUpdateFlexiRecord).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(300);
+      const result = await promise;
+      expect(multiUpdateFlexiRecord).toHaveBeenCalledTimes(3);
+      expect(result.filled).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -62,9 +62,9 @@ const CONFIG_CELL = JSON.stringify({
   at: '2026-06-01T09:00:00Z',
   by: 'Simon Clark',
   cfg: {
+    sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30',
     start: '2026-06-01',
     end: '2026-08-31',
-    sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
   },
 });
 
@@ -225,8 +225,8 @@ describe('loadRota', () => {
     const configWithOff = JSON.stringify({
       v: 1, at: '2026-06-01T09:00:00Z', by: 'Simon Clark',
       cfg: {
+        sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30',
         start: '2026-06-01', end: '2026-08-31',
-        sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
         sessions: { S_20260721_49097: { c: 1 } },
       },
     });

--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -198,6 +198,15 @@ describe('discoverRotaRecords', () => {
       recordId: 55, hostSection: otherSection,
     }]);
   });
+
+  it('rethrows when every section fails during the scan fallback, instead of silently reporting no rota', async () => {
+    const otherSection = { sectionid: 902, sectionname: 'Scouts', section: 'scouts' };
+    databaseService.getSections.mockResolvedValue([OTHER_SECTION, otherSection]);
+    getFlexiRecords.mockRejectedValue(new Error('OSM 500'));
+
+    await expect(discoverRotaRecords(TOKEN)).rejects.toThrow(/OSM 500/);
+    expect(getFlexiRecords).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('loadRota', () => {
@@ -662,6 +671,76 @@ describe('writeSessionMeta', () => {
     expect(written.m.st).toBe('19:00');
     expect(written.m.by).toBe('Simon Clark');
   });
+
+  it('falls back to the caller-supplied base when the column is virgin (no live winner), preserving the base fields the patch does not touch', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_2: '' }]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeSessionMeta({
+      rota,
+      fieldId: 'f_2',
+      scoutid: 10,
+      by: 'Simon Clark',
+      metaPatch: { n: 'note' },
+      base: { act: 'Rafting', st: '18:00', en: '19:00', k: 10, p: 2 },
+      token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.m.v).toBe(1);
+    expect(written.m.act).toBe('Rafting');
+    expect(written.m.st).toBe('18:00');
+    expect(written.m.en).toBe('19:00');
+    expect(written.m.k).toBe(10);
+    expect(written.m.p).toBe(2);
+    expect(written.m.n).toBe('note');
+  });
+
+  it('falls back to SESSION_META_DEFAULTS when the column is virgin and no base is supplied (pinned prior behaviour)', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_2: '' }]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeSessionMeta({
+      rota,
+      fieldId: 'f_2',
+      scoutid: 10,
+      by: 'Simon Clark',
+      metaPatch: { n: 'note' },
+      token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.m.v).toBe(1);
+    expect(written.m.act).toBe('On the water');
+    expect(written.m.st).toBe('18:30');
+    expect(written.m.en).toBe('20:00');
+    expect(written.m.k).toBe(0);
+    expect(written.m.p).toBe(0);
+    expect(written.m.n).toBe('note');
+  });
+
+  it('ignores the base when a live winner already exists — the winner still wins', async () => {
+    const rivalWinner = JSON.stringify({ m: { ...META, v: 4, act: 'Canoeing' } });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, f_2: '' },
+      { scoutid: 11, f_2: rivalWinner },
+    ]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeSessionMeta({
+      rota,
+      fieldId: 'f_2',
+      scoutid: 10,
+      by: 'Simon Clark',
+      metaPatch: { n: 'note' },
+      base: { act: 'Rafting', st: '18:00', en: '19:00', k: 10, p: 2 },
+      token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.m.v).toBe(5);
+    expect(written.m.act).toBe('Canoeing');
+  });
 });
 
 describe('writeConfig', () => {
@@ -724,6 +803,17 @@ describe('writeConfig', () => {
       S_20260602_49097: { c: 1 },
       S_20260609_49097: { pt: 'New title' },
     });
+  });
+
+  it('throws a clear error in patch mode when there is no live config candidate to patch, instead of a cryptic schema error', async () => {
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_1: '' }]));
+
+    await expect(
+      writeConfig({
+        rota, configFieldId: 'f_1', scoutid: 10, by: 'Simon Clark', cfg: { act: 'Canoeing' }, token: TOKEN,
+      }),
+    ).rejects.toThrow(/no existing config found/);
+    expect(updateFlexiRecord).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -172,6 +172,25 @@ describe('discoverRotaRecords', () => {
     await discoverRotaRecords(TOKEN, 5);
     expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 5);
   });
+
+  it('skips a section whose flexi-list read fails during the scan fallback, instead of failing discovery entirely', async () => {
+    const otherSection = { sectionid: 902, sectionname: 'Scouts', section: 'scouts' };
+    databaseService.getSections.mockResolvedValue([OTHER_SECTION, otherSection]);
+    getFlexiRecords.mockImplementation(async (sectionId) => {
+      if (sectionId === OTHER_SECTION.sectionid) {
+        throw new Error('OSM 500');
+      }
+      return { items: [{ name: 'Viking Water Rota Scouts Summer 2026 [902.924956]', extraid: 55 }] };
+    });
+
+    const result = await discoverRotaRecords(TOKEN);
+
+    expect(getFlexiRecords).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([{
+      sectionName: 'Scouts', seasonBucket: 'Summer 2026', sectionId: '902', termId: '924956',
+      recordId: 55, hostSection: otherSection,
+    }]);
+  });
 });
 
 describe('loadRota', () => {

--- a/src/features/water-rota/services/__tests__/rotaService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaService.test.js
@@ -45,6 +45,7 @@ import {
   loadRota,
   loadRotaGroup,
   prefillRegulars,
+  writeConfig,
   writeSessionMeta,
   writeSignup,
 } from '../rotaService.js';
@@ -171,6 +172,12 @@ describe('discoverRotaRecords', () => {
     getFlexiRecords.mockResolvedValue({ items: [] });
     await discoverRotaRecords(TOKEN, 5);
     expect(getFlexiRecords).toHaveBeenCalledWith(expect.anything(), TOKEN, 'n', false, 5);
+  });
+
+  it('rethrows when the host-only scan\'s single flexi-list read fails, instead of silently reporting no rota', async () => {
+    getFlexiRecords.mockRejectedValue(new Error('OSM 500'));
+
+    await expect(discoverRotaRecords(TOKEN)).rejects.toThrow(/OSM 500/);
   });
 
   it('skips a section whose flexi-list read fails during the scan fallback, instead of failing discovery entirely', async () => {
@@ -615,7 +622,7 @@ describe('writeSessionMeta', () => {
       fieldId: 'f_2',
       scoutid: 10,
       by: 'Simon Clark',
-      fields: { act: 'Rafting', st: '18:00', en: '19:15', k: 20, p: 2, c: 0 },
+      metaPatch: { act: 'Rafting', st: '18:00', en: '19:15', k: 20, p: 2, c: 0 },
       token: TOKEN,
     });
 
@@ -625,6 +632,98 @@ describe('writeSessionMeta', () => {
     expect(written.m.by).toBe('Simon Clark');
     expect(written.s).toBe('B');
     expect(written.sat).toBe('2026-07-01T08:00:00Z');
+  });
+
+  it('merges only the patched fields onto the live winner, so a concurrent co-leader\'s edit to an untouched field survives', async () => {
+    // The caller loaded v5 with act:'Kayaking'; by the time this write's lock
+    // turn comes, a co-leader has already landed v6 with act:'Canoeing'. The
+    // caller only meant to change the start time.
+    const rivalWinner = JSON.stringify({
+      m: { ...META, v: 6, act: 'Canoeing', by: 'Rival Leader' },
+    });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([
+      { scoutid: 10, f_2: '' },
+      { scoutid: 11, f_2: rivalWinner },
+    ]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeSessionMeta({
+      rota,
+      fieldId: 'f_2',
+      scoutid: 10,
+      by: 'Simon Clark',
+      metaPatch: { st: '19:00' },
+      token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.m.v).toBe(7);
+    expect(written.m.act).toBe('Canoeing');
+    expect(written.m.st).toBe('19:00');
+    expect(written.m.by).toBe('Simon Clark');
+  });
+});
+
+describe('writeConfig', () => {
+  const rota = { hostSection: HOST_SECTION, recordId: 777, termId: 'T1' };
+  const baseCfg = {
+    sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30',
+    start: '2026-06-01', end: '2026-08-31', regulars: ['10'],
+  };
+
+  it('replace mode fully replaces the winner\'s cfg', async () => {
+    const winnerCell = JSON.stringify({ v: 3, at: '2026-06-01T09:00:00Z', by: 'Old', cfg: baseCfg });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_1: winnerCell }]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    const replacement = { sid: '49097', sname: 'Cubs', act: 'Rafting', st: '18:00', en: '19:00' };
+    await writeConfig({
+      rota, configFieldId: 'f_1', scoutid: 10, by: 'Simon Clark', cfg: replacement, replace: true, token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.v).toBe(4);
+    expect(written.cfg).toEqual(replacement);
+  });
+
+  it('patch mode shallow-merges the caller\'s changed keys onto the live winner, preserving fields the caller did not touch', async () => {
+    const winnerCell = JSON.stringify({ v: 3, at: '2026-06-01T09:00:00Z', by: 'Old', cfg: baseCfg });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_1: winnerCell }]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeConfig({
+      rota, configFieldId: 'f_1', scoutid: 10, by: 'Simon Clark', cfg: { act: 'Canoeing' }, token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.v).toBe(4);
+    expect(written.cfg.act).toBe('Canoeing');
+    // Untouched fields (including a concurrent editor's regulars change)
+    // survive the merge instead of being wiped by a stale-base replace.
+    expect(written.cfg.regulars).toEqual(['10']);
+    expect(written.cfg.sid).toBe('49097');
+  });
+
+  it('patch mode merges sessions key-wise (winner.sessions ⊕ patch.sessions)', async () => {
+    const winnerCfg = { ...baseCfg, sessions: { S_20260602_49097: { c: 1 } } };
+    const winnerCell = JSON.stringify({ v: 3, at: '2026-06-01T09:00:00Z', by: 'Old', cfg: winnerCfg });
+    getSingleFlexiRecord.mockResolvedValue(gridWith([{ scoutid: 10, f_1: winnerCell }]));
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    await writeConfig({
+      rota,
+      configFieldId: 'f_1',
+      scoutid: 10,
+      by: 'Simon Clark',
+      cfg: { sessions: { S_20260609_49097: { pt: 'New title' } } },
+      token: TOKEN,
+    });
+
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.cfg.sessions).toEqual({
+      S_20260602_49097: { c: 1 },
+      S_20260609_49097: { pt: 'New title' },
+    });
   });
 });
 

--- a/src/features/water-rota/services/__tests__/rotaSetupService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaSetupService.test.js
@@ -232,7 +232,11 @@ describe('syncRotaWithProgramme', () => {
     getFlexiStructure.mockResolvedValue({
       config: JSON.stringify([{ id: 'f_9', name: 'RotaConfig' }]),
     });
-    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: '' }] });
+    // Patch mode merges onto the LIVE winner re-fetched inside the lock — a
+    // record that already has a plan config (guaranteed by syncRotaWithProgramme's
+    // own guard above) has a real config cell here, not an empty one.
+    const liveConfigCell = JSON.stringify({ v: 1, at: '2026-06-01T09:00:00Z', by: 'Setup', cfg: rota.config.cfg });
+    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: liveConfigCell }] });
     updateFlexiRecord.mockResolvedValue({ ok: true });
 
     const result = await syncRotaWithProgramme({ rota, token: 'tok', scoutid: 900, by: 'Simon Clark' });
@@ -261,7 +265,8 @@ describe('syncRotaWithProgramme', () => {
     getFlexiStructure.mockResolvedValue({
       config: JSON.stringify([{ id: 'f_9', name: 'RotaConfig' }]),
     });
-    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: '' }] });
+    const liveConfigCell = JSON.stringify({ v: 1, at: '2026-06-01T09:00:00Z', by: 'Setup', cfg: rotaWithState.config.cfg });
+    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: liveConfigCell }] });
     updateFlexiRecord.mockResolvedValue({ ok: true });
 
     const result = await syncRotaWithProgramme({ rota: rotaWithState, token: 'tok', scoutid: 900, by: 'Simon Clark' });
@@ -326,6 +331,36 @@ describe('syncRotaWithProgramme', () => {
     expect(result.titlesSkippedNoIdentity).toBe(true);
     expect(result.titlesUpdated).toBe(0);
     expect(updateFlexiRecord).not.toHaveBeenCalled();
+  });
+
+  it('patch mode preserves a concurrent edit to the live cfg (regulars) while adding the title patch', async () => {
+    fetchProgrammeMeetings.mockResolvedValue([
+      { date: '2026-06-02', startTime: null, endTime: null, title: 'Cubs Kayaking' },
+      { date: '2026-06-09', startTime: null, endTime: null, title: 'Cubs Canoe Trip' },
+    ]);
+    getFlexiStructure.mockResolvedValue({
+      config: JSON.stringify([{ id: 'f_9', name: 'RotaConfig' }]),
+    });
+    // A concurrent editor (e.g. changed regulars) already landed a newer
+    // RotaConfig candidate on the live grid, after `rota` (used here to
+    // compute the title patch) was loaded — the sync write must not clobber it.
+    const liveWinnerCell = JSON.stringify({
+      v: 3, at: '2026-07-01T09:00:00Z', by: 'Other Leader',
+      cfg: { ...rota.config.cfg, regulars: ['77'] },
+    });
+    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: liveWinnerCell }] });
+    updateFlexiRecord.mockResolvedValue({ ok: true });
+
+    const result = await syncRotaWithProgramme({ rota, token: 'tok', scoutid: 900, by: 'Simon Clark' });
+
+    expect(result.titlesUpdated).toBe(2);
+    const written = JSON.parse(updateFlexiRecord.mock.calls[0][4]);
+    expect(written.v).toBe(4);
+    expect(written.cfg.regulars).toEqual(['77']);
+    expect(written.cfg.sessions).toEqual({
+      S_20260602_49097: { pt: 'Cubs Kayaking' },
+      S_20260609_49097: { pt: 'Cubs Canoe Trip' },
+    });
   });
 
   it('reports a failed programme fetch as a failed section and does not orphan its existing sessions', async () => {

--- a/src/features/water-rota/services/__tests__/rotaSetupService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaSetupService.test.js
@@ -79,6 +79,8 @@ describe('createOrCompleteRota', () => {
     const { section, template, termId } = createOrCompleteFlexiRecord.mock.calls[0][0];
     expect(section).toBe(HOST_SECTION);
     expect(termId).toBe('T1');
+    // STOPGAP naming (pre-WP3, see createOrCompleteRota's JSDoc): still the
+    // plain year-based literal, not the new per-section buildRotaRecordName.
     expect(template.name).toBe('Viking Water Rota 2026');
     expect(template.fields).toEqual(['RotaConfig', 'S_20260602_49097', 'S_20260605_49099']);
   });
@@ -110,9 +112,9 @@ describe('writeRotaConfig', () => {
     updateFlexiRecord.mockResolvedValue({ ok: true });
 
     const cfg = {
+      sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30',
       start: '2026-06-01',
       end: '2026-08-31',
-      sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
     };
 
     await writeRotaConfig({
@@ -160,9 +162,9 @@ describe('syncRotaWithProgramme', () => {
     termId: 'T1',
     config: {
       cfg: {
+        sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30',
         start: '2026-06-01',
         end: '2026-08-31',
-        sections: [{ sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' }],
       },
     },
     sessions: [

--- a/src/features/water-rota/services/__tests__/rotaSetupService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaSetupService.test.js
@@ -36,7 +36,6 @@ vi.mock('../programmeService.js', () => ({
 
 import { createOrCompleteFlexiRecord } from '../../../flexi-records/services/flexiRecordCreationService.js';
 import {
-  getFlexiRecords,
   getFlexiStructure,
   getSingleFlexiRecord,
   updateFlexiRecord,
@@ -54,9 +53,10 @@ import {
 
 const HOST_SECTION = { sectionid: 900, sectionname: 'Adults', section: 'adults' };
 
+const RECORD = { sectionId: '49097', sectionName: 'Cubs', termId: '924956', seasonBucket: 'Summer 2026' };
+
 const SESSIONS = [
   { date: '2026-06-02', sectionId: '49097', sectionName: 'Cubs', startTime: '18:15', endTime: '19:30', activity: 'Kayaking', title: null },
-  { date: '2026-06-05', sectionId: '49099', sectionName: 'Scouts', startTime: '19:00', endTime: '20:30', activity: 'Bell boats', title: null },
 ];
 
 beforeEach(() => {
@@ -64,13 +64,13 @@ beforeEach(() => {
 });
 
 describe('createOrCompleteRota', () => {
-  it('builds a template with the config column plus one column per session', async () => {
+  it('builds a template with the config column plus one column per session, under the per-section record name', async () => {
     createOrCompleteFlexiRecord.mockResolvedValue({ success: true, flexirecordid: 777 });
 
     const result = await createOrCompleteRota({
       hostSection: HOST_SECTION,
-      year: 2026,
-      termId: 'T1',
+      hostTermId: 'HT1',
+      record: RECORD,
       sessions: SESSIONS,
       token: 'tok',
     });
@@ -78,21 +78,21 @@ describe('createOrCompleteRota', () => {
     expect(result.flexirecordid).toBe(777);
     const { section, template, termId } = createOrCompleteFlexiRecord.mock.calls[0][0];
     expect(section).toBe(HOST_SECTION);
-    expect(termId).toBe('T1');
-    // STOPGAP naming (pre-WP3, see createOrCompleteRota's JSDoc): still the
-    // plain year-based literal, not the new per-section buildRotaRecordName.
-    expect(template.name).toBe('Viking Water Rota 2026');
-    expect(template.fields).toEqual(['RotaConfig', 'S_20260602_49097', 'S_20260605_49099']);
+    // hostTermId drives the creation orchestrator's structure reads only —
+    // it is never part of the record's name/identity.
+    expect(termId).toBe('HT1');
+    expect(template.name).toBe('Viking Water Rota Cubs Summer 2026 [49097.924956]');
+    expect(template.fields).toEqual(['RotaConfig', 'S_20260602_49097']);
   });
 
   it('surfaces partial failure results untouched so callers can retry', async () => {
-    const partial = { success: false, flexirecordid: 777, errors: [{ field: 'S_20260605_49099', error: 'boom' }] };
+    const partial = { success: false, flexirecordid: 777, errors: [{ field: 'S_20260602_49097', error: 'boom' }] };
     createOrCompleteFlexiRecord.mockResolvedValue(partial);
 
     const result = await createOrCompleteRota({
       hostSection: HOST_SECTION,
-      year: 2026,
-      termId: 'T1',
+      hostTermId: 'HT1',
+      record: RECORD,
       sessions: SESSIONS,
       token: 'tok',
     });
@@ -147,7 +147,7 @@ describe('writeRotaConfig', () => {
         termId: 'T1',
         scoutid: 10,
         by: 'Simon Clark',
-        cfg: { start: '2026-06-01', end: '2026-08-31', sections: [] },
+        cfg: { sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' },
         token: 'tok',
       }),
     ).rejects.toThrow(/RotaConfig column not found/);
@@ -156,10 +156,12 @@ describe('writeRotaConfig', () => {
 
 describe('syncRotaWithProgramme', () => {
   const rota = {
-    year: 2026,
     hostSection: HOST_SECTION,
     recordId: 777,
-    termId: 'T1',
+    termId: 'HT1',
+    sectionId: '49097',
+    planningTermId: '924956',
+    seasonBucket: 'Summer 2026',
     config: {
       cfg: {
         sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30',
@@ -173,8 +175,13 @@ describe('syncRotaWithProgramme', () => {
     ],
   };
 
-  beforeEach(() => {
-    CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: 'T1' });
+  it('fetches the programme under the record\'s own planning termId (not the section\'s current active term)', async () => {
+    fetchProgrammeMeetings.mockResolvedValue([]);
+
+    await syncRotaWithProgramme({ rota, token: 'tok' });
+
+    expect(fetchProgrammeMeetings).toHaveBeenCalledWith('49097', '924956', 'tok');
+    expect(CurrentActiveTermsService.getCurrentActiveTerm).not.toHaveBeenCalled();
   });
 
   it('appends columns for new meetings and reports vanished ones', async () => {
@@ -188,7 +195,11 @@ describe('syncRotaWithProgramme', () => {
 
     expect(result.added).toBe(1);
     expect(result.orphaned.map((column) => column.date)).toEqual(['2026-06-09']);
-    const { template } = createOrCompleteFlexiRecord.mock.calls[0][0];
+    const { template, termId } = createOrCompleteFlexiRecord.mock.calls[0][0];
+    // hostTermId (rota.termId), not the planning termId, drives the creation
+    // orchestrator's structure reads.
+    expect(termId).toBe('HT1');
+    expect(template.name).toBe('Viking Water Rota Cubs Summer 2026 [49097.924956]');
     expect(template.fields).toEqual(['RotaConfig', 'S_20260616_49097']);
   });
 
@@ -317,10 +328,9 @@ describe('syncRotaWithProgramme', () => {
     expect(updateFlexiRecord).not.toHaveBeenCalled();
   });
 
-  it('reports a section whose programme fetch fails as failed (not unchecked) and does not orphan it', async () => {
+  it('reports a failed programme fetch as a failed section and does not orphan its existing sessions', async () => {
     // A fetch error (e.g. expired token) is a real failure — its existing
-    // sessions must NOT be orphaned, and it must be distinguishable from the
-    // benign no-active-term case so the caller can raise an error.
+    // sessions must NOT be orphaned.
     fetchProgrammeMeetings.mockRejectedValue(new Error('OSM 500'));
 
     const result = await syncRotaWithProgramme({ rota, token: 'tok' });
@@ -332,31 +342,30 @@ describe('syncRotaWithProgramme', () => {
     expect(createOrCompleteFlexiRecord).not.toHaveBeenCalled();
   });
 
-  it('flags a section with no active term as unchecked (not failed) and does not orphan it', async () => {
-    CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: null });
-
-    const result = await syncRotaWithProgramme({ rota, token: 'tok' });
-
-    expect(result.orphaned).toEqual([]);
-    expect(result.uncheckedSections).toEqual(['49097']);
-    expect(result.failedSections).toEqual([]);
-  });
-
   it('throws without a plan config', async () => {
     await expect(syncRotaWithProgramme({ rota: { ...rota, config: null }, token: 'tok' })).rejects.toThrow(/config/);
   });
 });
 
 describe('activateWaterSession', () => {
-  const rota = { year: 2026, hostSection: HOST_SECTION, recordId: 777, termId: 'T1' };
+  const rota = {
+    hostSection: HOST_SECTION,
+    recordId: 777,
+    termId: 'HT1',
+    sectionId: '49097',
+    planningTermId: '924956',
+    seasonBucket: 'Summer 2026',
+    config: {
+      cfg: { sid: '49097', sname: 'Cubs', act: 'Kayaking', st: '18:15', en: '19:30' },
+    },
+  };
 
   beforeEach(() => {
     databaseService.getSections.mockResolvedValue([HOST_SECTION]);
     databaseService.getFlexiData.mockResolvedValue(null);
     databaseService.saveFlexiData.mockResolvedValue(undefined);
     databaseService.getMembers.mockResolvedValue([]);
-    CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: 'T1' });
-    getFlexiRecords.mockResolvedValue({ items: [{ name: 'Viking Water Rota 2026', extraid: 777 }] });
+    CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: 'HT1' });
     getFlexiStructure.mockResolvedValue({
       config: JSON.stringify([
         { id: 'f_1', name: 'RotaConfig' },
@@ -382,6 +391,10 @@ describe('activateWaterSession', () => {
       scoutid: 10,
       token: 'tok',
     });
+
+    const { template, termId } = createOrCompleteFlexiRecord.mock.calls[0][0];
+    expect(termId).toBe('HT1');
+    expect(template.name).toBe('Viking Water Rota Cubs Summer 2026 [49097.924956]');
 
     const [, , , columnid, value] = updateFlexiRecord.mock.calls[0];
     expect(columnid).toBe('f_2');
@@ -432,6 +445,23 @@ describe('activateWaterSession', () => {
       }),
     ).rejects.toThrow(/could not be confirmed/);
     expect(updateFlexiRecord).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cached section name when the rota has no config yet', async () => {
+    createOrCompleteFlexiRecord.mockResolvedValue({ success: true, flexirecordid: 777 });
+
+    await activateWaterSession({
+      rota: { ...rota, config: null, sectionNames: { '49097': 'Cubs' } },
+      date: '2026-07-14',
+      sectionId: '49097',
+      fields: { act: 'Kayaking', st: '18:15', en: '19:30', k: 24, p: 3 },
+      by: 'Simon Clark',
+      scoutid: 10,
+      token: 'tok',
+    });
+
+    const { template } = createOrCompleteFlexiRecord.mock.calls[0][0];
+    expect(template.name).toBe('Viking Water Rota Cubs Summer 2026 [49097.924956]');
   });
 });
 

--- a/src/features/water-rota/services/__tests__/rotaSetupService.test.js
+++ b/src/features/water-rota/services/__tests__/rotaSetupService.test.js
@@ -15,6 +15,7 @@ vi.mock('../../../../shared/services/api/api/index.js', () => ({
   getFlexiStructure: vi.fn(),
   getSingleFlexiRecord: vi.fn(),
   updateFlexiRecord: vi.fn(),
+  multiUpdateFlexiRecord: vi.fn(),
 }));
 
 vi.mock('../../../../shared/services/storage/database.js', () => ({
@@ -39,6 +40,7 @@ import {
   getFlexiStructure,
   getSingleFlexiRecord,
   updateFlexiRecord,
+  multiUpdateFlexiRecord,
 } from '../../../../shared/services/api/api/index.js';
 import databaseService from '../../../../shared/services/storage/database.js';
 import { CurrentActiveTermsService } from '../../../../shared/services/storage/currentActiveTermsService.js';
@@ -124,6 +126,9 @@ describe('writeRotaConfig', () => {
       scoutid: 10,
       by: 'Simon Clark',
       cfg,
+      // Matches RotaSetupWizard's real call: an initial write against a
+      // fresh grid (no live winner yet) must be a replace, not a patch.
+      replace: true,
       token: 'tok',
     });
 
@@ -203,6 +208,64 @@ describe('syncRotaWithProgramme', () => {
     expect(template.fields).toEqual(['RotaConfig', 'S_20260616_49097']);
   });
 
+  describe('regular pre-fill on sync', () => {
+    // rotaService.js is NOT mocked in this file — loadRota/prefillRegulars run
+    // for real against the mocked API/storage layer below, so a new session
+    // needs a fully decodable structure + grid for the post-create reload.
+    const rotaWithRegulars = {
+      ...rota,
+      config: { cfg: { ...rota.config.cfg, regulars: ['10'] } },
+    };
+    const liveConfigCell = JSON.stringify({
+      v: 1, at: '2026-06-01T09:00:00Z', by: 'Setup', cfg: rotaWithRegulars.config.cfg,
+    });
+
+    beforeEach(() => {
+      createOrCompleteFlexiRecord.mockResolvedValue({ success: true, flexirecordid: 777, errors: [] });
+      CurrentActiveTermsService.getCurrentActiveTerm.mockResolvedValue({ currentTermId: 'HT1' });
+      getFlexiStructure.mockResolvedValue({
+        config: JSON.stringify([
+          { id: 'f_9', name: 'RotaConfig' },
+          { id: 'f_2', name: 'S_20260602_49097' },
+          { id: 'f_3', name: 'S_20260609_49097' },
+          { id: 'f_4', name: 'S_20260616_49097' },
+        ]),
+      });
+      getSingleFlexiRecord.mockResolvedValue({
+        items: [{ scoutid: 900, firstname: 'Host', lastname: 'Member', f_9: liveConfigCell, f_2: '', f_3: '', f_4: '' }],
+      });
+      fetchProgrammeMeetings.mockResolvedValue([
+        { date: '2026-06-02', startTime: null, endTime: null, title: null },
+        { date: '2026-06-09', startTime: null, endTime: null, title: null },
+        { date: '2026-06-16', startTime: null, endTime: null, title: null },
+      ]);
+    });
+
+    it('pre-fills regulars onto the newly added session ONLY, and reloads with forceRefresh:true', async () => {
+      multiUpdateFlexiRecord.mockResolvedValue({ ok: true });
+
+      const result = await syncRotaWithProgramme({ rota: rotaWithRegulars, token: 'tok' });
+
+      expect(result.added).toBe(1);
+      expect(result.prefillErrors).toEqual([]);
+      expect(multiUpdateFlexiRecord).toHaveBeenCalledTimes(1);
+      // f_2/f_3 (existing sessions) must never be re-touched by sync's prefill
+      // — only the newly added f_4 (06-16).
+      expect(multiUpdateFlexiRecord.mock.calls[0][3]).toBe('f_4');
+      expect(
+        getFlexiStructure.mock.calls.some((call) => call[4] === true),
+      ).toBe(true);
+    });
+
+    it('surfaces regular pre-fill failures in the result\'s prefillErrors field', async () => {
+      multiUpdateFlexiRecord.mockResolvedValue({ ok: false, message: 'denied' });
+
+      const result = await syncRotaWithProgramme({ rota: rotaWithRegulars, token: 'tok' });
+
+      expect(result.prefillErrors).toEqual([{ fieldId: 'f_4', error: 'denied' }]);
+    });
+  });
+
   it('does nothing when the rota already matches', async () => {
     fetchProgrammeMeetings.mockResolvedValue([
       { date: '2026-06-02', startTime: null, endTime: null, title: null },
@@ -220,6 +283,7 @@ describe('syncRotaWithProgramme', () => {
       titlesSkippedNoIdentity: false,
       uncheckedSections: [],
       failedSections: [],
+      prefillErrors: [],
     });
     expect(createOrCompleteFlexiRecord).not.toHaveBeenCalled();
   });
@@ -311,11 +375,17 @@ describe('syncRotaWithProgramme', () => {
     getFlexiStructure.mockResolvedValue({
       config: JSON.stringify([{ id: 'f_9', name: 'RotaConfig' }]),
     });
-    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: '' }] });
+    // Patch mode merges onto the LIVE winner re-fetched inside the lock, so
+    // this needs a real live config cell (see the sibling test above) —
+    // otherwise the write dies before updateFlexiRecord is ever called and
+    // this test's rejection would be dead code.
+    const liveConfigCell = JSON.stringify({ v: 1, at: '2026-06-01T09:00:00Z', by: 'Setup', cfg: rota.config.cfg });
+    getSingleFlexiRecord.mockResolvedValue({ items: [{ scoutid: 900, f_9: liveConfigCell }] });
     updateFlexiRecord.mockRejectedValue(new Error('OSM write rejected'));
 
     const result = await syncRotaWithProgramme({ rota, token: 'tok', scoutid: 900, by: 'Simon Clark' });
 
+    expect(updateFlexiRecord).toHaveBeenCalledTimes(1);
     expect(result.titleWriteFailed).toBe(true);
     expect(result.titlesUpdated).toBe(0);
   });

--- a/src/features/water-rota/services/__tests__/rotaTemplates.test.js
+++ b/src/features/water-rota/services/__tests__/rotaTemplates.test.js
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { guessActivityFromTitle, looksLikeWaterSession } from '../rotaTemplates.js';
+import {
+  buildRotaRecordName,
+  guessActivityFromTitle,
+  looksLikeWaterSession,
+  parseRotaRecordName,
+  seasonBucketForRange,
+} from '../rotaTemplates.js';
 
 describe('guessActivityFromTitle', () => {
   it('matches preset names inside meeting titles', () => {
@@ -75,5 +81,74 @@ describe('looksLikeWaterSession', () => {
     expect(looksLikeWaterSession('')).toBe(false);
     expect(looksLikeWaterSession(null)).toBe(false);
     expect(looksLikeWaterSession(undefined)).toBe(false);
+  });
+});
+
+describe('buildRotaRecordName / parseRotaRecordName', () => {
+  it('round-trips a record identity', () => {
+    const identity = { sectionName: 'Scouts', seasonBucket: 'Summer 2026', sectionId: '49097', termId: '924956' };
+    const name = buildRotaRecordName(identity);
+    expect(name).toBe('Viking Water Rota Scouts Summer 2026 [49097.924956]');
+    expect(parseRotaRecordName(name)).toEqual(identity);
+  });
+
+  it('round-trips section names with spaces and digits', () => {
+    const identity = { sectionName: '1st Walton Scouts', seasonBucket: 'Autumn 2026', sectionId: '49099', termId: '900001' };
+    expect(parseRotaRecordName(buildRotaRecordName(identity))).toEqual(identity);
+  });
+
+  it('extracts both ids and the season bucket from the two-part bracket', () => {
+    const parsed = parseRotaRecordName('Viking Water Rota Adults Spring 2027 [11107.901823]');
+    expect(parsed).toEqual({ sectionName: 'Adults', seasonBucket: 'Spring 2027', sectionId: '11107', termId: '901823' });
+  });
+
+  it('returns null for the retired year-model name', () => {
+    expect(parseRotaRecordName('Viking Water Rota 2026')).toBeNull();
+  });
+
+  it('returns null for the retired three-part-bracket shape', () => {
+    expect(parseRotaRecordName('Viking Water Rota Scouts Summer 2026 [49097.924956.1]')).toBeNull();
+  });
+
+  it('returns null for junk input', () => {
+    expect(parseRotaRecordName('Viking Event Mgmt')).toBeNull();
+    expect(parseRotaRecordName('')).toBeNull();
+    expect(parseRotaRecordName(null)).toBeNull();
+    expect(parseRotaRecordName(undefined)).toBeNull();
+  });
+});
+
+describe('seasonBucketForRange', () => {
+  it('buckets all eight live Summer-2026 term variants to "Summer 2026"', () => {
+    const ranges = [
+      ['2026-04-01', '2026-07-17'],
+      ['2026-04-01', '2026-07-24'],
+      ['2026-04-02', '2026-07-24'],
+      ['2026-04-06', '2026-08-31'],
+      ['2026-04-07', '2026-08-31'],
+      ['2026-04-08', '2026-08-31'],
+      ['2026-04-12', '2026-08-31'],
+      ['2026-04-01', '2026-08-31'],
+    ];
+    for (const [start, end] of ranges) {
+      expect(seasonBucketForRange(start, end), `${start}..${end}`).toBe('Summer 2026');
+    }
+  });
+
+  it('buckets a Jan-Mar term to Spring', () => {
+    expect(seasonBucketForRange('2026-01-06', '2026-03-27')).toBe('Spring 2026');
+  });
+
+  it('buckets a Sep-Dec term to Autumn', () => {
+    expect(seasonBucketForRange('2026-09-01', '2026-12-18')).toBe('Autumn 2026');
+  });
+
+  it('buckets a Dec-Feb straddling term to Spring of the later year', () => {
+    expect(seasonBucketForRange('2025-12-01', '2026-02-15')).toBe('Spring 2026');
+  });
+
+  it('is UTC-deterministic regardless of the runner\'s local timezone', () => {
+    // Midnight-ISO boundaries would flip a day in a non-UTC-aware implementation.
+    expect(seasonBucketForRange('2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')).toBe('Spring 2026');
   });
 });

--- a/src/features/water-rota/services/__tests__/vikingWaterRotaValidation.test.js
+++ b/src/features/water-rota/services/__tests__/vikingWaterRotaValidation.test.js
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import { validateWaterRotaStructure } from '../vikingWaterRotaValidation.js';
-import { parseRotaRecordYear, buildRotaRecordName } from '../rotaTemplates.js';
 
 describe('validateWaterRotaStructure', () => {
   it('accepts a structure with RotaConfig and session columns, ignoring strays', () => {
@@ -35,17 +34,5 @@ describe('validateWaterRotaStructure', () => {
   it('fails safely on a missing structure', () => {
     expect(validateWaterRotaStructure(null).isValid).toBe(false);
     expect(validateWaterRotaStructure({}).isValid).toBe(false);
-  });
-});
-
-describe('rota record naming', () => {
-  it('round-trips the year', () => {
-    expect(parseRotaRecordYear(buildRotaRecordName(2026))).toBe(2026);
-  });
-
-  it('rejects other record names', () => {
-    expect(parseRotaRecordYear('Viking Event Mgmt')).toBeNull();
-    expect(parseRotaRecordYear('Viking Water Rota')).toBeNull();
-    expect(parseRotaRecordYear(null)).toBeNull();
   });
 });

--- a/src/features/water-rota/services/rotaEncoding.js
+++ b/src/features/water-rota/services/rotaEncoding.js
@@ -1,15 +1,16 @@
 /**
  * Pure encoding/decoding for the Water Rota FlexiRecord.
  *
- * Layout: one FlexiRecord per year in a host section. Rows are host-section
- * members. A permit holder only ever writes their own row's signup cell, so
- * signups never conflict across users (setup/regular pre-fill is the one
- * exception — the organiser writes other members' cells once, up front). Two
- * column kinds:
+ * Layout: one FlexiRecord per (planning section, that section's own term),
+ * all hosted in the Adults section. Rows are host-section members. A permit
+ * holder only ever writes their own row's signup cell, so signups never
+ * conflict across users (setup/regular pre-fill is the one exception — the
+ * organiser writes other members' cells once, up front). Two column kinds:
  *
- * - "RotaConfig": whole-plan config JSON. Written to a single deterministic
- *   anchor row (the lowest-scoutid host member), not the editor's own row;
- *   readers take the last-writer-wins (LWW) winner across all rows by (v, at).
+ * - "RotaConfig": one section's whole-plan config JSON. Written to a single
+ *   deterministic anchor row (the lowest-scoutid host member), not the
+ *   editor's own row; readers take the last-writer-wins (LWW) winner across
+ *   all rows by (v, at).
  * - "S_<yyyymmdd>_<sectionid>": one column per session. A cell holds the row
  *   member's signup (s/sat) plus an optional session-metadata candidate (m);
  *   readers take the LWW winner of m across the column.
@@ -38,21 +39,6 @@ const timeSchema = z.string().regex(/^\d{2}:\d{2}$/);
 const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
 const isoInstantSchema = z.string().min(1);
 
-const sectionDefaultsSchema = z
-  .object({
-    sid: z.string().min(1),
-    sname: z.string(),
-    act: z.string(),
-    st: timeSchema,
-    en: timeSchema,
-    k: z.number().int().nonnegative().optional(),
-    p: z.number().int().nonnegative().optional(),
-    // Scoutids of the section's regular permit holders — pre-filled as
-    // confirmed signups on every on-water session for the section.
-    regulars: z.array(z.string()).optional(),
-  })
-  .passthrough();
-
 const sessionOverrideSchema = z
   .object({
     act: z.string().optional(),
@@ -72,12 +58,22 @@ const rotaConfigSchema = z
     v: z.number().int().nonnegative(),
     at: isoInstantSchema,
     by: z.string(),
+    // One section's whole plan — a single-section record has nothing to
+    // merge, so this replaces the old cfg.sections[] array.
     cfg: z
       .object({
-        start: isoDateSchema,
-        end: isoDateSchema,
-        termId: z.string().optional(),
-        sections: z.array(sectionDefaultsSchema),
+        sid: z.string().min(1),
+        sname: z.string(),
+        act: z.string(),
+        st: timeSchema,
+        en: timeSchema,
+        k: z.number().int().nonnegative().optional(),
+        p: z.number().int().nonnegative().optional(),
+        // Scoutids of the section's regular permit holders — pre-filled as
+        // confirmed signups on every on-water session for the section.
+        regulars: z.array(z.string()).optional(),
+        start: isoDateSchema.optional(),
+        end: isoDateSchema.optional(),
         sessions: z.record(z.string(), sessionOverrideSchema).optional(),
       })
       .passthrough(),

--- a/src/features/water-rota/services/rotaEncoding.js
+++ b/src/features/water-rota/services/rotaEncoding.js
@@ -4,13 +4,14 @@
  * Layout: one FlexiRecord per (planning section, that section's own term),
  * all hosted in the Adults section. Rows are host-section members. A permit
  * holder only ever writes their own row's signup cell, so signups never
- * conflict across users (setup/regular pre-fill is the one exception — the
- * organiser writes other members' cells once, up front). Two column kinds:
+ * conflict across users (setup/regular pre-fill and a leader's assignSignup
+ * are the two exceptions — the organiser/leader writes another member's cell
+ * directly). Two column kinds:
  *
- * - "RotaConfig": one section's whole-plan config JSON. Written to a single
- *   deterministic anchor row (the lowest-scoutid host member), not the
- *   editor's own row; readers take the last-writer-wins (LWW) winner across
- *   all rows by (v, at).
+ * - "RotaConfig": one section's whole-plan config JSON. The row it's written
+ *   to is caller-designated — setup passes a deterministic member row, and
+ *   programme sync's title backfill passes the editor's own row; readers
+ *   take the last-writer-wins (LWW) winner across all rows by (v, at).
  * - "S_<yyyymmdd>_<sectionid>": one column per session. A cell holds the row
  *   member's signup (s/sat) plus an optional session-metadata candidate (m);
  *   readers take the LWW winner of m across the column.
@@ -244,7 +245,9 @@ export function encodeSessionMeta(existingRaw, meta) {
 }
 
 /**
- * Encode a whole-plan config candidate for the editor's own RotaConfig cell.
+ * Encode a whole-plan config candidate. Pure encode — the caller selects
+ * which row's RotaConfig cell to store it in (setup passes a deterministic
+ * row; sync passes the editor's own row).
  *
  * @param {Object} candidate - Full candidate ({v, at, by, cfg})
  * @returns {string} New raw cell value

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -139,6 +139,12 @@ export async function discoverRotaRecords(token, priority = 0) {
         sectionId: section.sectionid,
         error: error.message,
       }, LOG_CATEGORIES.ERROR);
+      if (hostSection) {
+        // Host-only scan: a failed read here means we genuinely don't know
+        // whether rota records exist — surface the error instead of
+        // silently reporting "no rota", which would invite a duplicate setup.
+        throw error;
+      }
       continue;
     }
     for (const item of list?.items || []) {
@@ -423,19 +429,31 @@ export async function assignSignup({ rota, fieldId, scoutid, status, token }) {
 }
 
 /**
- * Write a session-metadata update into the editor's own row, bumping the
- * LWW version above the current column winner read live inside the lock.
+ * Base metadata used as the merge target when a session has no prior
+ * metadata candidate at all (a brand-new column) — matches the defaults
+ * SessionEditForm/SessionDetailModal show for an unedited session.
+ * @type {{act: string, st: string, en: string, k: number, p: number, c: 0}}
+ */
+const SESSION_META_DEFAULTS = { act: 'On the water', st: '18:30', en: '20:00', k: 0, p: 0, c: 0 };
+
+/**
+ * Write a session-metadata patch into the editor's own row, merging it onto
+ * the live column winner read fresh inside the lock (falling back to
+ * {@link SESSION_META_DEFAULTS} when no winner exists yet) and bumping the
+ * LWW version above it. Only the fields present in `metaPatch` are changed —
+ * a concurrent co-leader's edit to any field the caller didn't touch
+ * survives (PRD §5.4 freshness constraint).
  *
  * @param {Object} params
  * @param {LoadedRota} params.rota - Loaded rota
  * @param {string} params.fieldId - Session column field id (f_N)
  * @param {string|number} params.scoutid - The editor's member row id
  * @param {string} params.by - Editor display name for the audit trail
- * @param {{act: string, st: string, en: string, k: number, p: number, n?: string, c: 0|1}} params.fields - Full metadata fields
+ * @param {{act?: string, st?: string, en?: string, k?: number, p?: number, n?: string, c?: 0|1}} params.metaPatch - Only the fields the caller intends to change
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  */
-export async function writeSessionMeta({ rota, fieldId, scoutid, by, fields, token }) {
+export async function writeSessionMeta({ rota, fieldId, scoutid, by, metaPatch, token }) {
   await writeOwnCell({
     rota,
     fieldId,
@@ -446,7 +464,8 @@ export async function writeSessionMeta({ rota, fieldId, scoutid, by, fields, tok
         items.map((item) => ({ scoutid: item.scoutid, name: '', value: item[fieldId] })),
       );
       const meta = {
-        ...fields,
+        ...(winner ?? SESSION_META_DEFAULTS),
+        ...metaPatch,
         v: (winner?.v ?? 0) + 1,
         at: new Date().toISOString(),
         by,
@@ -459,18 +478,25 @@ export async function writeSessionMeta({ rota, fieldId, scoutid, by, fields, tok
 /**
  * Write a whole-plan config candidate into the editor's own RotaConfig cell,
  * bumping the LWW version above the current winner read live inside the
- * lock. A plain replace — a single-section record has nothing to merge.
+ * lock.
+ *
+ * Two modes: `replace: true` is an intentional full-plan replace (the setup
+ * wizard re-running with a fresh plan); the default patch mode shallow-merges
+ * `cfg`'s keys onto the live winner's cfg, with `sessions` merged key-wise
+ * (winner.cfg.sessions ⊕ cfg.sessions) so a concurrent edit to a field or
+ * session override the caller didn't touch survives (PRD §5.4).
  *
  * @param {Object} params
  * @param {LoadedRota} params.rota - Loaded rota
  * @param {string} params.configFieldId - RotaConfig column field id (f_N)
  * @param {string|number} params.scoutid - The editor's member row id
  * @param {string} params.by - Editor display name
- * @param {Object} params.cfg - This record's plan config ({sid, sname, act, st, en, ...})
+ * @param {Object} params.cfg - The full plan config (`replace: true`) or just the changed keys (patch mode)
+ * @param {boolean} [params.replace=false] - Full replace instead of a merge patch
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  */
-export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, token }) {
+export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, replace = false, token }) {
   await writeOwnCell({
     rota,
     fieldId: configFieldId,
@@ -478,14 +504,31 @@ export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, token
     token,
     mutate: (_ownRaw, items) => {
       const winner = mergeLwwConfig(items.map((item) => item[configFieldId]));
+      const nextCfg = replace ? cfg : mergeConfigPatch(winner?.cfg, cfg);
       return encodeConfig({
         v: (winner?.v ?? 0) + 1,
         at: new Date().toISOString(),
         by,
-        cfg,
+        cfg: nextCfg,
       });
     },
   });
+}
+
+/**
+ * Shallow-merge a config patch onto the live winner's cfg, merging `sessions`
+ * key-wise rather than replacing the whole map.
+ *
+ * @param {Object|undefined} winnerCfg - The live LWW winner's cfg (undefined when none)
+ * @param {Object} patch - The caller's changed keys
+ * @returns {Object} Merged cfg
+ */
+function mergeConfigPatch(winnerCfg, patch) {
+  const merged = { ...(winnerCfg ?? {}), ...patch };
+  if (patch.sessions || winnerCfg?.sessions) {
+    merged.sessions = { ...(winnerCfg?.sessions ?? {}), ...(patch.sessions ?? {}) };
+  }
+  return merged;
 }
 
 /**

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -1,7 +1,9 @@
 /**
- * Water Rota data service: discovers the yearly rota FlexiRecord across the
- * user's sections, loads and decodes it, and performs the rota writes
- * (signup, session metadata, plan config, and regular pre-fill).
+ * Water Rota data service: discovers the per-(planning section, planning
+ * term) rota FlexiRecords hosted in the Adults section, loads and decodes
+ * them (individually or aggregated into a season-bucket group), and performs
+ * the rota writes (signup, session metadata, plan config, and regular
+ * pre-fill).
  *
  * Write discipline (PRD §5.4 freshness constraint): the per-user writes
  * (signup, session metadata) re-fetch the live grid, merge into a single
@@ -10,9 +12,9 @@
  * patch the local cache optimistically. These are serialized through a
  * module-level promise-chain lock so two in-flight writes cannot interleave
  * their read-merge-write cycles. prefillRegulars is a setup-time bulk write
- * that targets other members' rows (organiser-only, cells empty). Rota writes
- * are online-only — offline attempts throw WRITE_UNAVAILABLE from the API
- * layer.
+ * that targets other members' rows (organiser-only, cells empty), throttled
+ * between calls to stay under OSM's rate limit. Rota writes are online-only —
+ * offline attempts throw WRITE_UNAVAILABLE from the API layer.
  *
  * @module rotaService
  */
@@ -39,7 +41,7 @@ import {
   mergeSessionColumn,
   parseSessionColumnName,
 } from './rotaEncoding.js';
-import { ROTA_RECORD_NAME_PREFIX } from './rotaTemplates.js';
+import { parseRotaRecordName } from './rotaTemplates.js';
 import { validateWaterRotaStructure } from './vikingWaterRotaValidation.js';
 
 let writeLock = Promise.resolve();
@@ -58,55 +60,105 @@ function withWriteLock(fn) {
 }
 
 /**
- * A loaded, decoded rota.
+ * A rota record's discovered identity, parsed from its FlexiRecord name
+ * (PRD §2.1) plus where it lives.
+ *
+ * @typedef {Object} RotaDescriptor
+ * @property {string} sectionName - Planning section's display name
+ * @property {string} seasonBucket - Deterministic season label, e.g. "Summer 2026"
+ * @property {string} sectionId - Planning section id
+ * @property {string} termId - Planning section's own term id the plan was built from
+ * @property {string|number} recordId - FlexiRecord id (extraid)
+ * @property {Object} hostSection - The Adults section the record is hosted in
+ */
+
+/**
+ * A loaded, decoded rota record for one planning section.
  *
  * @typedef {Object} LoadedRota
- * @property {number} year - Rota calendar year
- * @property {Object} hostSection - Section the record lives in ({sectionid, sectionname, section, ...})
  * @property {string|number} recordId - FlexiRecord id (extraid)
- * @property {string} termId - Term id used for grid reads
+ * @property {Object} hostSection - Section the record lives in ({sectionid, sectionname, section, ...})
+ * @property {string} termId - Host section's read-context term id, resolved at load time (PRD §3.3)
+ * @property {string} sectionId - Planning section id (from the record's identity)
+ * @property {string} planningTermId - Planning section's own term id (from the record's identity)
+ * @property {string} seasonBucket - Deterministic season label (from the record's identity)
+ * @property {string} configFieldId - RotaConfig column field id (f_N)
  * @property {Object|null} config - LWW-winning plan config candidate ({v, at, by, cfg}), null before first config write
  * @property {Array<Object>} sessions - Decoded sessions ({fieldId, date, sectionId, meta, signups})
  * @property {Array<{scoutid: string, name: string, photo_guid: string|null}>} members - Host-section member rows
+ * @property {Object} sectionNames - Map of section id to display name
  */
 
 /**
- * Find the rota FlexiRecord for a year by scanning the user's sections.
+ * A season bucket's aggregated view across every planning section's record.
  *
- * @param {number} year - Calendar year
- * @param {string} token - OSM authentication token
- * @param {number} [priority=0] - Rate-limit queue priority for the flexi-list reads
- * @returns {Promise<{hostSection: Object, recordId: string|number}|null>} Discovery result, or null when no rota exists
+ * @typedef {Object} RotaGroup
+ * @property {string} seasonBucket - The bucket loaded, e.g. "Summer 2026"
+ * @property {Object|null} hostSection - Shared Adults section (from any record)
+ * @property {LoadedRota[]} records - Every loaded record in the bucket
+ * @property {Object|null} config - Assembled group config (see {@link assembleGroupConfig})
+ * @property {Array<Object>} sessions - Union of every record's sessions, each with a `record` back-reference
+ * @property {Array<Object>} members - Adults roster (same rows in every record — taken from the first)
+ * @property {Object} sectionNames - Map of section id to display name (from the first record)
  */
-export async function discoverRotaRecord(year, token, priority = 0) {
-  const recordName = `${ROTA_RECORD_NAME_PREFIX} ${year}`;
-  const sections = (await databaseService.getSections()) || [];
 
-  for (const section of sections) {
-    try {
-      const list = await getFlexiRecords(section.sectionid, token, 'n', false, priority);
-      const match = (list?.items || []).find((record) => record.name === recordName);
-      if (match) {
-        return { hostSection: section, recordId: match.extraid };
-      }
-    } catch (error) {
-      logger.warn('Rota discovery: flexi list read failed for section', {
-        sectionId: section.sectionid,
-        error: error.message,
-      }, LOG_CATEGORIES.API);
-    }
-  }
-
-  return null;
+/**
+ * Find the Adults section that hosts every rota record, by name — the same
+ * heuristic the setup wizard already uses as a default (PRD §3.1).
+ *
+ * @param {Array<Object>} sections - Cached sections ({sectionid, sectionname, section, ...})
+ * @returns {Object|null} The host section, or null when none looks like Adults
+ */
+export function findHostSection(sections) {
+  return (sections ?? []).find((s) =>
+    `${s.section ?? ''} ${s.sectionname ?? ''}`.toLowerCase().includes('adult')) ?? null;
 }
 
 /**
- * Resolve the term id to use for rota grid reads on the host section.
+ * Discover every rota record via a single flexi-list read on the Adults host
+ * section (falling back to scanning every cached section when no Adults
+ * section is visible). Record identity is parsed entirely from each item's
+ * name (PRD §2.1) — no term resolution is involved in discovery.
+ *
+ * @param {string} token - OSM authentication token
+ * @param {number} [priority=0] - Rate-limit queue priority for the flexi-list read(s)
+ * @returns {Promise<RotaDescriptor[]>} Every discovered rota record, deduped by (sectionId, termId)
+ */
+export async function discoverRotaRecords(token, priority = 0) {
+  const sections = (await databaseService.getSections()) || [];
+  const hostSection = findHostSection(sections);
+  const scan = hostSection ? [hostSection] : sections;
+  const byIdentity = new Map();
+
+  for (const section of scan) {
+    const list = await getFlexiRecords(section.sectionid, token, 'n', false, priority);
+    for (const item of list?.items || []) {
+      const parsed = parseRotaRecordName(item.name);
+      if (!parsed) {
+        continue;
+      }
+      const key = `${parsed.sectionId}.${parsed.termId}`;
+      const existing = byIdentity.get(key);
+      // Numeric lowest-extraid dedupe for accidental same-name duplicates
+      // (extraids "9" vs "10" must pick "9" — a string compare would not).
+      if (!existing || Number(item.extraid) < Number(existing.recordId)) {
+        byIdentity.set(key, { ...parsed, recordId: item.extraid, hostSection: section });
+      }
+    }
+  }
+
+  return [...byIdentity.values()];
+}
+
+/**
+ * Resolve the host section's current-active-term id for rota grid reads,
+ * fresh on every load (PRD §3.3). Record identity never depends on this
+ * value — only the API/cache reads within a load do.
  *
  * @param {string|number} hostSectionId - Host section id
  * @returns {Promise<string|null>} Current active term id, or null when unknown
  */
-export async function resolveRotaTermId(hostSectionId) {
+async function resolveHostReadTermId(hostSectionId) {
   try {
     const term = await CurrentActiveTermsService.getCurrentActiveTerm(hostSectionId);
     return term?.currentTermId ?? null;
@@ -120,43 +172,38 @@ export async function resolveRotaTermId(hostSectionId) {
 }
 
 /**
- * Load and decode the rota for a year: discovery, structure validation,
- * LWW config merge, and per-session column merges. Persists the fetched
- * grid to the flexi cache so the board renders offline afterwards.
+ * Load and decode one rota record: structure validation, LWW config merge,
+ * and per-session column merges. Persists the fetched grid to the flexi
+ * cache so the board renders offline afterwards.
  *
- * @param {number} year - Calendar year
+ * @param {RotaDescriptor} descriptor - Record identity from {@link discoverRotaRecords}
  * @param {string} token - OSM authentication token
  * @param {Object} [options]
  * @param {boolean} [options.forceRefresh=false] - Bypass the structure cache (use after adding a column)
  * @param {number} [options.priority=0] - Rate-limit queue priority for this load's reads; raise
  *   on a deep-link/landing load so the rota jumps ahead of the background post-login sync
- * @returns {Promise<LoadedRota|null>} Decoded rota, or null when none exists for the year
- * @throws {Error} When the record exists but its structure is invalid or unreadable
+ * @returns {Promise<LoadedRota>} Decoded rota record
+ * @throws {Error} When the host section has no cached current active term, or the record's structure is invalid or unreadable
  */
-export async function loadRota(year, token, { forceRefresh = false, priority = 0 } = {}) {
-  const discovery = await discoverRotaRecord(year, token, priority);
-  if (!discovery) {
-    return null;
-  }
-
-  const { hostSection, recordId } = discovery;
-  const termId = await resolveRotaTermId(hostSection.sectionid);
-  if (!termId) {
+export async function loadRota(descriptor, token, { forceRefresh = false, priority = 0 } = {}) {
+  const { recordId, hostSection } = descriptor;
+  const hostTermId = await resolveHostReadTermId(hostSection.sectionid);
+  if (!hostTermId) {
     throw new Error('No active term found for the rota host section');
   }
 
-  const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, forceRefresh, priority);
+  const structureData = await getFlexiStructure(recordId, hostSection.sectionid, hostTermId, token, forceRefresh, priority);
   const structure = decodeStructure(structureData);
   const check = validateWaterRotaStructure(structure);
   if (!check.isValid) {
     throw new Error(`Water rota record is invalid: ${check.errors.join('; ')}`);
   }
 
-  const grid = await getSingleFlexiRecord(recordId, hostSection.sectionid, termId, token, priority);
+  const grid = await getSingleFlexiRecord(recordId, hostSection.sectionid, hostTermId, token, priority);
   const items = Array.isArray(grid?.items) ? grid.items : [];
 
   try {
-    await databaseService.saveFlexiData(recordId, hostSection.sectionid, termId, items);
+    await databaseService.saveFlexiData(recordId, hostSection.sectionid, hostTermId, items);
   } catch (error) {
     logger.warn('Rota: caching grid for offline use failed', {
       error: error.message,
@@ -202,16 +249,86 @@ export async function loadRota(year, token, { forceRefresh = false, priority = 0
   const sectionNames = await loadSectionNameMap();
 
   return {
-    year,
-    hostSection,
     recordId,
-    termId,
+    hostSection,
+    termId: hostTermId,
+    sectionId: descriptor.sectionId,
+    planningTermId: descriptor.termId,
+    seasonBucket: descriptor.seasonBucket,
     configFieldId: check.configFieldId,
     config,
     sessions,
     members,
     sectionNames,
   };
+}
+
+/**
+ * Assemble the board's group-wide config shape from every loaded record's
+ * single-section config (PRD §2.5) — sections[] plus a merged sessions{} map
+ * (session column names never collide across records, since the sectionid
+ * stays in the key) and the union of every record's date range.
+ *
+ * @param {LoadedRota[]} records - Loaded records (each `.config` may be null)
+ * @returns {{cfg: {start: string|undefined, end: string|undefined, sections: Array, sessions: Object}}|null}
+ *   Assembled config, or null when no record has config yet
+ */
+export function assembleGroupConfig(records) {
+  const sections = [];
+  const sessions = {};
+  let start, end;
+  for (const record of records) {
+    const c = record.config?.cfg;
+    if (!c) continue;
+    sections.push({ sid: c.sid, sname: c.sname, act: c.act, st: c.st, en: c.en,
+      k: c.k, p: c.p, regulars: c.regulars ?? [] });
+    Object.assign(sessions, c.sessions ?? {});
+    start = !start || (c.start && c.start < start) ? (c.start ?? start) : start;
+    end = !end || (c.end && c.end > end) ? (c.end ?? end) : end;
+  }
+  return sections.length ? { cfg: { start, end, sections, sessions } } : null;
+}
+
+/**
+ * Assemble a season bucket's aggregated group view from its loaded records.
+ * Every session carries a `record` back-reference so writes route to the
+ * record that owns it (PRD §5.2–5.3).
+ *
+ * @param {string} seasonBucket - The bucket assembled, e.g. "Summer 2026"
+ * @param {LoadedRota[]} records - Loaded records in the bucket
+ * @returns {RotaGroup} Assembled group
+ */
+export function assembleRotaGroup(seasonBucket, records) {
+  return {
+    seasonBucket,
+    hostSection: records[0]?.hostSection ?? null,
+    records,
+    config: assembleGroupConfig(records),
+    sessions: records.flatMap((record) => record.sessions.map((session) => ({ ...session, record }))),
+    members: records[0]?.members ?? [],
+    sectionNames: records[0]?.sectionNames ?? {},
+  };
+}
+
+/**
+ * Discover and load every rota record in a season bucket, aggregated into
+ * the board's group view.
+ *
+ * @param {string} seasonBucket - Season bucket to load, e.g. "Summer 2026"
+ * @param {string} token - OSM authentication token
+ * @param {Object} [options]
+ * @param {boolean} [options.forceRefresh=false] - Bypass the structure cache on every record load
+ * @param {number} [options.priority=0] - Rate-limit queue priority for every read in this load
+ * @returns {Promise<RotaGroup|null>} Assembled group, or null when the bucket has no records
+ */
+export async function loadRotaGroup(seasonBucket, token, { forceRefresh = false, priority = 0 } = {}) {
+  const descriptors = (await discoverRotaRecords(token, priority))
+    .filter((d) => !seasonBucket || d.seasonBucket === seasonBucket);
+  if (descriptors.length === 0) {
+    return null;
+  }
+  const records = await Promise.all(descriptors.map((d) => loadRota(d, token, { forceRefresh, priority })));
+  return assembleRotaGroup(seasonBucket, records.filter(Boolean));
 }
 
 /**
@@ -332,19 +449,19 @@ export async function writeSessionMeta({ rota, fieldId, scoutid, by, fields, tok
 
 /**
  * Write a whole-plan config candidate into the editor's own RotaConfig cell,
- * bumping the LWW version above the current winner read live inside the lock.
+ * bumping the LWW version above the current winner read live inside the
+ * lock. A plain replace — a single-section record has nothing to merge.
  *
  * @param {Object} params
  * @param {LoadedRota} params.rota - Loaded rota
  * @param {string} params.configFieldId - RotaConfig column field id (f_N)
  * @param {string|number} params.scoutid - The editor's member row id
  * @param {string} params.by - Editor display name
- * @param {Object} params.cfg - Full plan config ({start, end, termId?, sections}); ignored when transformCfg is given
- * @param {(liveCfg: Object) => Object} [params.transformCfg] - When set, derive the config to write from the live winner read inside the lock (used to merge one section's setup into the shared config without clobbering others), instead of replacing with `cfg`
+ * @param {Object} params.cfg - This record's plan config ({sid, sname, act, st, en, ...})
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  */
-export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, transformCfg, token }) {
+export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, token }) {
   await writeOwnCell({
     rota,
     fieldId: configFieldId,
@@ -352,24 +469,32 @@ export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, trans
     token,
     mutate: (_ownRaw, items) => {
       const winner = mergeLwwConfig(items.map((item) => item[configFieldId]));
-      const nextCfg = transformCfg ? transformCfg(winner?.cfg ?? {}) : cfg;
       return encodeConfig({
         v: (winner?.v ?? 0) + 1,
         at: new Date().toISOString(),
         by,
-        cfg: nextCfg,
+        cfg,
       });
     },
   });
 }
 
 /**
+ * Fixed delay between successive prefillRegulars multi-update calls, on top
+ * of the underlying rate-limit queue — cheap insurance against a burst of
+ * back-to-back writes during setup (PRD §4.3).
+ * @type {number}
+ */
+const PREFILL_THROTTLE_MS = 300;
+
+/**
  * Pre-fill a section's regular permit holders as confirmed signups on its
  * water sessions. Setup-time bulk write: one multiUpdateFlexiRecord per
- * session sets every regular's cell to a confirmed signup. Targets other
- * members' rows (organiser-only, run when cells are empty), so it does NOT go
- * through the own-cell write lock. Confirmed-by-default: gaps on a session
- * then represent the extra permit holders still needed.
+ * session (throttled between calls) sets every regular's cell to a confirmed
+ * signup. Targets other members' rows (organiser-only, run when cells are
+ * empty), so it does NOT go through the own-cell write lock. Confirmed-by-
+ * default: gaps on a session then represent the extra permit holders still
+ * needed.
  *
  * @param {Object} params
  * @param {LoadedRota} params.rota - Loaded rota (host section, record, term)
@@ -385,12 +510,17 @@ export async function prefillRegulars({ rota, regularsBySection, token, sessions
 
   let filled = 0;
   const errors = [];
+  let calls = 0;
 
   for (const session of targetSessions) {
     const scouts = regularsBySection[String(session.sectionId)] ?? [];
     if (scouts.length === 0) {
       continue;
     }
+    if (calls > 0) {
+      await new Promise((resolve) => setTimeout(resolve, PREFILL_THROTTLE_MS));
+    }
+    calls += 1;
     try {
       const response = await multiUpdateFlexiRecord(
         rota.hostSection.sectionid,

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -131,7 +131,16 @@ export async function discoverRotaRecords(token, priority = 0) {
   const byIdentity = new Map();
 
   for (const section of scan) {
-    const list = await getFlexiRecords(section.sectionid, token, 'n', false, priority);
+    let list;
+    try {
+      list = await getFlexiRecords(section.sectionid, token, 'n', false, priority);
+    } catch (error) {
+      logger.warn('Rota: flexi-list read failed for a section during discovery', {
+        sectionId: section.sectionid,
+        error: error.message,
+      }, LOG_CATEGORIES.ERROR);
+      continue;
+    }
     for (const item of list?.items || []) {
       const parsed = parseRotaRecordName(item.name);
       if (!parsed) {

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -39,7 +39,7 @@ import {
   mergeSessionColumn,
   parseSessionColumnName,
 } from './rotaEncoding.js';
-import { buildRotaRecordName } from './rotaTemplates.js';
+import { ROTA_RECORD_NAME_PREFIX } from './rotaTemplates.js';
 import { validateWaterRotaStructure } from './vikingWaterRotaValidation.js';
 
 let writeLock = Promise.resolve();
@@ -79,7 +79,7 @@ function withWriteLock(fn) {
  * @returns {Promise<{hostSection: Object, recordId: string|number}|null>} Discovery result, or null when no rota exists
  */
 export async function discoverRotaRecord(year, token, priority = 0) {
-  const recordName = buildRotaRecordName(year);
+  const recordName = `${ROTA_RECORD_NAME_PREFIX} ${year}`;
   const sections = (await databaseService.getSections()) || [];
 
   for (const section of sections) {

--- a/src/features/water-rota/services/rotaService.js
+++ b/src/features/water-rota/services/rotaService.js
@@ -5,11 +5,12 @@
  * the rota writes (signup, session metadata, plan config, and regular
  * pre-fill).
  *
- * Write discipline (PRD §5.4 freshness constraint): the per-user writes
- * (signup, session metadata) re-fetch the live grid, merge into a single
- * target row's cell (the caller's own row for signup/meta; a deterministic
- * anchor row for config — see writeConfig), send one updateFlexiRecord, then
- * patch the local cache optimistically. These are serialized through a
+ * Write discipline (never overwrite state you haven't just read — the live
+ * grid is re-fetched inside the write lock): the per-user writes (signup,
+ * session metadata, config) re-fetch the live grid, merge into a single
+ * target row's cell (the caller's own row for signup/meta; whatever row the
+ * caller passes in for config — see writeConfig), send one updateFlexiRecord,
+ * then patch the local cache optimistically. These are serialized through a
  * module-level promise-chain lock so two in-flight writes cannot interleave
  * their read-merge-write cycles. prefillRegulars is a setup-time bulk write
  * that targets other members' rows (organiser-only, cells empty), throttled
@@ -103,8 +104,7 @@ function withWriteLock(fn) {
  */
 
 /**
- * Find the Adults section that hosts every rota record, by name — the same
- * heuristic the setup wizard already uses as a default (PRD §3.1).
+ * Find the Adults section that hosts every rota record, by name (PRD §3.1).
  *
  * @param {Array<Object>} sections - Cached sections ({sectionid, sectionname, section, ...})
  * @returns {Object|null} The host section, or null when none looks like Adults
@@ -129,6 +129,8 @@ export async function discoverRotaRecords(token, priority = 0) {
   const hostSection = findHostSection(sections);
   const scan = hostSection ? [hostSection] : sections;
   const byIdentity = new Map();
+  let scanFailures = 0;
+  let lastScanError = null;
 
   for (const section of scan) {
     let list;
@@ -145,6 +147,8 @@ export async function discoverRotaRecords(token, priority = 0) {
         // silently reporting "no rota", which would invite a duplicate setup.
         throw error;
       }
+      scanFailures += 1;
+      lastScanError = error;
       continue;
     }
     for (const item of list?.items || []) {
@@ -160,6 +164,13 @@ export async function discoverRotaRecords(token, priority = 0) {
         byIdentity.set(key, { ...parsed, recordId: item.extraid, hostSection: section });
       }
     }
+  }
+
+  // Fallback scan: same "don't lie about no rota" discipline as the
+  // host-only path above — if every section we tried failed, we don't
+  // actually know whether rota records exist.
+  if (!hostSection && scan.length > 0 && scanFailures === scan.length) {
+    throw lastScanError;
   }
 
   return [...byIdentity.values()];
@@ -437,12 +448,43 @@ export async function assignSignup({ rota, fieldId, scoutid, status, token }) {
 const SESSION_META_DEFAULTS = { act: 'On the water', st: '18:30', en: '20:00', k: 0, p: 0, c: 0 };
 
 /**
+ * Fields writeSessionMeta will pick out of a caller-supplied `base` (its
+ * other properties, e.g. a full SessionView's `label`/`status`/`confirmed`,
+ * are irrelevant to the stored metadata and ignored).
+ * @type {string[]}
+ */
+const SESSION_META_BASE_FIELDS = ['act', 'st', 'en', 'k', 'p', 'n', 'c'];
+
+/**
+ * Build a complete merge base from the caller's resolved effective session
+ * values (see writeSessionMeta's `base` param), filling any field the caller
+ * didn't supply from {@link SESSION_META_DEFAULTS} so the result always
+ * satisfies the session-metadata schema.
+ *
+ * @param {Object|null|undefined} base - Caller-resolved effective session values
+ * @returns {Object} Complete merge base
+ */
+function resolveSessionMetaBase(base) {
+  if (!base) {
+    return SESSION_META_DEFAULTS;
+  }
+  const picked = {};
+  for (const field of SESSION_META_BASE_FIELDS) {
+    if (base[field] !== undefined) {
+      picked[field] = base[field];
+    }
+  }
+  return { ...SESSION_META_DEFAULTS, ...picked };
+}
+
+/**
  * Write a session-metadata patch into the editor's own row, merging it onto
- * the live column winner read fresh inside the lock (falling back to
- * {@link SESSION_META_DEFAULTS} when no winner exists yet) and bumping the
- * LWW version above it. Only the fields present in `metaPatch` are changed —
- * a concurrent co-leader's edit to any field the caller didn't touch
- * survives (PRD §5.4 freshness constraint).
+ * the live column winner read fresh inside the lock (falling back to the
+ * caller-supplied `base` — the caller's resolved effective values for a
+ * virgin column — and finally to {@link SESSION_META_DEFAULTS} when neither
+ * exists) and bumping the LWW version above it. Only the fields present in
+ * `metaPatch` are changed — a concurrent co-leader's edit to any field the
+ * caller didn't touch survives (never overwrite state you haven't just read).
  *
  * @param {Object} params
  * @param {LoadedRota} params.rota - Loaded rota
@@ -450,10 +492,11 @@ const SESSION_META_DEFAULTS = { act: 'On the water', st: '18:30', en: '20:00', k
  * @param {string|number} params.scoutid - The editor's member row id
  * @param {string} params.by - Editor display name for the audit trail
  * @param {{act?: string, st?: string, en?: string, k?: number, p?: number, n?: string, c?: 0|1}} params.metaPatch - Only the fields the caller intends to change
+ * @param {Object} [params.base] - Caller-resolved effective session values (e.g. a SessionView) used as the merge base when this column has no live metadata winner yet — prevents a notes-only edit from silently flipping activity/times/permits-needed to {@link SESSION_META_DEFAULTS}
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  */
-export async function writeSessionMeta({ rota, fieldId, scoutid, by, metaPatch, token }) {
+export async function writeSessionMeta({ rota, fieldId, scoutid, by, metaPatch, token, base }) {
   await writeOwnCell({
     rota,
     fieldId,
@@ -464,7 +507,7 @@ export async function writeSessionMeta({ rota, fieldId, scoutid, by, metaPatch, 
         items.map((item) => ({ scoutid: item.scoutid, name: '', value: item[fieldId] })),
       );
       const meta = {
-        ...(winner ?? SESSION_META_DEFAULTS),
+        ...(winner ?? resolveSessionMetaBase(base)),
         ...metaPatch,
         v: (winner?.v ?? 0) + 1,
         at: new Date().toISOString(),
@@ -476,25 +519,29 @@ export async function writeSessionMeta({ rota, fieldId, scoutid, by, metaPatch, 
 }
 
 /**
- * Write a whole-plan config candidate into the editor's own RotaConfig cell,
+ * Write a whole-plan config candidate into the given RotaConfig cell,
  * bumping the LWW version above the current winner read live inside the
- * lock.
+ * lock. The row it's written to is caller-designated (setup passes a
+ * deterministic member row; sync's title backfill passes the editor's own
+ * row) — writeConfig itself has no row-selection logic.
  *
  * Two modes: `replace: true` is an intentional full-plan replace (the setup
  * wizard re-running with a fresh plan); the default patch mode shallow-merges
  * `cfg`'s keys onto the live winner's cfg, with `sessions` merged key-wise
  * (winner.cfg.sessions ⊕ cfg.sessions) so a concurrent edit to a field or
- * session override the caller didn't touch survives (PRD §5.4).
+ * session override the caller didn't touch survives (never overwrite state
+ * you haven't just read).
  *
  * @param {Object} params
  * @param {LoadedRota} params.rota - Loaded rota
  * @param {string} params.configFieldId - RotaConfig column field id (f_N)
- * @param {string|number} params.scoutid - The editor's member row id
+ * @param {string|number} params.scoutid - The member row to store this candidate in (setup passes a deterministic row; sync passes the editor's own row)
  * @param {string} params.by - Editor display name
  * @param {Object} params.cfg - The full plan config (`replace: true`) or just the changed keys (patch mode)
  * @param {boolean} [params.replace=false] - Full replace instead of a merge patch
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
+ * @throws {Error} In patch mode, when no live config candidate exists yet (nothing to patch — run setup first)
  */
 export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, replace = false, token }) {
   await writeOwnCell({
@@ -504,6 +551,9 @@ export async function writeConfig({ rota, configFieldId, scoutid, by, cfg, repla
     token,
     mutate: (_ownRaw, items) => {
       const winner = mergeLwwConfig(items.map((item) => item[configFieldId]));
+      if (!replace && !winner) {
+        throw new Error('Cannot patch rota config: no existing config found — run setup first');
+      }
       const nextCfg = replace ? cfg : mergeConfigPatch(winner?.cfg, cfg);
       return encodeConfig({
         v: (winner?.v ?? 0) + 1,
@@ -584,6 +634,11 @@ export async function prefillRegulars({ rota, regularsBySection, token, sessions
       );
       const failure = detectWriteFailure(response);
       if (failure) {
+        logger.error('Rota: regular pre-fill failed for a session', {
+          fieldId: session.fieldId,
+          sectionId: session.sectionId,
+          error: failure,
+        }, LOG_CATEGORIES.API);
         errors.push({ fieldId: session.fieldId, error: failure });
       } else {
         filled += 1;

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -16,7 +16,6 @@ import { createOrCompleteFlexiRecord } from '../../flexi-records/services/flexiR
 import {
   getFlexiStructure,
 } from '../../../shared/services/api/api/index.js';
-import { CurrentActiveTermsService } from '../../../shared/services/storage/currentActiveTermsService.js';
 import { parseFlexiStructure } from '../../../shared/utils/flexiRecordTransforms.js';
 import logger, { LOG_CATEGORIES } from '../../../shared/services/utils/logger.js';
 import {
@@ -24,32 +23,28 @@ import {
   buildSessionColumnName,
   parseSessionColumnName,
 } from './rotaEncoding.js';
-import { ROTA_CREATE_OPTIONS, ROTA_RECORD_NAME_PREFIX } from './rotaTemplates.js';
+import { ROTA_CREATE_OPTIONS, buildRotaRecordName } from './rotaTemplates.js';
 import { loadRota, prefillRegulars, writeConfig, writeSessionMeta } from './rotaService.js';
 import { fetchProgrammeMeetings } from './programmeService.js';
 import { generateSessionsFromProgramme } from '../utils/rotaDates.js';
 
 /**
- * Create or complete the rota record for a year on the host section.
- *
- * STOPGAP (pre-WP3): the per-section-record model's `buildRotaRecordName`
- * needs a record identity ({sectionName, seasonBucket, sectionId, termId},
- * PRD §2.1) that this whole-year, multi-section function has no way to
- * supply, so this still names the record with the plain year-based literal
- * rather than the new builder. WP3 replaces this whole function with the
- * per-section create flow (PRD §4.2).
+ * Create or complete a planning section's rota record on the host section.
+ * Record identity is fully name-derived (PRD §2.1) — `hostTermId` is a mere
+ * API/cache parameter for the creation orchestrator's structure reads, never
+ * part of the record's identity or name.
  *
  * @param {Object} params
  * @param {Object} params.hostSection - Host section ({sectionid, sectionname, section})
- * @param {number} params.year - Calendar year the rota covers
- * @param {string|number} params.termId - Term id for structure reads
+ * @param {string|number} params.hostTermId - Host section's resolved read-context term id (structure reads only)
+ * @param {{sectionId: string|number, sectionName: string, termId: string|number, seasonBucket: string}} params.record - Planning section's record identity (PRD §2.1)
  * @param {import('../utils/rotaDates.js').SessionDescriptor[]} params.sessions - Sessions to create columns for
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<import('../../flexi-records/services/flexiRecordCreationService.js').CreationResult>} Per-column result; success=false with errors on partial failure (safe to re-run)
  */
-export async function createOrCompleteRota({ hostSection, year, termId, sessions, token }) {
+export async function createOrCompleteRota({ hostSection, hostTermId, record, sessions, token }) {
   const template = {
-    name: `${ROTA_RECORD_NAME_PREFIX} ${year}`,
+    name: buildRotaRecordName(record),
     fields: [
       ROTA_CONFIG_COLUMN,
       ...sessions.map((session) => buildSessionColumnName(session.date, session.sectionId)),
@@ -57,7 +52,7 @@ export async function createOrCompleteRota({ hostSection, year, termId, sessions
     createOptions: ROTA_CREATE_OPTIONS,
   };
 
-  return createOrCompleteFlexiRecord({ section: hostSection, template, termId, token });
+  return createOrCompleteFlexiRecord({ section: hostSection, template, termId: hostTermId, token });
 }
 
 /**
@@ -121,16 +116,13 @@ export function diffSessions(existingColumns, descriptors) {
 }
 
 /**
- * Sync an existing rota with its (single) section's programme: appends
- * columns for newly added meeting dates and reports sessions whose programme
- * meeting has vanished (candidates to mark not-on-water — never deleted,
- * since OSM has no column delete).
- *
- * STOPGAP (pre-WP3): still resolves the section's *current active* term via
- * {@link CurrentActiveTermsService} rather than the record's own planning
- * `termId` (PRD §4.4) — LoadedRota doesn't thread a planning termid through
- * this call site yet. `uncheckedSections`/`failedSections` are single-section
- * results (0 or 1 entries), kept as arrays for now to minimize caller churn.
+ * Sync an existing rota record with its (single) planning section's
+ * programme: appends columns for newly added meeting dates and reports
+ * sessions whose programme meeting has vanished (candidates to mark
+ * not-on-water — never deleted, since OSM has no column delete). Fetches the
+ * programme under the record's own planning `termId` (PRD §4.4) — never the
+ * section's current active term, which may differ from the term the plan was
+ * built for.
  *
  * @param {Object} params
  * @param {import('./rotaService.js').LoadedRota} params.rota - Loaded rota with config
@@ -138,9 +130,11 @@ export function diffSessions(existingColumns, descriptors) {
  * @param {string|number} [params.scoutid] - Editor's host-section row id, to attribute the title backfill config write
  * @param {string} [params.by] - Editor display name for the title backfill config write
  * @returns {Promise<{added: number, orphaned: Array, errors: Array, titlesUpdated: number, titleWriteFailed: boolean, titlesSkippedNoIdentity: boolean, uncheckedSections: string[], failedSections: string[]}>}
- *   Sync outcome. `uncheckedSections` = no active term found (benign, nothing
- *   to sync); `failedSections` = the programme fetch threw (a real error,
- *   e.g. expired token) — both are excluded from `orphaned`.
+ *   Sync outcome for this single record. `uncheckedSections` is always empty
+ *   (the planning term is always known — it's the record's own identity, not
+ *   a "current active term" lookup); `failedSections` holds the section id
+ *   when the programme fetch threw (e.g. an expired token) — excluded from
+ *   `orphaned` either way, kept as arrays for caller compatibility.
  * @throws {Error} When the rota has no config to sync against
  */
 export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
@@ -150,34 +144,17 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
   }
 
   const range = { start: cfg.start, end: cfg.end };
-  const descriptors = [];
-  // Set when the section's programme couldn't be read this run. We must NOT
-  // treat its existing sessions as orphaned — we don't know its programme, so
-  // leave them untouched. Split by cause so the caller can tell a benign "no
-  // active term" apart from a real fetch failure (e.g. an expired token) and
-  // message accordingly.
-  const unchecked = new Set();
-  const failed = new Set();
+  let descriptors = [];
+  let failed = false;
 
   try {
-    const term = await CurrentActiveTermsService.getCurrentActiveTerm(cfg.sid);
-    if (!term?.currentTermId) {
-      unchecked.add(String(cfg.sid));
-    } else {
-      const meetings = await fetchProgrammeMeetings(cfg.sid, term.currentTermId, token);
-      descriptors.push(...generateSessionsFromProgramme(meetings, cfg, range));
-    }
+    const meetings = await fetchProgrammeMeetings(cfg.sid, rota.planningTermId, token);
+    descriptors = generateSessionsFromProgramme(meetings, cfg, range);
   } catch (error) {
-    failed.add(String(cfg.sid));
-    logger.warn('Programme sync: section fetch failed', {
+    failed = true;
+    logger.error('Programme sync: section fetch failed', {
       sectionId: cfg.sid,
       error: error.message,
-    }, LOG_CATEGORIES.API);
-  }
-
-  if (failed.size > 0) {
-    logger.error('Programme sync: could not read one or more sections\' programmes', {
-      failedSections: [...failed],
     }, LOG_CATEGORIES.API);
   }
 
@@ -187,18 +164,16 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
     sectionId: session.sectionId,
   }));
   const { toAdd, orphaned: rawOrphaned } = diffSessions(existingColumns, descriptors);
-  // Drop orphans from any section we couldn't check (no term or fetch error) —
-  // otherwise a transient failure would flag every one of its valid sessions.
-  const orphaned = rawOrphaned.filter(
-    (column) => !unchecked.has(String(column.sectionId)) && !failed.has(String(column.sectionId)),
-  );
+  // A failed fetch means we don't know this run's programme — don't flag its
+  // existing sessions as orphaned.
+  const orphaned = failed ? [] : rawOrphaned;
 
   let errors = [];
   if (toAdd.length > 0) {
     const result = await createOrCompleteRota({
       hostSection: rota.hostSection,
-      year: rota.year,
-      termId: rota.termId,
+      hostTermId: rota.termId,
+      record: recordIdentityFromRota(rota),
       sessions: toAdd,
       token,
     });
@@ -286,8 +261,8 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
     titlesUpdated,
     titleWriteFailed,
     titlesSkippedNoIdentity,
-    uncheckedSections: [...unchecked],
-    failedSections: [...failed],
+    uncheckedSections: [],
+    failedSections: failed ? [String(cfg.sid)] : [],
   };
 }
 
@@ -311,8 +286,8 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
 export async function activateWaterSession({ rota, date, sectionId, fields, by, scoutid, token }) {
   const result = await createOrCompleteRota({
     hostSection: rota.hostSection,
-    year: rota.year,
-    termId: rota.termId,
+    hostTermId: rota.termId,
+    record: recordIdentityFromRota(rota),
     sessions: [{ date, sectionId }],
     token,
   });
@@ -358,6 +333,26 @@ function descriptorFromRota(rota) {
     recordId: rota.recordId,
     hostSection: rota.hostSection,
     sectionId: rota.sectionId,
+    termId: rota.planningTermId,
+    seasonBucket: rota.seasonBucket,
+  };
+}
+
+/**
+ * Rebuild a record identity ({@link buildRotaRecordName}'s input) from an
+ * already-loaded rota, so `createOrCompleteRota` reconstructs the exact same
+ * name as the record was originally created with (required for its
+ * find-by-name idempotency). The section name is read from the record's own
+ * config first — the value the record was actually named with — falling back
+ * to the cached section name map for a record with no config yet.
+ *
+ * @param {import('./rotaService.js').LoadedRota} rota - Loaded rota
+ * @returns {{sectionId: string, sectionName: string, termId: string, seasonBucket: string}} Record identity
+ */
+function recordIdentityFromRota(rota) {
+  return {
+    sectionId: rota.sectionId,
+    sectionName: rota.config?.cfg?.sname ?? rota.sectionNames?.[rota.sectionId] ?? rota.sectionId,
     termId: rota.planningTermId,
     seasonBucket: rota.seasonBucket,
   };

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -1,6 +1,7 @@
 /**
- * Water Rota setup: creates (or completes) the yearly rota FlexiRecord with
- * one column per planned session, writes the initial plan config, and diffs
+ * Water Rota setup: creates (or completes) a planning section's per-term
+ * rota FlexiRecord with one column per planned session, writes the initial
+ * plan config, and diffs
  * an existing rota against freshly generated sessions for programme sync.
  *
  * Creation is resumable and idempotent — it reuses the flexi-records
@@ -65,7 +66,7 @@ export async function createOrCompleteRota({ hostSection, hostTermId, record, se
  * @param {Object} params.hostSection - Host section
  * @param {string|number} params.recordId - FlexiRecord id from creation
  * @param {string|number} params.termId - Term id
- * @param {string|number} params.scoutid - The editor's member row id in the host section
+ * @param {string|number} params.scoutid - The member row to store this candidate in (setup passes a deterministic row; sync passes the editor's own row)
  * @param {string} params.by - Editor display name
  * @param {Object} params.cfg - The full plan config (`replace: true`) or just the changed keys (patch mode)
  * @param {boolean} [params.replace=false] - Full replace instead of a merge patch (see {@link writeConfig})
@@ -131,12 +132,15 @@ export function diffSessions(existingColumns, descriptors) {
  * @param {string} params.token - OSM authentication token
  * @param {string|number} [params.scoutid] - Editor's host-section row id, to attribute the title backfill config write
  * @param {string} [params.by] - Editor display name for the title backfill config write
- * @returns {Promise<{added: number, orphaned: Array, errors: Array, titlesUpdated: number, titleWriteFailed: boolean, titlesSkippedNoIdentity: boolean, uncheckedSections: string[], failedSections: string[]}>}
+ * @returns {Promise<{added: number, orphaned: Array, errors: Array, titlesUpdated: number, titleWriteFailed: boolean, titlesSkippedNoIdentity: boolean, uncheckedSections: string[], failedSections: string[], prefillErrors: Array<{fieldId: string, error: string}>}>}
  *   Sync outcome for this single record. `uncheckedSections` is always empty
  *   (the planning term is always known — it's the record's own identity, not
  *   a "current active term" lookup); `failedSections` holds the section id
  *   when the programme fetch threw (e.g. an expired token) — excluded from
  *   `orphaned` either way, kept as arrays for caller compatibility.
+ *   `prefillErrors` carries any regular pre-fill failures on newly added
+ *   sessions (empty when no new sessions needed pre-filling, or all
+ *   succeeded).
  * @throws {Error} When the rota has no config to sync against
  */
 export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
@@ -171,6 +175,7 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
   const orphaned = failed ? [] : rawOrphaned;
 
   let errors = [];
+  let prefillErrors = [];
   if (toAdd.length > 0) {
     const result = await createOrCompleteRota({
       hostSection: rota.hostSection,
@@ -185,12 +190,16 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
     // re-touch existing sessions, which would undo people's withdrawals.
     const regularsBySection = { [String(cfg.sid)]: cfg.regulars ?? [] };
     if (Object.values(regularsBySection).some((list) => list.length > 0)) {
-      const reloaded = await loadRota(descriptorFromRota(rota), token);
+      // Bypass the structure cache — otherwise the just-added columns come
+      // back as config-only (fieldId null) and the prefill below silently
+      // skips them (mirrors activateWaterSession's same guard).
+      const reloaded = await loadRota(descriptorFromRota(rota), token, { forceRefresh: true });
       const addedNames = new Set(toAdd.map((d) => buildSessionColumnName(d.date, d.sectionId)));
       const newSessions = (reloaded?.sessions ?? []).filter(
         (session) => session.fieldId && addedNames.has(buildSessionColumnName(session.date, session.sectionId)),
       );
-      await prefillRegulars({ rota: reloaded, regularsBySection, token, sessions: newSessions });
+      const prefillResult = await prefillRegulars({ rota: reloaded, regularsBySection, token, sessions: newSessions });
+      prefillErrors = prefillResult.errors ?? [];
     }
   }
 
@@ -266,6 +275,7 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
     titlesUpdated,
     titleWriteFailed,
     titlesSkippedNoIdentity,
+    prefillErrors,
     uncheckedSections: [],
     failedSections: failed ? [String(cfg.sid)] : [],
   };

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -67,12 +67,13 @@ export async function createOrCompleteRota({ hostSection, hostTermId, record, se
  * @param {string|number} params.termId - Term id
  * @param {string|number} params.scoutid - The editor's member row id in the host section
  * @param {string} params.by - Editor display name
- * @param {Object} params.cfg - This record's plan config
+ * @param {Object} params.cfg - The full plan config (`replace: true`) or just the changed keys (patch mode)
+ * @param {boolean} [params.replace=false] - Full replace instead of a merge patch (see {@link writeConfig})
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  * @throws {Error} When the RotaConfig column cannot be found
  */
-export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, token }) {
+export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, replace = false, token }) {
   const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, true);
   const configFieldId = findConfigFieldId(structureData);
   if (!configFieldId) {
@@ -85,6 +86,7 @@ export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, 
     scoutid,
     by,
     cfg,
+    replace,
     token,
   });
 }
@@ -205,17 +207,20 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
   // them to" — and preserve each session's existing config state (its
   // not-on-water flag / activity override) by merging rather than replacing.
   // Only descriptors from sections we actually read this run are considered, so
-  // a section we couldn't reach never loses its stored title.
-  const nextSessions = { ...(cfg.sessions ?? {}) };
+  // a section we couldn't reach never loses its stored title. The patch below
+  // carries ONLY the added/updated session overrides (not the whole sessions
+  // map) — writeConfig's patch mode merges it key-wise onto the live winner's
+  // sessions, so a concurrent regulars/date edit to this record survives.
+  const sessionPatch = {};
   let pendingTitles = 0;
   for (const descriptor of descriptors) {
     if (!descriptor.title) {
       continue;
     }
     const key = buildSessionColumnName(descriptor.date, descriptor.sectionId);
-    const existing = nextSessions[key] ?? {};
+    const existing = (cfg.sessions ?? {})[key] ?? {};
     if (existing.pt !== descriptor.title) {
-      nextSessions[key] = { ...existing, pt: descriptor.title };
+      sessionPatch[key] = { ...existing, pt: descriptor.title };
       pendingTitles += 1;
     }
   }
@@ -232,7 +237,7 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
           termId: rota.termId,
           scoutid,
           by,
-          cfg: { ...cfg, sessions: nextSessions },
+          cfg: { sessions: sessionPatch },
           token,
         });
         titlesUpdated = pendingTitles;
@@ -314,7 +319,7 @@ export async function activateWaterSession({ rota, date, sectionId, fields, by, 
     fieldId: session.fieldId,
     scoutid,
     by,
-    fields: { ...fields, c: 0 },
+    metaPatch: { ...fields, c: 0 },
     token,
   });
 

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -24,14 +24,20 @@ import {
   buildSessionColumnName,
   parseSessionColumnName,
 } from './rotaEncoding.js';
-import { ROTA_CREATE_OPTIONS, buildRotaRecordName } from './rotaTemplates.js';
+import { ROTA_CREATE_OPTIONS, ROTA_RECORD_NAME_PREFIX } from './rotaTemplates.js';
 import { loadRota, prefillRegulars, writeConfig, writeSessionMeta } from './rotaService.js';
 import { fetchProgrammeMeetings } from './programmeService.js';
 import { generateSessionsFromProgramme } from '../utils/rotaDates.js';
-import { mergeSectionConfig } from '../utils/rotaSetupPlan.js';
 
 /**
  * Create or complete the rota record for a year on the host section.
+ *
+ * STOPGAP (pre-WP3): the per-section-record model's `buildRotaRecordName`
+ * needs a record identity ({sectionName, seasonBucket, sectionId, termId},
+ * PRD §2.1) that this whole-year, multi-section function has no way to
+ * supply, so this still names the record with the plain year-based literal
+ * rather than the new builder. WP3 replaces this whole function with the
+ * per-section create flow (PRD §4.2).
  *
  * @param {Object} params
  * @param {Object} params.hostSection - Host section ({sectionid, sectionname, section})
@@ -43,7 +49,7 @@ import { mergeSectionConfig } from '../utils/rotaSetupPlan.js';
  */
 export async function createOrCompleteRota({ hostSection, year, termId, sessions, token }) {
   const template = {
-    name: buildRotaRecordName(year),
+    name: `${ROTA_RECORD_NAME_PREFIX} ${year}`,
     fields: [
       ROTA_CONFIG_COLUMN,
       ...sessions.map((session) => buildSessionColumnName(session.date, session.sectionId)),
@@ -57,7 +63,8 @@ export async function createOrCompleteRota({ hostSection, year, termId, sessions
 /**
  * Write the initial (or updated) plan config after the record exists.
  * Reads the structure fresh to resolve the RotaConfig column id, then
- * delegates to the standard LWW config write.
+ * delegates to the standard LWW config write (a plain replace — a
+ * single-section record has nothing to merge).
  *
  * @param {Object} params
  * @param {Object} params.hostSection - Host section
@@ -65,13 +72,12 @@ export async function createOrCompleteRota({ hostSection, year, termId, sessions
  * @param {string|number} params.termId - Term id
  * @param {string|number} params.scoutid - The editor's member row id in the host section
  * @param {string} params.by - Editor display name
- * @param {Object} params.cfg - Plan config. A full config for the initial write, or one section's slice when mergeSections is set ({start, end, sections, sessions})
- * @param {boolean} [params.mergeSections] - Merge `cfg`'s sections into the live shared config instead of replacing it, so a per-section setup never deletes other leaders' sections and the date range grows (union) to cover it
+ * @param {Object} params.cfg - This record's plan config
  * @param {string} params.token - OSM authentication token
  * @returns {Promise<void>}
  * @throws {Error} When the RotaConfig column cannot be found
  */
-export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, token, mergeSections = false }) {
+export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, by, cfg, token }) {
   const structureData = await getFlexiStructure(recordId, hostSection.sectionid, termId, token, true);
   const configFieldId = findConfigFieldId(structureData);
   if (!configFieldId) {
@@ -83,9 +89,7 @@ export async function writeRotaConfig({ hostSection, recordId, termId, scoutid, 
     configFieldId,
     scoutid,
     by,
-    ...(mergeSections
-      ? { transformCfg: (live) => mergeSectionConfig(live, cfg) }
-      : { cfg }),
+    cfg,
     token,
   });
 }
@@ -117,10 +121,16 @@ export function diffSessions(existingColumns, descriptors) {
 }
 
 /**
- * Sync an existing rota with each section's programme: appends columns for
- * newly added meeting dates and reports sessions whose programme meeting
- * has vanished (candidates to mark not-on-water — never deleted, since OSM
- * has no column delete).
+ * Sync an existing rota with its (single) section's programme: appends
+ * columns for newly added meeting dates and reports sessions whose programme
+ * meeting has vanished (candidates to mark not-on-water — never deleted,
+ * since OSM has no column delete).
+ *
+ * STOPGAP (pre-WP3): still resolves the section's *current active* term via
+ * {@link CurrentActiveTermsService} rather than the record's own planning
+ * `termId` (PRD §4.4) — LoadedRota doesn't thread a planning termid through
+ * this call site yet. `uncheckedSections`/`failedSections` are single-section
+ * results (0 or 1 entries), kept as arrays for now to minimize caller churn.
  *
  * @param {Object} params
  * @param {import('./rotaService.js').LoadedRota} params.rota - Loaded rota with config
@@ -128,9 +138,9 @@ export function diffSessions(existingColumns, descriptors) {
  * @param {string|number} [params.scoutid] - Editor's host-section row id, to attribute the title backfill config write
  * @param {string} [params.by] - Editor display name for the title backfill config write
  * @returns {Promise<{added: number, orphaned: Array, errors: Array, titlesUpdated: number, titleWriteFailed: boolean, titlesSkippedNoIdentity: boolean, uncheckedSections: string[], failedSections: string[]}>}
- *   Sync outcome. `uncheckedSections` = sections with no active term (benign,
- *   nothing to sync); `failedSections` = sections whose programme fetch threw
- *   (a real error, e.g. expired token) — both are excluded from `orphaned`.
+ *   Sync outcome. `uncheckedSections` = no active term found (benign, nothing
+ *   to sync); `failedSections` = the programme fetch threw (a real error,
+ *   e.g. expired token) — both are excluded from `orphaned`.
  * @throws {Error} When the rota has no config to sync against
  */
 export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
@@ -141,30 +151,28 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
 
   const range = { start: cfg.start, end: cfg.end };
   const descriptors = [];
-  // Sections we couldn't read this run. We must NOT treat their existing
-  // sessions as orphaned — we don't know their programme, so leave them
-  // untouched. Split by cause so the caller can tell a benign "no active term"
-  // apart from a real fetch failure (e.g. an expired token failing every
-  // section) and message accordingly.
+  // Set when the section's programme couldn't be read this run. We must NOT
+  // treat its existing sessions as orphaned — we don't know its programme, so
+  // leave them untouched. Split by cause so the caller can tell a benign "no
+  // active term" apart from a real fetch failure (e.g. an expired token) and
+  // message accordingly.
   const unchecked = new Set();
   const failed = new Set();
 
-  for (const section of cfg.sections ?? []) {
-    try {
-      const term = await CurrentActiveTermsService.getCurrentActiveTerm(section.sid);
-      if (!term?.currentTermId) {
-        unchecked.add(String(section.sid));
-        continue;
-      }
-      const meetings = await fetchProgrammeMeetings(section.sid, term.currentTermId, token);
-      descriptors.push(...generateSessionsFromProgramme(meetings, section, range));
-    } catch (error) {
-      failed.add(String(section.sid));
-      logger.warn('Programme sync: section fetch failed', {
-        sectionId: section.sid,
-        error: error.message,
-      }, LOG_CATEGORIES.API);
+  try {
+    const term = await CurrentActiveTermsService.getCurrentActiveTerm(cfg.sid);
+    if (!term?.currentTermId) {
+      unchecked.add(String(cfg.sid));
+    } else {
+      const meetings = await fetchProgrammeMeetings(cfg.sid, term.currentTermId, token);
+      descriptors.push(...generateSessionsFromProgramme(meetings, cfg, range));
     }
+  } catch (error) {
+    failed.add(String(cfg.sid));
+    logger.warn('Programme sync: section fetch failed', {
+      sectionId: cfg.sid,
+      error: error.message,
+    }, LOG_CATEGORIES.API);
   }
 
   if (failed.size > 0) {
@@ -196,11 +204,9 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
     });
     errors = result.errors ?? [];
 
-    // Pre-fill each section's regulars onto the NEW sessions only — never
+    // Pre-fill the section's regulars onto the NEW sessions only — never
     // re-touch existing sessions, which would undo people's withdrawals.
-    const regularsBySection = Object.fromEntries(
-      (cfg.sections ?? []).map((section) => [String(section.sid), section.regulars ?? []]),
-    );
+    const regularsBySection = { [String(cfg.sid)]: cfg.regulars ?? [] };
     if (Object.values(regularsBySection).some((list) => list.length > 0)) {
       const reloaded = await loadRota(rota.year, token);
       const addedNames = new Set(toAdd.map((d) => buildSessionColumnName(d.date, d.sectionId)));

--- a/src/features/water-rota/services/rotaSetupService.js
+++ b/src/features/water-rota/services/rotaSetupService.js
@@ -208,7 +208,7 @@ export async function syncRotaWithProgramme({ rota, token, scoutid, by }) {
     // re-touch existing sessions, which would undo people's withdrawals.
     const regularsBySection = { [String(cfg.sid)]: cfg.regulars ?? [] };
     if (Object.values(regularsBySection).some((list) => list.length > 0)) {
-      const reloaded = await loadRota(rota.year, token);
+      const reloaded = await loadRota(descriptorFromRota(rota), token);
       const addedNames = new Set(toAdd.map((d) => buildSessionColumnName(d.date, d.sectionId)));
       const newSessions = (reloaded?.sessions ?? []).filter(
         (session) => session.fieldId && addedNames.has(buildSessionColumnName(session.date, session.sectionId)),
@@ -323,7 +323,7 @@ export async function activateWaterSession({ rota, date, sectionId, fields, by, 
   // The column was just added, so bypass the cached structure — otherwise the
   // new session comes back as config-only (fieldId null) and the meta write
   // that puts it on the water is silently skipped.
-  const reloaded = await loadRota(rota.year, token, { forceRefresh: true });
+  const reloaded = await loadRota(descriptorFromRota(rota), token, { forceRefresh: true });
   const columnName = buildSessionColumnName(date, sectionId);
   const session = (reloaded?.sessions ?? []).find(
     (s) => s.fieldId && buildSessionColumnName(s.date, s.sectionId) === columnName,
@@ -344,6 +344,23 @@ export async function activateWaterSession({ rota, date, sectionId, fields, by, 
   });
 
   return reloaded;
+}
+
+/**
+ * Rebuild a {@link import('./rotaService.js').RotaDescriptor} from an
+ * already-loaded rota, so a reload doesn't need to re-run discovery.
+ *
+ * @param {import('./rotaService.js').LoadedRota} rota - Loaded rota
+ * @returns {Object} Descriptor accepted by rotaService's loadRota
+ */
+function descriptorFromRota(rota) {
+  return {
+    recordId: rota.recordId,
+    hostSection: rota.hostSection,
+    sectionId: rota.sectionId,
+    termId: rota.planningTermId,
+    seasonBucket: rota.seasonBucket,
+  };
 }
 
 /**

--- a/src/features/water-rota/services/rotaTemplates.js
+++ b/src/features/water-rota/services/rotaTemplates.js
@@ -1,14 +1,17 @@
 /**
  * Presets and naming for the Water Session Permit Rota.
  *
- * The rota is stored in one OSM FlexiRecord per calendar year, discovered by
- * name prefix so every leader's device finds it without local configuration.
+ * The rota is stored as one OSM FlexiRecord per (planning section, that
+ * section's own term), all hosted in the Adults section. Record identity —
+ * planning sectionid, planning termid, season bucket — is fully name-derived
+ * so every leader's device finds it without local configuration and without
+ * depending on any term resolution.
  *
  * @module rotaTemplates
  */
 
 /**
- * Name prefix shared by every yearly rota FlexiRecord.
+ * Name prefix shared by every rota FlexiRecord.
  * @type {string}
  */
 export const ROTA_RECORD_NAME_PREFIX = 'Viking Water Rota';
@@ -46,13 +49,50 @@ export const DEFAULT_SESSION_TIMES = { start: '18:30', end: '20:00' };
 export const ROTA_CREATE_OPTIONS = { dob: '0', age: '0', patrol: '0', type: 'none' };
 
 /**
- * Build the exact FlexiRecord name for a rota year.
+ * Build the exact FlexiRecord name for one planning section's record.
  *
- * @param {number} year - Four-digit calendar year (e.g. 2026)
- * @returns {string} Record name, e.g. "Viking Water Rota 2026"
+ * @param {Object} identity
+ * @param {string} identity.sectionName - Planning section's display name
+ * @param {string} identity.seasonBucket - Deterministic season label (see {@link seasonBucketForRange})
+ * @param {string|number} identity.sectionId - Planning section id
+ * @param {string|number} identity.termId - Planning section's own term id the plan was built from
+ * @returns {string} Record name, e.g. "Viking Water Rota Scouts Summer 2026 [49097.924956]"
  */
-export function buildRotaRecordName(year) {
-  return `${ROTA_RECORD_NAME_PREFIX} ${year}`;
+export function buildRotaRecordName({ sectionName, seasonBucket, sectionId, termId }) {
+  return `${ROTA_RECORD_NAME_PREFIX} ${sectionName} ${seasonBucket} [${sectionId}.${termId}]`;
+}
+
+/**
+ * Parse a rota FlexiRecord name back into its identity. Names from the
+ * retired year model (or any other shape) are not rota records and parse to
+ * null — good, since a record's identity must be fully name-derived.
+ *
+ * @param {string} name - FlexiRecord name
+ * @returns {{sectionName: string, seasonBucket: string, sectionId: string, termId: string}|null} Record identity, or null when the name is not a rota record
+ */
+export function parseRotaRecordName(name) {
+  const match = /^Viking Water Rota (.+) ((?:Spring|Summer|Autumn) \d{4}) \[(\d+)\.(\d+)\]$/
+    .exec(String(name ?? '').trim());
+  return match
+    ? { sectionName: match[1].trim(), seasonBucket: match[2], sectionId: match[3], termId: match[4] }
+    : null;
+}
+
+/**
+ * Derive the deterministic season-bucket grouping key from a term's date
+ * range, using the range's midpoint month so every section's own term for
+ * "the same season" (different dates, different termids) lands in the same
+ * bucket. Term names are not reliable identifiers; dates are.
+ *
+ * @param {string} startISO - Term start date (yyyy-mm-dd)
+ * @param {string} endISO - Term end date (yyyy-mm-dd)
+ * @returns {string} Season bucket label, e.g. "Summer 2026"
+ */
+export function seasonBucketForRange(startISO, endISO) {
+  const mid = new Date((Date.parse(startISO) + Date.parse(endISO)) / 2);
+  const month = mid.getUTCMonth() + 1;
+  const season = month <= 3 ? 'Spring' : month <= 8 ? 'Summer' : 'Autumn';
+  return `${season} ${mid.getUTCFullYear()}`;
 }
 
 /**
@@ -109,15 +149,4 @@ export function looksLikeWaterSession(title) {
   }
   const haystack = title.toLowerCase();
   return WATER_KEYWORDS.some((keyword) => haystack.includes(keyword));
-}
-
-/**
- * Extract the year from a rota FlexiRecord name.
- *
- * @param {string} name - FlexiRecord name
- * @returns {number|null} Four-digit year, or null when the name is not a rota record
- */
-export function parseRotaRecordYear(name) {
-  const match = /^Viking Water Rota (\d{4})$/.exec(String(name ?? '').trim());
-  return match ? Number(match[1]) : null;
 }

--- a/src/features/water-rota/services/vikingWaterRotaValidation.js
+++ b/src/features/water-rota/services/vikingWaterRotaValidation.js
@@ -1,5 +1,7 @@
 /**
- * Structure validation for a "Viking Water Rota <year>" FlexiRecord.
+ * Structure validation for a "Viking Water Rota <SectionName> <SeasonBucket>
+ * [<sectionid>.<termid>]" FlexiRecord (one per planning section's own term,
+ * hosted in the Adults section).
  *
  * Pure sibling of vikingEventMgmtValidation: it takes an already-fetched
  * structure (fieldMapping) rather than fetching, because rota discovery and

--- a/src/features/water-rota/utils/__tests__/rotaSetupPlan.test.js
+++ b/src/features/water-rota/utils/__tests__/rotaSetupPlan.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { buildSessionOverrides, mergeSectionConfig } from '../rotaSetupPlan.js';
+import { buildSessionOverrides } from '../rotaSetupPlan.js';
 
 describe('buildSessionOverrides', () => {
   const sectionDefaults = [{ sid: '49097', act: 'Kayaking', st: '18:15', en: '19:30' }];
@@ -57,68 +57,5 @@ describe('buildSessionOverrides', () => {
       sectionDefaults,
     );
     expect(overrides.S_20260714_49097).toEqual({ c: 1 });
-  });
-});
-
-describe('mergeSectionConfig', () => {
-  const base = {
-    start: '2026-06-01',
-    end: '2026-07-31',
-    sections: [
-      { sid: '10', sname: 'Beavers', act: 'Kayaking' },
-      { sid: '20', sname: 'Cubs', act: 'Canoeing' },
-    ],
-    sessions: {
-      S_20260603_10: { pt: 'Beavers night' },
-      S_20260605_20: { pt: 'Cubs night', c: 1 },
-    },
-  };
-
-  it('rewrites only the touched section and preserves the others', () => {
-    // Beavers leader re-runs setup; Cubs must be untouched.
-    const patch = {
-      start: '2026-06-08',
-      end: '2026-07-31',
-      sections: [{ sid: '10', sname: 'Beavers', act: 'Canoeing' }],
-      sessions: { S_20260610_10: { pt: 'Beavers new' } },
-    };
-    const merged = mergeSectionConfig(base, patch);
-
-    // Cubs section + its session survive intact
-    expect(merged.sections).toContainEqual({ sid: '20', sname: 'Cubs', act: 'Canoeing' });
-    expect(merged.sessions.S_20260605_20).toEqual({ pt: 'Cubs night', c: 1 });
-    // Beavers is replaced: new defaults, old session dropped, new session added
-    expect(merged.sections.find((s) => s.sid === '10')).toEqual({ sid: '10', sname: 'Beavers', act: 'Canoeing' });
-    expect(merged.sessions.S_20260603_10).toBeUndefined();
-    expect(merged.sessions.S_20260610_10).toEqual({ pt: 'Beavers new' });
-  });
-
-  it('unions the date range so a section extends it, never truncates', () => {
-    const merged = mergeSectionConfig(base, {
-      start: '2026-05-15', end: '2026-08-31', sections: [{ sid: '10' }], sessions: {},
-    });
-    expect(merged.start).toBe('2026-05-15');
-    expect(merged.end).toBe('2026-08-31');
-  });
-
-  it('keeps the base range when the patch range sits inside it', () => {
-    const merged = mergeSectionConfig(base, {
-      start: '2026-06-10', end: '2026-07-10', sections: [{ sid: '10' }], sessions: {},
-    });
-    expect(merged.start).toBe('2026-06-01');
-    expect(merged.end).toBe('2026-07-31');
-  });
-
-  it('acts as a plain write when the base config is empty (first setup)', () => {
-    const patch = {
-      start: '2026-06-01', end: '2026-07-31',
-      sections: [{ sid: '10', sname: 'Beavers' }],
-      sessions: { S_20260603_10: { pt: 'x' } },
-    };
-    const merged = mergeSectionConfig({}, patch);
-    expect(merged.sections).toEqual([{ sid: '10', sname: 'Beavers' }]);
-    expect(merged.sessions).toEqual({ S_20260603_10: { pt: 'x' } });
-    expect(merged.start).toBe('2026-06-01');
-    expect(merged.end).toBe('2026-07-31');
   });
 });

--- a/src/features/water-rota/utils/rotaDisplay.js
+++ b/src/features/water-rota/utils/rotaDisplay.js
@@ -51,6 +51,7 @@ export function coverStatus({ confirmedCount, backupCount, needed, cancelled }) 
  *
  * @typedef {Object} SessionView
  * @property {string} fieldId - Session column field id
+ * @property {import('../services/rotaService.js').LoadedRota|undefined} record - Owning record, when resolved from a rota group
  * @property {string} date - yyyy-mm-dd
  * @property {string} sectionId - OSM section id
  * @property {string} sectionName - Display section name
@@ -114,6 +115,12 @@ export function resolveSessionView(session, config, sectionNames = {}) {
 
   const view = {
     fieldId: session.fieldId,
+    // Owning record — carried through from a group-aggregated session
+    // (rotaService.assembleRotaGroup) so signup/meta writes route to the
+    // record that owns this session, not the whole group. Undefined for a
+    // single-record (non-aggregated) rota, which is fine since callers only
+    // read it when write-routing a group.
+    record: session.record,
     // Stable identity for React keys and selection — session columns share it
     // with config-only (not-on-water) sessions that have no fieldId.
     key: columnName,

--- a/src/features/water-rota/utils/rotaDisplay.js
+++ b/src/features/water-rota/utils/rotaDisplay.js
@@ -50,8 +50,9 @@ export function coverStatus({ confirmedCount, backupCount, needed, cancelled }) 
  * Render-ready session view model.
  *
  * @typedef {Object} SessionView
- * @property {string} fieldId - Session column field id
+ * @property {string|null} fieldId - Session column field id; null for a config-only not-on-water session with no signup column
  * @property {import('../services/rotaService.js').LoadedRota|undefined} record - Owning record, when resolved from a rota group
+ * @property {string} key - Session column name; stable identity (React keys, pending state, ?session= deep link)
  * @property {string} date - yyyy-mm-dd
  * @property {string} sectionId - OSM section id
  * @property {string} sectionName - Display section name
@@ -76,7 +77,7 @@ export function coverStatus({ confirmedCount, backupCount, needed, cancelled }) 
  * candidate survives (e.g. the writer left the host section), the session
  * self-heals from the config's per-section defaults.
  *
- * @param {{fieldId: string, date: string, sectionId: string, meta: Object|null, signups: Array}} session - Decoded session from loadRota
+ * @param {{fieldId: string|null, date: string, sectionId: string, meta: Object|null, signups: Array}} session - Decoded session from loadRota
  * @param {Object|null} config - LWW-winning config candidate ({cfg}) or null
  * @param {Object} [sectionNames] - Fallback map of sectionId to name (from cached sections)
  * @returns {SessionView} Render-ready view model
@@ -158,9 +159,9 @@ export function resolveSessionView(session, config, sectionNames = {}) {
 }
 
 /**
- * Resolve every session in a loaded rota, sorted by date.
+ * Resolve every session in a loaded rota group, sorted by date.
  *
- * @param {import('../services/rotaService.js').LoadedRota} rota - Loaded rota
+ * @param {import('../services/rotaService.js').RotaGroup} rota - Loaded rota group
  * @returns {SessionView[]} View models sorted by date then section
  */
 export function resolveAllSessions(rota) {

--- a/src/features/water-rota/utils/rotaSetupPlan.js
+++ b/src/features/water-rota/utils/rotaSetupPlan.js
@@ -6,74 +6,7 @@
  * @module rotaSetupPlan
  */
 
-import { buildSessionColumnName, parseSessionColumnName } from '../services/rotaEncoding.js';
-
-/**
- * Earlier of two yyyy-mm-dd date strings, ignoring null/undefined.
- * @param {string|null|undefined} a
- * @param {string|null|undefined} b
- * @returns {string|undefined}
- */
-function earlier(a, b) {
-  if (!a) return b || undefined;
-  if (!b) return a;
-  return a <= b ? a : b;
-}
-
-/**
- * Later of two yyyy-mm-dd date strings, ignoring null/undefined.
- * @param {string|null|undefined} a
- * @param {string|null|undefined} b
- * @returns {string|undefined}
- */
-function later(a, b) {
-  if (!a) return b || undefined;
-  if (!b) return a;
-  return a >= b ? a : b;
-}
-
-/**
- * Merge one setup run's sections into the shared rota config without disturbing
- * the sections it didn't touch. Section leaders set up their own section, so a
- * save must NEVER replace the whole config (which would delete every other
- * leader's section). Only the sections in `patch` are rewritten; the rota-wide
- * date range grows to cover the patch (union), so each section extends it.
- *
- * @param {Object|null|undefined} base - Live shared config ({start,end,sections,sessions})
- * @param {{sections?: Array<{sid: string}>, sessions?: Object, start?: string, end?: string}} patch - This run's data
- * @returns {Object} Merged config
- */
-export function mergeSectionConfig(base, patch) {
-  const baseCfg = base ?? {};
-  const p = patch ?? {};
-  const touched = new Set((p.sections ?? []).map((s) => String(s.sid)));
-
-  // Sections: keep untouched sections, replace/add the touched ones.
-  const sections = [
-    ...(baseCfg.sections ?? []).filter((s) => !touched.has(String(s.sid))),
-    ...(p.sections ?? []),
-  ];
-
-  // Sessions: drop the touched sections' old overrides (this run redefines
-  // them), keep every other section's, then add this run's.
-  const sessions = {};
-  for (const [col, override] of Object.entries(baseCfg.sessions ?? {})) {
-    const parsed = parseSessionColumnName(col);
-    if (parsed && touched.has(String(parsed.sectionId))) {
-      continue;
-    }
-    sessions[col] = override;
-  }
-  Object.assign(sessions, p.sessions ?? {});
-
-  return {
-    ...baseCfg,
-    start: earlier(baseCfg.start, p.start),
-    end: later(baseCfg.end, p.end),
-    sections,
-    sessions,
-  };
-}
+import { buildSessionColumnName } from '../services/rotaEncoding.js';
 
 /**
  * Build the per-session config map from all generated descriptors: water


### PR DESCRIPTION
## Summary

Storage-model rework of the Water Session Permit Rota (supersedes the year-record model shipped v2.19.0–v2.22.0). Clean rebuild, no migration — the old test FlexiRecord was deleted from OSM and verified gone.

**New model:** one FlexiRecord per **(section, that section's own term)**, all hosted in the Adults section (rows = permit holders, so anyone can sign up for any section). Record identity is fully name-derived: `Viking Water Rota <Section> <SeasonBucket> [<sectionid>.<termid>]` — both ids the planning section's own; no host termid in identity (resolved at call time from cached current-active-terms). The board groups records into **season buckets** derived from term dates (term *names* proved unreliable across sections) and aggregates all sections' records per bucket.

Designed against live OSM facts: terms are per-section (own ids/names/dates); Adults has year-terms only; flexi values are per-member, not term-scoped (verified). Full spec: `docs/features/water-rota-term-model-prd.md`.

## What changed

- **Encoding (WP1):** term-based record naming + parse, deterministic `seasonBucketForRange`, single-section `RotaConfig` payload.
- **Services (WP2):** one-call discovery on the host section (numeric lowest-extraid dedupe), descriptor-based `loadRota`, `loadRotaGroup` + group assembly, 300ms prefill throttle. `resolveRotaTermId` (the rollover bug) deleted.
- **Setup (WP3):** per-section wizard — pick your section, its own term (from `getTerms`), programme review, idempotent create-or-complete. No all-sections wizard, no config merging, no cross-section race (by construction: different sections are different records).
- **Board (WP4):** season picker + `?season=` links, multi-record aggregation, signup writes routed to each session's owning record (pending state keyed on globally-unique session column — fieldIds repeat across records), per-record "Sync programme" reporting, My week over the aggregate. Fixed a pre-existing wizard render crash (range-unloaded `parseISO`).
- **Identity (WP5):** resolved once per host section (was per record); "Signed in as … · Change" re-pick control on board + My week (wires the previously-dead `useRotaIdentity.clear()` — red-team #3).
- **Sweep (WP6):** all year-model/shared-config symbols grep-verified gone; feature docs updated; original design spikes closed out.
- **Review fixes:** two-lens (data-integrity + React-integration) review, then: live-winner merge for config/session-meta writes (concurrent co-leader edits no longer lost — pre-existing lost-update fixed), stale `?season=` fallback, discovery read errors surfaced instead of rendering as "no rota", identity re-pick no longer undone by concurrent refresh, wizard rejects host/waiting-list `?section=`.

## Testing

- `npm run lint` — 0 errors
- `npm run test:run` — **943 passed / 0 failed** (248 in water-rota across 23 files)
- `npm run build` — succeeds; `npx cap sync` clean (local `pod install` gem issue is machine-specific, unrelated)
- Live-OSM smoke test pending: create two sections' Summer 2026 records via the new wizard, verify board aggregation + cross-record signup

## Known follow-ups (deliberate, not in this PR)

1. `RotaBoardPage`/`MyCommitmentsPage` component-test harness (none existed before; hooks/services are unit-tested)
2. Cover semantics (red-team #2): regulars still auto-confirmed — deferred by decision 2026-07-13
3. Partial render when one section's record read fails (currently fail-fast, matching previous behaviour)
4. My week follows the default season rather than the board's picked one (moot while a single season is live)
5. Multi-section sync progress UX polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyLxWyhCcnPne8pe4P84SR