### PR TITLE
fix: water rota falls back to cache or sign-in prompt when token missing/expired

### DIFF
--- a/src/features/water-rota/components/MyCommitmentsPage.jsx
+++ b/src/features/water-rota/components/MyCommitmentsPage.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import ConfirmModal from '../../../shared/components/ui/ConfirmModal.jsx';
 import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
 import { useWaterRota } from '../hooks/useWaterRota.js';
+import { useAuth } from '../../auth/hooks/useAuth.jsx';
 import { useRotaIdentity } from '../hooks/useRotaIdentity.js';
 import { useRotaSignup } from '../hooks/useRotaSignup.js';
 import {
@@ -29,7 +30,8 @@ const BUCKET_LABELS = [
  * @returns {JSX.Element} My commitments page
  */
 function MyCommitmentsPage() {
-  const { loading, rota, error, refresh } = useWaterRota();
+  const { loading, rota, error, refresh, needsAuth } = useWaterRota();
+  const { login } = useAuth();
   const identityState = useRotaIdentity(rota);
   const { identity, needsPicker, choose, clear } = identityState;
   const { setSignup, pendingKey } = useRotaSignup(rota, identity, refresh);
@@ -69,6 +71,24 @@ function MyCommitmentsPage() {
 
   if (loading) {
     return <LoadingScreen message="Loading your sessions..." />;
+  }
+
+  if (needsAuth) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-12 text-center">
+        <p className="text-gray-700 font-medium">Sign in to see your sessions</p>
+        <p className="mt-1 text-sm text-gray-500">
+          Your OSM session has expired or you&apos;re not signed in.
+        </p>
+        <button
+          type="button"
+          onClick={login}
+          className="mt-4 px-4 py-2 rounded-md bg-scout-blue text-white text-sm font-medium hover:bg-scout-blue-dark"
+        >
+          Sign in to OSM
+        </button>
+      </div>
+    );
   }
 
   if (error || !rota) {

--- a/src/features/water-rota/components/RotaBoardPage.jsx
+++ b/src/features/water-rota/components/RotaBoardPage.jsx
@@ -5,6 +5,7 @@ import SectionFilter from '../../../shared/components/ui/SectionFilter.jsx';
 import ConfirmModal from '../../../shared/components/ui/ConfirmModal.jsx';
 import LoadingScreen from '../../../shared/components/LoadingScreen.jsx';
 import { useWaterRota } from '../hooks/useWaterRota.js';
+import { useAuth } from '../../auth/hooks/useAuth.jsx';
 import { useRotaIdentity } from '../hooks/useRotaIdentity.js';
 import { useRotaSignup } from '../hooks/useRotaSignup.js';
 import {
@@ -54,7 +55,8 @@ function RotaBoardPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const seasonParam = searchParams.get('season');
-  const { loading, rota, error, refresh, seasonBucket, buckets } = useWaterRota(seasonParam || undefined);
+  const { loading, rota, error, refresh, seasonBucket, buckets, needsAuth } = useWaterRota(seasonParam || undefined);
+  const { login } = useAuth();
   const identityState = useRotaIdentity(rota);
   const { identity, needsPicker, choose, clear } = identityState;
   const { setSignup, pendingKey } = useRotaSignup(rota, identity, refresh);
@@ -403,6 +405,24 @@ function RotaBoardPage() {
 
   if (loading) {
     return <LoadingScreen message="Loading water rota..." />;
+  }
+
+  if (needsAuth) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-12 text-center">
+        <p className="text-gray-700 font-medium">Sign in to see the water rota</p>
+        <p className="mt-1 text-sm text-gray-500">
+          Your OSM session has expired or you&apos;re not signed in. Sign in to load the rota.
+        </p>
+        <button
+          type="button"
+          onClick={login}
+          className="mt-4 px-4 py-2 rounded-md bg-scout-blue text-white text-sm font-medium hover:bg-scout-blue-dark"
+        >
+          Sign in to OSM
+        </button>
+      </div>
+    );
   }
 
   if (error) {

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -24,6 +24,7 @@ vi.mock('../../../../shared/services/data/dataLoadingService.js', () => ({
   },
 }));
 
+import logger from '../../../../shared/services/utils/logger.js';
 import { discoverRotaRecords, loadRotaGroup } from '../../services/rotaService.js';
 import dataLoadingService from '../../../../shared/services/data/dataLoadingService.js';
 import {
@@ -269,5 +270,33 @@ describe('useWaterRota', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBeInstanceOf(Error);
     expect(result.current.rota).toBeNull();
+    expect(result.current.needsAuth).toBe(false);
+  });
+
+  it('classifies a missing-token error as needsAuth, logged at info (not error, to avoid spamming Sentry)', async () => {
+    const authError = new Error('No authentication token');
+    authError.code = 'NO_TOKEN';
+    discoverRotaRecords.mockRejectedValue(authError);
+
+    const { result } = renderHook(() => useWaterRota());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.needsAuth).toBe(true);
+    expect(result.current.error).toBe(authError);
+    expect(result.current.rota).toBeNull();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('classifies an expired-token error as needsAuth', async () => {
+    const authError = new Error('Cannot call testRead - authentication token has expired');
+    authError.isTokenExpired = true;
+    discoverRotaRecords.mockRejectedValue(authError);
+
+    const { result } = renderHook(() => useWaterRota());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.needsAuth).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
+++ b/src/features/water-rota/hooks/__tests__/useWaterRota.test.jsx
@@ -299,4 +299,17 @@ describe('useWaterRota', () => {
     expect(result.current.needsAuth).toBe(true);
     expect(logger.error).not.toHaveBeenCalled();
   });
+
+  it('classifies a server-rejected token (401) as needsAuth, not a false empty board', async () => {
+    const authError = new Error('Authentication failed');
+    authError.status = 401;
+    discoverRotaRecords.mockRejectedValue(authError);
+
+    const { result } = renderHook(() => useWaterRota());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.needsAuth).toBe(true);
+    expect(result.current.rota).toBeNull();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/water-rota/hooks/useRotaSignup.js
+++ b/src/features/water-rota/hooks/useRotaSignup.js
@@ -57,8 +57,12 @@ export function useRotaSignup(rota, identity, refresh) {
         notifySuccess(successMessage(status));
         await refresh();
       } catch (error) {
-        if (error?.code === 'WRITE_UNAVAILABLE') {
-          notifyError('You\'re offline — connect to change your signup.');
+        if (error?.code === 'NO_TOKEN' || error?.isTokenExpired === true) {
+          notifyError('Your session has expired — sign in again to change your signup.');
+        } else if (error?.code === 'WRITE_UNAVAILABLE') {
+          notifyError(/blocked/i.test(error.message)
+            ? 'OSM has temporarily blocked the app — try again later.'
+            : 'You\'re offline — connect to change your signup.');
         } else {
           notifyError(`Signup failed: ${error.message}`);
         }

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -161,14 +161,16 @@ export function useWaterRota(seasonBucket) {
       if (!isCurrent()) {
         return;
       }
-      const isAuthError = error?.code === 'NO_TOKEN' || error?.isTokenExpired === true;
+      const isAuthError = error?.code === 'NO_TOKEN' || error?.isTokenExpired === true || error?.status === 401;
       if (isAuthError) {
         // Expected signed-out/expired state, not a real failure — logging at
-        // error would spam Sentry every time a session lapses.
+        // error would spam Sentry every time a session lapses. status 401
+        // covers a locally-valid token the server rejected, which must not
+        // fall through to the generic error (or worse, an empty "no rota").
         logger.info('Water rota load needs sign-in', {
           seasonBucket,
           error: error.message,
-        }, LOG_CATEGORIES.ERROR);
+        }, LOG_CATEGORIES.AUTH);
         setState({ loading: false, rota: null, error, seasonBucket: null, buckets: [], needsAuth: true });
         return;
       }

--- a/src/features/water-rota/hooks/useWaterRota.js
+++ b/src/features/water-rota/hooks/useWaterRota.js
@@ -93,11 +93,11 @@ export function defaultSeasonBucket(buckets, todayISO = format(new Date(), 'yyyy
  * planning section's record in that bucket.
  *
  * @param {string} [seasonBucket] - Season bucket to load, e.g. "Summer 2026"; defaults to {@link defaultSeasonBucket}
- * @returns {{loading: boolean, rota: import('../services/rotaService.js').RotaGroup|null, error: Error|null, refresh: Function, seasonBucket: string|null, buckets: string[]}} Rota state
+ * @returns {{loading: boolean, rota: import('../services/rotaService.js').RotaGroup|null, error: Error|null, refresh: Function, seasonBucket: string|null, buckets: string[], needsAuth: boolean}} Rota state
  */
 export function useWaterRota(seasonBucket) {
   const [state, setState] = useState({
-    loading: true, rota: null, error: null, seasonBucket: null, buckets: [],
+    loading: true, rota: null, error: null, seasonBucket: null, buckets: [], needsAuth: false,
   });
   const requestIdRef = useRef(0);
   const mountedRef = useRef(true);
@@ -156,16 +156,27 @@ export function useWaterRota(seasonBucket) {
         });
         return;
       }
-      setState({ loading: false, rota, error: null, seasonBucket: activeBucket, buckets });
+      setState({ loading: false, rota, error: null, seasonBucket: activeBucket, buckets, needsAuth: false });
     } catch (error) {
       if (!isCurrent()) {
+        return;
+      }
+      const isAuthError = error?.code === 'NO_TOKEN' || error?.isTokenExpired === true;
+      if (isAuthError) {
+        // Expected signed-out/expired state, not a real failure — logging at
+        // error would spam Sentry every time a session lapses.
+        logger.info('Water rota load needs sign-in', {
+          seasonBucket,
+          error: error.message,
+        }, LOG_CATEGORIES.ERROR);
+        setState({ loading: false, rota: null, error, seasonBucket: null, buckets: [], needsAuth: true });
         return;
       }
       logger.error('Water rota load failed', {
         seasonBucket,
         error: error.message,
       }, LOG_CATEGORIES.ERROR);
-      setState({ loading: false, rota: null, error, seasonBucket: null, buckets: [] });
+      setState({ loading: false, rota: null, error, seasonBucket: null, buckets: [], needsAuth: false });
     }
   }, [seasonBucket]);
 

--- a/src/shared/services/api/api/__tests__/osmRequest.test.js
+++ b/src/shared/services/api/api/__tests__/osmRequest.test.js
@@ -208,4 +208,22 @@ describe('osmRequest token handling (issue #233)', () => {
     ).rejects.toMatchObject({ code: 'NO_TOKEN' });
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it('read with an expired token and no cache rejects with a TokenExpiredError shape', async () => {
+    isTokenExpired.mockReturnValue(true);
+    await expect(
+      osmRequest('testRead', '/read', { token: 'expired-tok', emptyValue: { items: [] } }),
+    ).rejects.toMatchObject({ isTokenExpired: true, status: 401 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('write with an expired token still rejects (unchanged behavior)', async () => {
+    isTokenExpired.mockReturnValue(true);
+    await expect(
+      osmRequest('testWrite', '/write', {
+        token: 'expired-tok', method: 'POST', write: true, body: { a: 1 },
+      }),
+    ).rejects.toMatchObject({ isTokenExpired: true });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/src/shared/services/api/api/__tests__/osmRequest.test.js
+++ b/src/shared/services/api/api/__tests__/osmRequest.test.js
@@ -39,6 +39,7 @@ vi.mock('../../../utils/sentry.js', () => ({
 
 import { osmRequest } from '../base.js';
 import { authHandler } from '../../../auth/authHandler.js';
+import { isTokenExpired } from '../../../auth/tokenService.js';
 
 function okResponse(body) {
   return {
@@ -54,6 +55,7 @@ beforeEach(() => {
   demoMock.enabled = false;
   localStorage.removeItem('osm_blocked');
   authHandler.shouldMakeAPICall.mockReturnValue(true);
+  isTokenExpired.mockReturnValue(false);
   global.fetch = vi.fn(async () => okResponse({ items: [1, 2] }));
 });
 
@@ -171,5 +173,39 @@ describe('osmRequest reads', () => {
     const result = await osmRequest('testRead', '/read', { token: 'tok' });
     expect(result._rateLimitInfo).toBeUndefined();
     expect(result.items).toEqual([1]);
+  });
+});
+
+describe('osmRequest token handling (issue #233)', () => {
+  it('read with a missing token falls back to cache instead of throwing', async () => {
+    const cacheRead = vi.fn(async () => ({ items: ['cached'] }));
+    const result = await osmRequest('testRead', '/read', { token: null, cacheRead });
+    expect(result.items).toEqual(['cached']);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('read with a missing token and no cache rejects with code NO_TOKEN (not emptyValue)', async () => {
+    await expect(
+      osmRequest('testRead', '/read', { token: null, emptyValue: { items: [] } }),
+    ).rejects.toMatchObject({ code: 'NO_TOKEN' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('read with an expired token falls back to cache', async () => {
+    isTokenExpired.mockReturnValue(true);
+    const cacheRead = vi.fn(async () => ({ items: ['cached'] }));
+    const result = await osmRequest('testRead', '/read', { token: 'expired-tok', cacheRead });
+    expect(result.items).toEqual(['cached']);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('write with a missing token still rejects (unchanged behavior)', async () => {
+    const cacheRead = vi.fn(async () => ({ items: ['cached'] }));
+    await expect(
+      osmRequest('testWrite', '/write', {
+        token: null, method: 'POST', write: true, body: { a: 1 }, cacheRead,
+      }),
+    ).rejects.toMatchObject({ code: 'NO_TOKEN' });
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/services/api/api/base.js
+++ b/src/shared/services/api/api/base.js
@@ -352,10 +352,30 @@ export async function osmRequest(apiName, path, opts = {}) {
     return unavailable('authentication failed this session');
   }
 
-  validateTokenBeforeAPICall(token, apiName);
-
   if (write) {
+    validateTokenBeforeAPICall(token, apiName);
     checkWritePermission();
+  } else {
+    const tokenValidation = validateTokenBeforeAPICall(token, apiName, { allowMissingToken: true });
+    if (!tokenValidation.isValid) {
+      if (cacheRead) {
+        try {
+          const cached = await cacheRead();
+          if (cached !== null && cached !== undefined) return cached;
+        } catch (cacheError) {
+          logger.debug(`${apiName}: cache read failed`, { error: cacheError.message }, LOG_CATEGORIES.API);
+        }
+      }
+      // Deliberately not emptyValue here: an empty flexi list would make rota
+      // discovery falsely report "no rota set up" to a signed-out user.
+      if (tokenValidation.reason === 'TOKEN_EXPIRED') {
+        throw new TokenExpiredError(`Cannot call ${apiName} - authentication token has expired`);
+      }
+      const err = new Error('No authentication token');
+      err.status = 401;
+      err.code = 'NO_TOKEN';
+      throw err;
+    }
   }
 
   try {

--- a/src/shared/services/api/api/base.js
+++ b/src/shared/services/api/api/base.js
@@ -363,7 +363,10 @@ export async function osmRequest(apiName, path, opts = {}) {
           const cached = await cacheRead();
           if (cached !== null && cached !== undefined) return cached;
         } catch (cacheError) {
-          logger.debug(`${apiName}: cache read failed`, { error: cacheError.message }, LOG_CATEGORIES.API);
+          // warn, not debug: a cache failure here changes the user-visible
+          // outcome (sign-in wall instead of cached data), so storage
+          // problems must stay findable.
+          logger.warn(`${apiName}: cache read failed`, { error: cacheError.message }, LOG_CATEGORIES.API);
         }
       }
       // Deliberately not emptyValue here: an empty flexi list would make rota


### PR DESCRIPTION
## Summary

Closes #233 (Sentry **VIKING-EVENT-MGMT-HE** — 'No authentication token' on /water-rota, 6 users, active daily).

A missing/expired token was the **only** unavailability case in `osmRequest` that hard-threw before the cache-fallback machinery — offline, OSM-blocked, and auth-breaker cases all degrade gracefully, but `validateTokenBeforeAPICall` was called without `allowMissingToken` and outside the try/catch. So a signed-out or lapsed-session user on the rota (the app's most-shared deep link) got a raw error page, and every visit logged an error-level Sentry event. In the July 22 incident the OSM block killed token refresh, which made this fire alongside the blocked-JSON errors (same session in Sentry).

## Changes

- **`osmRequest` reads** (`src/shared/services/api/api/base.js`): missing/expired token → try `cacheRead()` first (restores the offline-first promise: a previously loaded board renders from cache); only with no cache throw an auth-coded error (`code: 'NO_TOKEN'` / `TokenExpiredError`). Deliberately **not** `emptyValue` — an empty flexi list would make rota discovery falsely report "no rota set up" to signed-out users (the discovery "don't lie" discipline). **Writes unchanged** — they still throw immediately.
- **`useWaterRota`**: classifies `NO_TOKEN`/`isTokenExpired` errors as `needsAuth`, logged at **info** instead of error — ends the Sentry error spam for an expected signed-out state.
- **`RotaBoardPage`**: `needsAuth` renders a "Sign in to see the water rota" card with a **Sign in to OSM** button calling the plain `login()` — no return-path storage, per the mobile-Safari OAuth incident (v2.19.0). Known tradeoff: after sign-in the user lands on the default page, not back on the rota deep link — re-enabling deep-link return needs the mobile-Safari-safe restore noted in `useAuth`.

## Testing

- 4 new `osmRequest` token-handling tests (cache fallback on missing/expired token, NO_TOKEN throw with no cache, write path unchanged)
- 2 new `useWaterRota` tests (needsAuth classification, no error-level logging)
- Full suite: 970 passed / 13 skipped, lint 0 errors, build green

## Sentry

Fixes VIKING-EVENT-MGMT-HE. Related VIKING-EVENT-MGMT-C0 (`/events` refresh path) is a different throw site and is **not** covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rte229WWoYp3wKfgK59NnP